### PR TITLE
Phase A.1 — ship-readiness remediation (27/28 R-XX items)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 dist
 coverage
-docs
+docs/api
 .DS_Store
 *.log
 .vite

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing to agentonomous
+
+Thanks for helping out. This document captures the workflow we've converged on
+for branches, commits, releases, and local development.
+
+## Branch model
+
+We follow a [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/)–flavored
+layout with two long-lived branches:
+
+| Branch    | Purpose                                                                        |
+| --------- | ------------------------------------------------------------------------------ |
+| `main`    | Tracks what's currently published on npm. Tagged `vX.Y.Z` per release.         |
+| `develop` | Integration branch. Reflects the latest accepted work toward the next release. |
+
+Feature branches, bug fixes, and remediation work all live on short-lived
+topic branches cut from `develop`:
+
+- `feat/<slug>` — new features (`feat/markdown-memory-adapter`).
+- `fix/<slug>` — bug fixes (`fix/snapshot-roundtrip-mood`).
+- `refactor/<slug>` — internal reshaping with no behavior change.
+- `docs/<slug>` — documentation-only.
+- `phase-<n>/<theme>` — large multi-item work (`phase-a1/persistence`).
+
+### Lifecycle of a change
+
+```
+develop ─────────────────────────────────────────────▶
+         \                                         /
+          \─ feat/foo ─ fix/bar ─ refactor/baz ──/
+                                                  ▲
+                                                  │
+                                                  PR + review
+```
+
+1. Branch from `develop`: `git switch develop && git pull && git switch -c feat/foo`.
+2. Commit locally. Follow the commit-message convention below.
+3. Push. Open a pull request targeting `develop`.
+4. CI gates + reviewer approve. Squash-or-rebase merge. Delete the topic branch.
+5. `develop` accumulates merged work until we're ready to release.
+
+### Releases
+
+Releases flow `develop` → `main`:
+
+1. Cut a `release/vX.Y.Z` branch from `develop` if you need a stabilization
+   window, or fast-forward `main` from `develop` directly for a clean tip.
+2. Land any last fixups on that branch (changelog regeneration, version bump).
+3. Merge into `main`, tag `vX.Y.Z`, push the tag.
+4. The `.github/workflows/release.yml` workflow runs `changeset publish` and
+   pushes to npm with provenance attestation. See [PUBLISHING.md](./PUBLISHING.md)
+   for the full release flow.
+
+Hotfixes that can't wait for `develop`'s next release cycle:
+
+```
+main ──────────────▶ main
+       \           /
+        hotfix/v1.2.1
+```
+
+Branch `hotfix/<version>` off `main`, land the fix, tag, ship. Merge back
+into `develop` afterwards so the fix propagates.
+
+## Commit messages
+
+Subject line: `<type>: <summary>` or `<Rxx>: <summary>` for remediation items.
+
+- `type` is one of `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `build`, `ci`.
+- Keep subjects under 72 chars.
+- Body explains **why**, not what. Wrap at 72.
+- One logical change per commit. Squash noise before opening a PR.
+
+Example:
+
+```
+fix: snapshot mood roundtrip no longer re-emits MoodChanged
+
+The previous restore path set `currentMood` only when a snapshot
+carried one, leaving stale state on partial restores. …
+```
+
+## Pull requests
+
+- Target: always `develop` (except hotfixes → `main`).
+- Title: short, imperative, no period. "Add markdown memory adapter".
+- Body: summary + test plan. Link to relevant R-XX or issue numbers.
+- Required gates before merge: `npm run verify` (= format:check + lint +
+  typecheck + test + build), GitHub Actions CI green.
+- Reviews: at least one approving review for anything beyond a
+  one-line docs tweak.
+
+## Local setup
+
+```bash
+nvm use               # node 22
+npm install
+npm test              # vitest
+npm run typecheck     # tsc --noEmit
+npm run lint          # eslint flat config
+npm run format        # prettier --write .
+npm run build         # vite library mode
+```
+
+### Husky + lint-staged
+
+Pre-commit hooks run `eslint --fix` and `prettier --write` on staged files.
+To bypass in emergencies: `git commit --no-verify` (discouraged — it means
+CI will reject the PR).
+
+### Changesets
+
+Every PR that changes library behavior needs a changeset describing the
+semver bump + user-facing summary:
+
+```bash
+npm run changeset
+```
+
+The generated `.changeset/*.md` file goes in the same commit. Docs-only and
+refactor-only PRs can skip changesets.
+
+## Testing
+
+- `tests/unit/` mirrors `src/` one-for-one. Test filename: same as the source
+  file under test with `.test.ts`.
+- `tests/integration/` hosts multi-subsystem tests (e.g. deterministic-replay).
+- Under `SeededRng` + `ManualClock`, the same inputs must produce byte-identical
+  `DecisionTrace`s. Two runs with matching setup → `expect(runA).toEqual(runB)`.
+
+## Coding conventions
+
+- TypeScript strict mode, `exactOptionalPropertyTypes` + `noUncheckedIndexedAccess`
+  both on.
+- ESM, `.js` extensions in relative imports (`verbatimModuleSyntax`).
+- No `Date.now()` / `Math.random()` / `setTimeout` in library code — ports only
+  (`WallClock`, `Rng`). ESLint enforces this.
+- Default to no comments; reserve JSDoc for non-obvious invariants or
+  public API. `//` comments only when the WHY isn't already in the code.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,6 +1,13 @@
 # Publishing
 
-Release flow for `agentonomous`.
+Release flow for `agentonomous`. For contribution workflow + branch model
+see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Branch model recap
+
+- `main` — tracks what's on npm. Each release is a tagged commit here.
+- `develop` — integration branch; all work lands here first.
+- Releases flow `develop` → `main`, then a tag triggers the publish workflow.
 
 ## Prerequisites
 
@@ -9,7 +16,7 @@ Release flow for `agentonomous`.
   The token must be an **automation token** (not a classic publish token) so
   npm's provenance attestation works.
 - `main` branch protected; releases happen only via Changesets PRs landing on
-  `main`.
+  `main` (and those PRs originate from `develop` or `release/*`).
 
 ## Local dry runs
 
@@ -47,14 +54,18 @@ changesets per PR are fine — they get merged at release time.
 
 The `.github/workflows/release.yml` workflow runs on every push to `main`:
 
-1. If unreleased changesets exist, the workflow opens (or updates) a
-   `chore(release): version packages` PR that bumps `package.json`, updates
-   `CHANGELOG.md`, and consumes the changeset files.
-2. Merging that PR into `main` re-triggers the workflow, which now has no
-   pending changesets and instead runs `npm run release` (`changeset
-publish` → `npm publish`).
+1. A release PR is prepared on `develop` (or a `release/vX.Y.Z` branch
+   cut from `develop`). It bumps `package.json`, regenerates
+   `CHANGELOG.md` from the pending `.changeset/` entries, and consumes
+   the changeset files. Open the PR with base = `main`.
+2. Merging that PR into `main` runs the workflow, which now has no
+   pending changesets and instead runs `npm run release` (`changeset publish`
+   → `npm publish`) and tags `vX.Y.Z`.
 3. npm provenance is attested automatically (`publishConfig.provenance: true`
    - `id-token: write` permission in the workflow + GitHub's OIDC token).
+4. After the tag lands, fast-forward `develop` with `main` (or open a
+   back-merge PR) so the version bump + changelog propagate back for the
+   next cycle.
 
 No manual `npm publish` calls are needed in the normal path.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,106 @@ requestAnimationFrame(frame);
 That's the whole MVP surface. See `examples/nurture-pet` for a full browser
 demo with HUD, buffs, random events, and localStorage persistence.
 
+### Interaction flow
+
+`agent.interact(verb, params?)` is the recommended entrypoint for UI- or
+host-triggered actions. It publishes an `InteractionRequested` event on the
+agent's bus. Reactive handlers — the `defaultPetInteractionModule` ships
+with one — translate verbs into `invokeSkill(...)` calls:
+
+```
+click → agent.interact('feed')
+  └─► InteractionRequested (on bus)
+      └─► defaultPetInteractionModule handler
+          └─► agent.invokeSkill('feed', …)
+              └─► FeedSkill.execute(ctx)
+                  └─► SkillCompleted + effects (needs, modifiers)
+```
+
+If you route your own verbs, register a module with a `reactiveHandlers`
+entry keyed on `'InteractionRequested'`. The `AgentFacade` passed to the
+handler gives you `facade.invokeSkill(id, params)` without reaching for the
+`Agent` directly.
+
+### Advanced: random events + custom skills
+
+```ts
+import {
+  createAgent,
+  defineRandomEvent,
+  defineSpecies,
+  err,
+  ok,
+  RandomEventTicker,
+  SkillRegistry,
+  type Skill,
+} from 'agentonomous';
+
+const rainstorm: Skill = {
+  id: 'rainstorm',
+  label: 'Rainstorm',
+  baseEffectiveness: 1,
+  execute(_params, ctx) {
+    if (!ctx.hasModifier('outside')) {
+      return Promise.resolve(err({ code: 'indoors', message: 'Pet is inside.' }));
+    }
+    ctx.applyModifier({
+      id: 'wet',
+      source: 'skill:rainstorm',
+      appliedAt: ctx.clock.now(),
+      expiresAt: ctx.clock.now() + 30_000,
+      stack: 'refresh',
+      effects: [{ target: { type: 'mood-bias', category: 'sad' }, kind: 'add', value: 0.2 }],
+    });
+    return Promise.resolve(ok({ fxHint: 'rain-drops' }));
+  },
+};
+
+const skills = new SkillRegistry();
+skills.register(rainstorm);
+
+const randomEvents = new RandomEventTicker([
+  defineRandomEvent({
+    id: 'weather:rain',
+    probabilityPerSecond: 0.005,
+    cooldownSeconds: 120,
+    emit: () => ({ type: 'RandomEvent', subtype: 'rain', at: 0 }),
+  }),
+]);
+
+const pet = createAgent({
+  id: 'whiskers',
+  species: defineSpecies({ id: 'cat' }),
+  skills,
+  randomEvents,
+});
+```
+
+Skills return `ok(...)` for success or `err(...)` for expected failure. A
+thrown exception is caught by the tick pipeline and surfaced as
+`SkillFailed` with `code: 'execution-threw'` — no RNG draws happen between
+the throw and the next tick, so replay stays deterministic.
+
+### Running the example
+
+The `examples/nurture-pet` demo consumes the library via a workspace-local
+build. You must build the library before the example resolves it:
+
+```bash
+# From the repo root.
+npm install
+npm run build                       # → dist/ populated so the example can import
+
+# Install the example's own deps + start Vite dev server.
+cd examples/nurture-pet
+npm install
+npm run dev
+```
+
+Open the printed `http://localhost:5173/` URL. Feed, pet, clean, and watch
+the pet grow up, get hungry, and eventually die (with a life-summary
+modal). LocalStorage persists the pet across reloads.
+
 ## Determinism
 
 Under a fixed `SeededRng` + `ManualClock`, every tick produces a
@@ -101,7 +201,7 @@ expect(runA.finalState).toEqual(runB.finalState);
 
 The library forbids raw `Date.now()` / `Math.random()` / `setTimeout` inside
 its own code via ESLint rules — all non-determinism flows through the
-`WallClock`, `Rng`, `RemoteController`, and `LlmProviderPort` ports.
+`WallClock`, `Rng`, and `RemoteController` ports.
 
 ## Adding your own species
 
@@ -124,8 +224,31 @@ defaults.
 
 ## Reactive store (Pinia, Zustand, …)
 
+`bindAgentToStore` takes any listener; wire it into whichever reactive
+store you use. A Pinia example end-to-end:
+
 ```ts
-import { bindAgentToStore } from 'agentonomous';
+// stores/pet.ts
+import { defineStore } from 'pinia';
+import type { AgentState } from 'agentonomous';
+
+export const usePetStore = defineStore('pet', {
+  state: (): { snapshot: AgentState | null } => ({ snapshot: null }),
+  actions: {
+    syncFromAgent(state: AgentState): void {
+      this.snapshot = state;
+    },
+  },
+});
+```
+
+```ts
+// main.ts
+import { bindAgentToStore, createAgent, defineSpecies } from 'agentonomous';
+import { usePetStore } from './stores/pet';
+
+const pet = createAgent({ id: 'whiskers', species: defineSpecies({ id: 'cat' }) });
+const store = usePetStore();
 
 const unsubscribe = bindAgentToStore(pet, (state) => {
   store.syncFromAgent(state);
@@ -133,8 +256,8 @@ const unsubscribe = bindAgentToStore(pet, (state) => {
 ```
 
 The listener fires synchronously on every event and receives the current
-`getState()` slice (id, stage, needs, modifiers, mood, animation, halted,
-ageSeconds).
+`getState()` slice (`id`, `stage`, `needs`, `modifiers`, `mood`,
+`animation`, `halted`, `ageSeconds`). Call `unsubscribe()` to detach.
 
 ## Development
 
@@ -146,7 +269,17 @@ npm run typecheck     # tsc --noEmit
 npm run lint          # eslint 9 flat config
 npm run build         # vite library mode → dist/
 npm run docs          # typedoc → docs/
+npm run analyze       # build + list the 20 largest dist/*.js files by bytes
 ```
+
+### Bundle-size budget
+
+The library's core bundle (everything re-exported from
+`agentonomous`) targets ~80 KB unminified ESM. The
+`agentonomous/integrations/excalibur` subpath is a separate entry so
+consumers who don't use Excalibur don't pay for it. Run
+`npm run analyze` after meaningful changes; a significant regression is a
+signal to check for accidentally-bundled adapters or heavy deps.
 
 Phase A milestones (M0–M15) are all green. Phase B (sim-ecs adapter, LLM
 tool, Markdown memory, social/dialogue, possession/jobs, Mistreevous BTs,

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ ageSeconds).
 ```bash
 nvm use               # node 22
 npm install
-npm test              # vitest (245 tests, 45 files)
+npm test              # vitest
 npm run typecheck     # tsc --noEmit
 npm run lint          # eslint 9 flat config
 npm run build         # vite library mode → dist/
@@ -151,6 +151,12 @@ npm run docs          # typedoc → docs/
 Phase A milestones (M0–M15) are all green. Phase B (sim-ecs adapter, LLM
 tool, Markdown memory, social/dialogue, possession/jobs, Mistreevous BTs,
 JS-son BDI, brain.js learning) lands post-V1.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for branch model, commit style, PR
+conventions, and the release flow. TL;DR: work on a topic branch cut from
+`develop`, PR against `develop`, keep commits small and reversible.
 
 ## License
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,141 @@
+# Style guide
+
+This document pins the stylistic conventions for `src/` and `tests/`.
+`CONTRIBUTING.md` covers workflow; this file is just the code-level rules
+that prettier and eslint can't always enforce mechanically.
+
+Where prettier or eslint already enforces a rule, we say so and move on.
+
+## TypeScript features
+
+- **Strict mode on.** `strict`, `exactOptionalPropertyTypes`,
+  `noUncheckedIndexedAccess`, `noImplicitOverride`,
+  `noFallthroughCasesInSwitch`, `noImplicitReturns` — all on. Don't turn
+  any off without discussion.
+- **ESM only.** `"type": "module"` in `package.json`; all relative imports
+  carry the `.js` extension (`verbatimModuleSyntax`). No CommonJS, no
+  dynamic `require`.
+- **`type` vs. `interface`.** Prefer `type X = …` for unions, tuples,
+  mapped types, conditional types, primitives, and any shape that looks
+  algebraic. Use `interface X` for open object shapes that consumers are
+  expected to extend, or when declaration merging is deliberate. When in
+  doubt → `type`.
+- **`unknown` over `any`.** `any` is an escape hatch of last resort. Every
+  `any` in `src/` should either be deleted or carry a one-line comment
+  explaining why `unknown` wasn't usable.
+- **No enums.** Use `as const` unions of string literals. Enums are a
+  runtime payload for a compile-time concept and don't play nicely with
+  the library's determinism contract.
+- **Immutable by default.** Fields are `readonly` unless mutation is
+  genuinely required. Arrays returned from public surfaces are
+  `readonly T[]`.
+- **Exhaustiveness.** `switch` statements over union discriminants end with
+  a `default: { const _exhaust: never = value; throw new Error(...) }`
+  block when the union is closed.
+
+## File layout
+
+- **One concept per file.** A file named `FooSkill.ts` exports `FooSkill`
+  and at most its immediate helpers. No kitchen-sink modules.
+- **Test mirror.** Every `src/foo/Bar.ts` has an optional
+  `tests/unit/foo/Bar.test.ts`. Integration tests go under
+  `tests/integration/`.
+- **Barrel control.** `src/index.ts` re-exports the public surface.
+  Internal modules (anything under `src/agent/internal/`, anything
+  prefixed `_`) do NOT appear in the barrel.
+
+## Exports
+
+- **Top-level JSDoc on every exported class / interface / type / const.**
+  Three requirements:
+  1. The first sentence describes the concept in one line.
+  2. The body explains the non-obvious invariants — when to use it, what
+     breaks, what it's NOT.
+  3. Renderable in IntelliSense — no multi-page essays, no ASCII diagrams
+     that break Markdown parsers.
+- **Barrel JSDoc.** One-liner comments above each re-export when the
+  identifier name is opaque on its own (see the cognition + needs + mood
+  sections of `src/index.ts`).
+- **No default exports.** Named exports only. Default exports break
+  re-exporting and make grep harder.
+
+## Imports
+
+- **Alphabetized inside each group.** Prettier doesn't sort them; eslint's
+  `perfectionist/sort-imports` or manual discipline does.
+- **Grouped:** standard library / node built-ins → third-party packages →
+  workspace (`../...`) → local (`./...`). A blank line between groups is
+  optional; consistency within a file is what matters.
+- **Type-only imports.** Use `import type` when the import is purely a
+  type — `verbatimModuleSyntax` requires it.
+
+## JSDoc
+
+- Reserve `//` comments for WHY-is-this-weird explanations that belong
+  inline with the code. Everything else that documents a symbol lives in
+  JSDoc.
+- No `@param` / `@returns` tags when the types are self-documenting. Use
+  them only when the prose clarifies units, valid ranges, or error modes.
+- No `@deprecated` without a migration path.
+- Code fences in JSDoc are fine; keep them short.
+
+## Naming
+
+- **Classes:** `PascalCase`, noun-phrased. `UrgencyReasoner`,
+  `AnimationStateMachine`.
+- **Interfaces + types:** `PascalCase`, noun-phrased. No `I` prefix.
+- **Functions + methods:** `camelCase`, verb-phrased. `createAgent`,
+  `satisfyNeed`, `selectIntention`.
+- **Constants:** `SCREAMING_SNAKE_CASE` for module-scoped literals
+  (`DEFAULT_TIME_SCALE`, `DECEASED_STAGE`). Local constants inside
+  functions are `camelCase`.
+- **Booleans:** `is` / `has` / `should` / `can` prefix. `isInvokeSkillAction`,
+  `hasModifier`, `shouldSave`.
+- **Private / internal:** leading underscore on exported-but-internal
+  symbols (`_internalPublish`, `_internalDie`). Every other private
+  member uses TypeScript's `private` or `protected`.
+
+## Commenting
+
+- Prose comments explain the WHY, not the WHAT — the latter belongs in the
+  code itself.
+- References to old milestones (`// M2:`, `// Phase B`) rot fast. Use them
+  only in the immediate commit they land in, and remove them in the next
+  pass (or open an issue if the reference still has value).
+- No `TODO` comments without a linked issue number. `// TODO` alone is
+  worse than no comment — it's a landmine.
+
+## Testing
+
+- **Arrange / Act / Assert.** Blank lines between the three phases inside
+  longer tests.
+- **Descriptive titles.** `it('returns null when the only candidate scores
+below threshold')` > `it('threshold')`.
+- **Seed everything.** Agent-level tests always construct with
+  `SeededRng(<literal>)` and `ManualClock(<literal>)` — never
+  `new SystemClock()`.
+- **Observable assertions.** Prefer asserting on event streams + public
+  state slices (`agent.getState()`, `agent.rng.next()`) over reaching for
+  protected fields. Reserve field access for the extraction tests of the
+  `src/agent/internal/*` helpers.
+
+## Flagged files under R-27
+
+The following files were authored in parallel by sub-agents during Phase A
+and should be held to this style going forward:
+
+- `src/skills/defaults/*.ts` (all ten default skills)
+- `src/body/*.ts`
+- `src/randomEvents/*.ts`
+- `src/agent/RemoteController.ts`
+- `src/agent/ScriptedController.ts`
+
+When editing any of the above, re-read the relevant section above and
+match it. Any `Phase B` references left over from the subagent prompts
+have been scrubbed in R-22; keep them out.
+
+## Enforcement
+
+- `npm run lint` covers the eslint-enforceable rules.
+- `npm run format:check` covers prettier rules.
+- Everything else in this guide is on human review at PR time.

--- a/docs/specs/vision.md
+++ b/docs/specs/vision.md
@@ -1,0 +1,317 @@
+# agentonomous — Product Vision
+
+> Companion to `docs/specs/overview.md` (technical spec) and
+> `docs/specs/roadmap.md` (phased delivery). This document answers the
+> "why" — the problem we solve, who we serve, and the invariants that
+> guide every trade-off.
+
+## Vision statement
+
+**Give TypeScript developers a deterministic, engine-agnostic agent core
+that turns simulations into living worlds — from a single pet you
+nurture in a browser tab to a headless village of thousands — without
+asking them to pick a rendering engine, an AI library, or a state
+manager first.**
+
+## The problem
+
+Building believable, persistent, autonomous characters in a TypeScript
+simulation today forces developers into one of three bad options:
+
+1. **Roll your own.** Weeks of yak-shaving on needs decay, mood
+   derivation, save/load, and determinism before any gameplay ships.
+   Every project reinvents the same state machine.
+2. **Adopt a game-engine-coupled framework.** Unity/Unreal equivalents
+   exist but tie you to their editor, runtime, and content pipeline.
+   Useless for headless simulations, browser games, or LLM-driven
+   experiments.
+3. **Glue together ad-hoc libraries.** A behavior-tree lib here, a
+   state-machine lib there, a separate persistence layer, a separate
+   RNG for determinism. Each seam leaks; none of it is designed to
+   work together.
+
+The result: most TypeScript games that *could* have rich autonomous
+characters ship with scripted cutouts instead. Most research
+simulations that *could* explore emergent behavior get stuck on
+infrastructure. Most LLM-driven "agent" experiments can't be replayed
+or debugged because nothing's deterministic.
+
+Consumers who successfully ship living characters today either have
+a team of 10+ or pay the roll-your-own tax. We want to remove that tax.
+
+## Target personas
+
+### P1 — The indie game developer
+
+Ships a TypeScript + ExcaliburJS / PixiJS / three.js / plain-canvas
+game. Wants a pet, an NPC shopkeeper, or a companion that feels alive
+between the player's inputs. Has one weekend to prototype, one month
+to polish. Does not want to study AI theory, state machines, or ECS
+architecture to get something on screen.
+
+**What success looks like for P1:** `npm install agentonomous`,
+copy-paste the quickstart, see a reactive pet in under 20 minutes.
+Add their own species via JSON when ready.
+
+### P2 — The simulation researcher
+
+Models social dynamics, emergent cooperation, or economic systems in
+headless TypeScript. Needs byte-identical replays under a fixed seed,
+snapshots they can diff, decision traces they can export to Jupyter.
+Runs a thousand agents in parallel, not one.
+
+**What success looks like for P2:** scripted replay test harness, RNG
+port they control, `DecisionTrace` per tick, no hidden globals.
+Integration with `sim-ecs` when needed (Phase B).
+
+### P3 — The LLM / agent-framework builder
+
+Building a next-gen agentic UI, a Claude-driven RPG, or a research
+project that blends LLM reasoning with classical agent mechanics.
+Needs an LLM provider port with prompt caching, strict budgets, and
+deterministic mocking. Doesn't want to rewrite needs, mood, or
+persistence themselves.
+
+**What success looks like for P3:** drop in `LlmProviderPort` + their
+provider of choice, use `MockLlmProvider` in tests, plug the library
+into their existing event bus via adapters. LLM tool integration
+(Phase B) treats non-determinism as a budget, not a bug.
+
+## Product pillars
+
+These are the invariants every feature must honor. Trade-offs flow
+around them, not through them.
+
+### 1. Determinism as a contract
+
+Given a fixed `SeededRng` + `ManualClock`, every tick produces a
+byte-identical `DecisionTrace`. This is testable, CI-enforced, and
+ESLint-protected (no raw `Date.now` / `Math.random` /
+`setTimeout` / `setInterval` in core). Breaking it is a breaking
+change.
+
+### 2. Ports & Adapters all the way down
+
+Every source of non-determinism, every side effect, every IO boundary
+is a port. `WallClock`, `Rng`, `Logger`, `EventBusPort`,
+`SnapshotStorePort`, `RemoteController`, `ScriptedController`,
+`MoodModel`, `Reasoner`, `BehaviorRunner`, `Learner`, `NeedsPolicy`,
+`MemoryRepository`, `LlmProviderPort`. Every one of them has a
+production adapter and a test double. Consumers own the edges.
+
+### 3. Zero-config for the common case
+
+`createAgent({ id, species })` must produce a working agent. In a
+browser, it auto-persists to `localStorage`. In Node, it stays in
+memory. In a reactive UI, `bindAgentToStore(agent, listener)` Just
+Works with Pinia, Zustand, Redux, Svelte stores, or signals — no
+framework dependency in core.
+
+### 4. Species-agnostic, data-driven
+
+No humanocentric primitives. A `SpeciesDescriptor` is JSON-editable.
+A cat, a fish, a dragon, a Mars rover, a merchant NPC — all live in
+the same abstraction. Designers edit species files without touching
+TypeScript. Consumers compose; they don't subclass.
+
+### 5. Engine-agnostic at the core, integration subpaths at the edge
+
+The core bundle does not import a rendering engine, a physics engine,
+or a specific ECS. Integrations (Excalibur today; sim-ecs,
+three.js, PixiJS later) live behind subpath exports
+(`agentonomous/integrations/<engine>`) so consumers only pay for
+what they use.
+
+### 6. Peer-optional brains
+
+Advanced cognition adapters (`JsSonReasoner`, `MistreevousBehavior`,
+`BrainJsLearner`, `AnthropicLlmProvider`, `OpenAiLlmProvider`) are
+peer dependencies with `peerDependenciesMeta.optional: true`. Core
+stays usable without any of them. Consumers opt in one at a time.
+
+### 7. Tight feedback, emergent narrative
+
+Every player-visible action emits an event with an `fxHint` the
+renderer can consume. Every tick produces a `DecisionTrace` that
+tells the story of why the agent did what it did. Consumers build
+emergent narrative out of data, not hand-scripted sequences.
+
+## What we build (feature pillars)
+
+### Agent core
+
+- Deterministic 10-stage tick pipeline (perceive → random events →
+  modifiers → needs → mood → animation → control-mode dispatch →
+  cognition → skills → persistence → trace).
+- `createAgent(config)` ergonomic builder. `new Agent(deps)` for full
+  control.
+- Lifecycle: birth → growth → aging → death. Catch-up-aware on
+  restore.
+- Control modes: `autonomous` / `scripted` / `remote`. The same agent
+  doubles as NPC, bot, or player-proxy.
+
+### Subsystems
+
+- **Needs**: homeostatic, configurable decay, urgency curves,
+  critical thresholds.
+- **Modifiers**: stackable buffs/debuffs, cross-cutting effects on
+  needs / mood / skills / intention scoring / locomotion / lifespan.
+- **Mood**: categorical, derived from needs + modifiers + persona.
+- **Animation**: state machine driven by active skill + mood +
+  modifiers. Decoupled from cognition.
+- **Cognition**: `UrgencyReasoner` + `DirectBehaviorRunner` defaults,
+  swappable for BDI / behavior-tree / LLM adapters.
+- **Skills**: 10 defaults (feed/clean/play/rest/pet/scold/medicate +
+  meow/sad/sleepy). Consumers add more via `SkillRegistry`.
+- **Random events**: seeded per-tick probability table with
+  cooldowns and guards.
+
+### Persistence
+
+- Versioned `AgentSnapshot` with per-subsystem slices.
+- Auto-save via `AutoSavePolicy` (every N ticks + on critical events).
+- `SnapshotStorePort` with `InMemory` / `LocalStorage` / `Fs`
+  adapters. Consumer can plug IndexedDB, remote DB, or save slots.
+- Offline catch-up: restore with elapsed time, deterministic
+  sub-stepping.
+
+### Reactive surface
+
+- `agent.subscribe(listener)` — pub/sub over the event bus.
+- `agent.getState()` — cheap frame-safe state slice.
+- `bindAgentToStore(agent, listener)` — framework-agnostic binding.
+
+### Integrations
+
+- `agentonomous/integrations/excalibur` — Actor sync, remote
+  controller, animation bridge.
+- Planned: sim-ecs, three.js, PixiJS, Phaser (Phase B+).
+
+## What we refuse to build
+
+Calling these out now so they never show up as creeping scope.
+
+- **Rendering.** We don't draw sprites. We emit state + events; the
+  consumer's engine renders.
+- **Physics or collision.** We track pose; we don't simulate bodies.
+- **Pathfinding.** Locomotion is a mode string + speed multiplier;
+  actual movement is the engine's job.
+- **Multiplayer networking.** `RemoteController` is the seam.
+  Consumers own the transport.
+- **Editor UI / authoring tools.** Species files are JSON for a
+  reason. Tools can come later as separate packages.
+- **A specific AI / LLM opinion.** We expose ports; consumers pick
+  providers.
+- **A specific reactive framework opinion.** We expose `subscribe` +
+  `getState`; consumers pick Pinia / Zustand / signals / whatever.
+
+## Success metrics
+
+### 6 months post-V1
+
+- 1,000+ weekly npm downloads.
+- 3+ community-published species descriptors.
+- 2+ public browser games shipping an `agentonomous` pet or NPC.
+- Zero reports of non-determinism in replay under fixed seed +
+  ManualClock.
+- GitHub Pages demo linked from README, working on mobile.
+
+### 12 months
+
+- Phase B complete (Markdown memory, jobs, social, LLM tool).
+- First academic paper / blog post citing `agentonomous` for a
+  simulation study.
+- 5,000+ weekly npm downloads.
+- Integration adapters shipped for at least one of: sim-ecs,
+  three.js, PixiJS.
+- First LLM-driven agent experiment using `LlmProviderPort` with
+  prompt caching.
+
+### 24 months
+
+- Used as the agent layer in a commercial indie game on Steam / itch.
+- Curriculum adoption: at least one university course references the
+  determinism test harness as a reference implementation.
+- Multi-agent coordination (Phase C) stable in production.
+- 20,000+ weekly npm downloads.
+
+## Principles that guide trade-offs
+
+When two features pull in opposite directions, resolve by consulting
+these in order.
+
+1. **Determinism beats performance.** A microsecond slower tick is
+   acceptable; a replay divergence is not.
+2. **Contract clarity beats feature count.** A smaller API surface
+   with crisp promises outperforms a kitchen sink with unclear
+   semantics.
+3. **Zero-config beats flexibility.** Consumers who need flexibility
+   can opt in. Consumers who need "it just works" must not be
+   penalized.
+4. **Data beats code.** If a feature can be a JSON-editable
+   descriptor, it is one.
+5. **Ports beat embedding.** If core needs to reach out for
+   something, it's a port, not a dependency.
+6. **Peer-optional beats bundled.** Any library outside our own
+   domain is a peer dep; core bundles nothing it doesn't strictly
+   need.
+7. **Small core beats big framework.** When in doubt, move it to an
+   integration subpath or a separate package.
+
+## Out of scope — forever
+
+- Proprietary content bundling (sprite packs, sound effects, etc.).
+  Content is the consumer's.
+- Rendering loops, frame pacing, tweening, interpolation.
+- A CLI or GUI binary. This is a library, always.
+- Running on non-JS runtimes. TypeScript / JavaScript only.
+- Supporting CommonJS. ESM-only, forever. TS 6+ agrees.
+
+## How we measure "alive" in a simulation
+
+The library succeeds when a consumer looks at their screen for 30
+seconds without giving the pet any input and sees it do *something
+interesting* — a meow, a mood shift, a stage transition, a random
+event, a modifier expiring. The pet is alive when its autonomous
+behavior fills the quiet between interactions. Every product decision
+is weighed against that feeling.
+
+## Relationship to other docs
+
+- **`docs/specs/overview.md`** — the technical spec. How each of
+  these pillars is implemented.
+- **`docs/specs/roadmap.md`** — the phased path from today to the
+  24-month horizon.
+- **`docs/plans/review-remediation.md`** — the specific work needed
+  to close the gap between current state and V1.0.0.
+- **`/root/.claude/plans/i-want-to-create-warm-matsumoto.md`** — the
+  internal planning document that drove the initial build.
+
+## Signatures of success (anti-checklist)
+
+How do we know we're building the right thing?
+
+- A designer can add a new species without opening a TypeScript file.
+- A researcher can re-run a simulation from six months ago and get
+  byte-identical results.
+- A Pinia user can bind an agent to their store in three lines.
+- A consumer who doesn't care about LLMs never sees an LLM
+  dependency.
+- A nurture-pet demo runs at 60fps in Chrome on a five-year-old
+  Android phone.
+- Shutting the tab and reopening it restores the pet exactly where it
+  was — including elapsed virtual time, modifiers that should have
+  expired, and mood.
+
+## Reviewing this document
+
+This vision is meant to be stable across Phase A, B, and C. When a
+proposed feature seems to contradict it, the feature gets refined, not
+the vision. Changes to this document require:
+
+1. A pull request with rationale.
+2. Sign-off from project owner.
+3. A corresponding update to `docs/specs/roadmap.md` showing how the
+   change propagates.
+
+Last reviewed: 2026-04-19. Next review: at V1.0.0 release.

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -16,18 +16,28 @@ import { mountHud } from './ui.js';
 const STORAGE_KEY = 'whiskers';
 
 // --- Random events ------------------------------------------------------------
+// R-11: cadence tuned so a player sees 2–3 events per virtual minute.
+// R-10: messyPlay applies a `dirty` modifier so the Clean button has a real
+// reason to exist, and simultaneously applies `disobedient` so the Scold
+// button (gated by default ScoldSkill) is corrective rather than abusive.
 const randomEvents = new RandomEventTicker([
   defineRandomEvent({
     id: 'mildIllness',
-    probabilityPerSecond: 0.002,
-    cooldownSeconds: 60,
+    probabilityPerSecond: 0.01,
+    cooldownSeconds: 30,
     emit: () => ({ type: 'RandomEvent', subtype: 'mildIllness', at: 0 }),
   }),
   defineRandomEvent({
     id: 'surpriseTreat',
-    probabilityPerSecond: 0.001,
-    cooldownSeconds: 90,
+    probabilityPerSecond: 0.01,
+    cooldownSeconds: 30,
     emit: () => ({ type: 'RandomEvent', subtype: 'surpriseTreat', at: 0 }),
+  }),
+  defineRandomEvent({
+    id: 'messyPlay',
+    probabilityPerSecond: 0.008,
+    cooldownSeconds: 30,
+    emit: () => ({ type: 'RandomEvent', subtype: 'messyPlay', at: 0 }),
   }),
 ]);
 
@@ -82,6 +92,26 @@ pet.subscribe((event) => {
       stack: 'refresh',
       effects: [{ target: { type: 'mood-bias', category: 'playful' }, kind: 'add', value: 0.5 }],
       visual: { hudIcon: '🎁', fxHint: 'sparkle-gold' },
+    });
+  } else if (re.subtype === 'messyPlay') {
+    // R-10: a mess to clean up + R-12: a reason to scold.
+    pet.applyModifier({
+      id: 'dirty',
+      source: 'event:messyPlay',
+      appliedAt: pet.clock.now(),
+      expiresAt: pet.clock.now() + 120_000,
+      stack: 'refresh',
+      effects: [{ target: { type: 'mood-bias', category: 'sad' }, kind: 'add', value: 0.2 }],
+      visual: { hudIcon: '🧹', fxHint: 'dust-cloud' },
+    });
+    pet.applyModifier({
+      id: 'disobedient',
+      source: 'event:messyPlay',
+      appliedAt: pet.clock.now(),
+      expiresAt: pet.clock.now() + 60_000,
+      stack: 'replace',
+      effects: [],
+      visual: { hudIcon: '😼', fxHint: 'mischief' },
     });
   }
 });

--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -18,6 +18,14 @@ const INTERACTION_BUTTONS: { verb: string; label: string }[] = [
   { verb: 'scold', label: '😠 Scold' },
 ];
 
+/** R-26: tracked lifetime counters for the death modal. */
+interface LifetimeCounters {
+  ateCount: number;
+  scoldedCount: number;
+  illnessCount: number;
+  petCount: number;
+}
+
 export function mountHud(agent: Agent): { update: (state: AgentState) => void } {
   const bars = document.getElementById('bars') as HTMLElement;
   const modifiersEl = document.getElementById('modifier-list') as HTMLElement;
@@ -52,8 +60,14 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
     buttonsEl.appendChild(btn);
   }
 
-  // Recent-event log (trimmed tail)
+  // Recent-event log (trimmed tail) + R-26 lifetime counters.
   const traceLines: string[] = [];
+  const counters: LifetimeCounters = {
+    ateCount: 0,
+    scoldedCount: 0,
+    illnessCount: 0,
+    petCount: 0,
+  };
   agent.subscribe((event) => {
     traceLines.push(
       `${new Date(event.at).toISOString().slice(11, 19)}  ${event.type}${
@@ -62,6 +76,20 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
     );
     if (traceLines.length > 40) traceLines.shift();
     trace.textContent = traceLines.join('\n');
+
+    // Tally the events we care about for the life-summary modal.
+    if (event.type === 'SkillCompleted') {
+      const skillId = (event as { skillId?: string }).skillId;
+      if (skillId === 'feed') counters.ateCount += 1;
+      else if (skillId === 'scold') counters.scoldedCount += 1;
+      else if (skillId === 'pet') counters.petCount += 1;
+    } else if (event.type === 'RandomEvent') {
+      if ((event as { subtype?: string }).subtype === 'mildIllness') {
+        counters.illnessCount += 1;
+      }
+    } else if (event.type === 'AgentDied') {
+      showLifeSummary(agent.identity.name ?? agent.identity.id, counters, event.at);
+    }
   });
 
   nameEl.textContent = agent.identity.name;
@@ -91,10 +119,13 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
         modifiersEl.appendChild(li);
       }
 
-      // Halt / animation visual cue
+      // Halt / animation visual cue.
       if (state.halted) {
         petEl.textContent = '💀';
         petEl.style.background = '#475569';
+      } else if (state.modifiers.some((m) => m.id === 'dirty')) {
+        petEl.textContent = '😾';
+        petEl.style.background = '#a8a29e';
       } else if (state.animation === 'sleeping') {
         petEl.textContent = '😴';
         petEl.style.background = '#93c5fd';
@@ -116,4 +147,65 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
       }
     },
   };
+}
+
+/**
+ * R-26: render a modal summarizing the pet's life when `AgentDied` fires.
+ * Counters are aggregated from observed events during the session.
+ */
+function showLifeSummary(name: string, counters: LifetimeCounters, diedAtMs: number): void {
+  if (document.getElementById('life-summary')) return;
+  const overlay = document.createElement('div');
+  overlay.id = 'life-summary';
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.style.cssText = [
+    'position:fixed',
+    'inset:0',
+    'background:rgba(15,23,42,0.7)',
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'z-index:9999',
+    'font-family:system-ui,sans-serif',
+  ].join(';');
+
+  const card = document.createElement('div');
+  card.style.cssText = [
+    'background:#fafafa',
+    'color:#0f172a',
+    'padding:24px 28px',
+    'border-radius:12px',
+    'max-width:360px',
+    'box-shadow:0 20px 60px rgba(0,0,0,0.35)',
+    'text-align:center',
+  ].join(';');
+
+  const died = new Date(diedAtMs).toISOString().slice(0, 19).replace('T', ' ');
+  card.innerHTML = `
+    <h2 style="margin:0 0 8px;font-size:22px;">🪦 ${escapeHtml(name)}</h2>
+    <p style="margin:0 0 16px;color:#475569;font-size:14px;">Passed away at ${escapeHtml(died)}.</p>
+    <ul style="list-style:none;padding:0;margin:0 0 16px;text-align:left;font-size:15px;">
+      <li>🍖 Fed <strong>${counters.ateCount}</strong> times</li>
+      <li>❤️ Petted <strong>${counters.petCount}</strong> times</li>
+      <li>😠 Scolded <strong>${counters.scoldedCount}</strong> times</li>
+      <li>🤒 Caught <strong>${counters.illnessCount}</strong> illnesses</li>
+    </ul>
+    <button id="life-summary-close" style="padding:8px 16px;border-radius:6px;border:none;background:#2563eb;color:white;cursor:pointer;font-size:14px;">Close</button>
+  `;
+
+  overlay.appendChild(card);
+  document.body.appendChild(overlay);
+  document.getElementById('life-summary-close')?.addEventListener('click', () => {
+    overlay.remove();
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "docs": "typedoc",
+    "analyze": "npm run build && du -sh dist && find dist -name '*.js' -not -path '*.d.*' -exec wc -c {} + | sort -rn | head -20",
     "changeset": "changeset",
     "release": "changeset publish",
     "prepare": "husky",

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -519,6 +519,12 @@ export class Agent {
     if (this.currentMood && wanted('mood')) {
       snap.mood = { ...this.currentMood };
     }
+    if (wanted('animation')) {
+      snap.animation = {
+        state: this.animation.current(),
+        activeSkillId: this.currentActiveSkillId,
+      };
+    }
     if (this.memory && wanted('memory') && isInMemoryMemoryAdapter(this.memory)) {
       const records = this.memory.snapshot();
       if (records.length > 0) snap.memory = [...records];
@@ -561,6 +567,10 @@ export class Agent {
     }
     if (snapshot.mood) {
       this.currentMood = { ...snapshot.mood };
+    }
+    if (snapshot.animation) {
+      this.animation.restore({ state: snapshot.animation.state });
+      this.currentActiveSkillId = snapshot.animation.activeSkillId;
     }
     if (snapshot.memory && this.memory && isInMemoryMemoryAdapter(this.memory)) {
       this.memory.restore(snapshot.memory);

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -4,6 +4,7 @@ import {
   AGENT_DIED,
   LIFE_STAGE_CHANGED,
   MODIFIER_APPLIED,
+  MODIFIER_EXPIRED,
   MODIFIER_REMOVED,
   type AgentDiedEvent,
   type LifeStageChangedEvent,
@@ -559,9 +560,24 @@ export class Agent {
       this.needs.restore(snapshot.needs);
     }
     if (snapshot.modifiers) {
+      const nowMs = this.clock.now();
       for (const mod of snapshot.modifiers) {
-        // Drop already-expired modifiers up front.
-        if (mod.expiresAt !== undefined && mod.expiresAt <= this.clock.now()) continue;
+        // Boundary case: modifiers whose expiresAt has already passed at
+        // the clock's current time are dropped on restore AND a
+        // `ModifierExpired` event fires exactly once so downstream
+        // consumers (stores, UIs, logs) see the expiration in the same
+        // shape they would from a normal tick.
+        if (mod.expiresAt !== undefined && mod.expiresAt <= nowMs) {
+          this.publish({
+            type: MODIFIER_EXPIRED,
+            at: nowMs,
+            agentId: this.identity.id,
+            modifierId: mod.id,
+            source: mod.source,
+            ...(mod.visual?.fxHint !== undefined ? { fxHint: mod.visual.fxHint } : {}),
+          });
+          continue;
+        }
         this.modifiers.apply(mod);
       }
     }

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -280,7 +280,7 @@ export class Agent {
         tickStartedAt,
         virtualDtSeconds,
         controlMode: this.controlMode,
-        stage: 'deceased',
+        stage: DECEASED_STAGE,
         halted: true,
         perceived: [],
         actions: [],
@@ -723,7 +723,7 @@ export class Agent {
     // Force the animation into its 'dead' state so renderers update
     // immediately; reconciliation is inert from now on since halted=true
     // short-circuits future ticks.
-    const animationT = this.animation.transition('dead', at, 'deceased');
+    const animationT = this.animation.transition('dead', at, DECEASED_STAGE);
     if (animationT) {
       const animEvent: AnimationTransitionEvent = {
         type: ANIMATION_TRANSITION,
@@ -731,7 +731,7 @@ export class Agent {
         agentId: this.identity.id,
         from: animationT.from,
         to: animationT.to,
-        reason: 'deceased',
+        reason: DECEASED_STAGE,
       };
       this.publish(animEvent);
     }

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -723,7 +723,7 @@ export class Agent {
     // Force the animation into its 'dead' state so renderers update
     // immediately; reconciliation is inert from now on since halted=true
     // short-circuits future ticks.
-    const animationT = this.animation.transition('dead', 'deceased');
+    const animationT = this.animation.transition('dead', at, 'deceased');
     if (animationT) {
       const animEvent: AnimationTransitionEvent = {
         type: ANIMATION_TRANSITION,

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -953,9 +953,9 @@ export class Agent {
 
   /**
    * Install an `AgentModule` after construction. `createAgent` installs
-   * modules via its config at construction time; this method is exposed so
-   * tests can add handlers mid-scenario. Runtime install for consumer use
-   * is a Phase B concern.
+   * modules via its config at construction time; this method is exposed
+   * so tests can add handlers mid-scenario. Runtime install for consumer
+   * use is not yet part of the supported public surface.
    */
   installModule(mod: AgentModule): void {
     this.modules.push(mod);

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -356,19 +356,18 @@ export class Agent {
     // Stage 2.8: animation reconcile.
     const animationTransition = this.animationReconciler.run(tickStartedAt);
 
-    // Stage 3: dispatch by control mode.
+    // Stages 3–7: cognition pipeline. `collectActions` dispatches by
+    // control mode (autonomous → reasoner + behavior runner, else
+    // remote/scripted). `executeActions` then runs invoke-skill /
+    // emit-event / noop actions through the registry, emits
+    // SkillCompleted | SkillFailed, and lets the learner score outcomes.
     const actions: AgentAction[] = await this.cognitionPipeline.collectActions(
       tickStartedAt,
       perceived,
     );
-
-    // Stage 7: execute actions (skills + noops + custom).
     await this.cognitionPipeline.executeActions(actions, tickStartedAt);
 
-    // Stage 4-7: cognition (M7 wires UrgencyReasoner + DirectBehaviorRunner).
-    // Stage 8:   score (learner) (M7 stub).
-
-    // Stage 9: persist + autosave (M10).
+    // Stage 9: persist + autosave.
     if (this.autoSaveTracker) {
       this.autoSaveTracker.advance(virtualDtSeconds);
     }

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -4,19 +4,11 @@ import {
   AGENT_DIED,
   LIFE_STAGE_CHANGED,
   MODIFIER_APPLIED,
-  MODIFIER_EXPIRED,
   MODIFIER_REMOVED,
-  MOOD_CHANGED,
-  NEED_CRITICAL,
-  NEED_SAFE,
   type AgentDiedEvent,
   type LifeStageChangedEvent,
   type ModifierAppliedEvent,
-  type ModifierExpiredEvent,
   type ModifierRemovedEvent,
-  type MoodChangedEvent,
-  type NeedCriticalEvent,
-  type NeedSafeEvent,
 } from '../events/standardEvents.js';
 import {
   ANIMATION_TRANSITION,
@@ -29,23 +21,19 @@ import {
 import type { Embodiment } from '../body/Embodiment.js';
 import type { BehaviorRunner } from '../cognition/behavior/BehaviorRunner.js';
 import { DirectBehaviorRunner } from '../cognition/behavior/DirectBehaviorRunner.js';
-import type { IntentionCandidate } from '../cognition/IntentionCandidate.js';
 import type { Learner } from '../cognition/learning/Learner.js';
 import { NoopLearner } from '../cognition/learning/NoopLearner.js';
 import type { Reasoner } from '../cognition/reasoning/Reasoner.js';
 import { UrgencyReasoner } from '../cognition/reasoning/UrgencyReasoner.js';
 import type { NeedsPolicy } from '../needs/NeedsPolicy.js';
-import type { AgeModel, LifeStageTransition } from '../lifecycle/AgeModel.js';
+import type { AgeModel } from '../lifecycle/AgeModel.js';
 import { DECEASED_STAGE, type LifeStage } from '../lifecycle/LifeStage.js';
 import type { StageCapabilityMap } from '../lifecycle/StageCapabilities.js';
-import { stageAllowsSkill } from '../lifecycle/StageCapabilities.js';
 import type { MemoryRepository } from '../memory/MemoryRepository.js';
 import type { Modifier } from '../modifiers/Modifier.js';
-import type { ModifierRemoval } from '../modifiers/Modifiers.js';
 import { Modifiers } from '../modifiers/Modifiers.js';
 import type { Mood } from '../mood/Mood.js';
 import type { MoodModel } from '../mood/MoodModel.js';
-import type { NeedsDelta } from '../needs/Need.js';
 import type { Needs } from '../needs/Needs.js';
 import type { AgentSnapshot, SnapshotPart } from '../persistence/AgentSnapshot.js';
 import { CURRENT_SNAPSHOT_VERSION } from '../persistence/AgentSnapshot.js';
@@ -58,17 +46,7 @@ import { runCatchUp } from '../persistence/offlineCatchUp.js';
 import type { SnapshotStorePort } from '../persistence/SnapshotStorePort.js';
 import type { RandomEventTicker } from '../randomEvents/RandomEventTicker.js';
 import { InMemoryMemoryAdapter } from '../memory/InMemoryMemoryAdapter.js';
-import type { SkillError, SkillOutcome } from '../skills/Skill.js';
-import type { SkillContext } from '../skills/SkillContext.js';
 import { SkillRegistry } from '../skills/SkillRegistry.js';
-import {
-  SKILL_COMPLETED,
-  SKILL_FAILED,
-  type SkillCompletedEvent,
-  type SkillFailedEvent,
-} from '../events/standardEvents.js';
-import type { Result } from './result.js';
-import { isInvokeSkillAction } from './AgentAction.js';
 import type { RemoteController } from './RemoteController.js';
 import type { ScriptedController } from './ScriptedController.js';
 import type { Rng } from '../ports/Rng.js';
@@ -85,6 +63,12 @@ import type { AgentModule, ReactiveHandler } from './AgentModule.js';
 import type { ControlMode } from './ControlMode.js';
 import type { DecisionTrace } from './DecisionTrace.js';
 import { MissingDependencyError } from './errors.js';
+import { LifecycleTicker } from './internal/LifecycleTicker.js';
+import { ModifiersTicker } from './internal/ModifiersTicker.js';
+import { NeedsTicker } from './internal/NeedsTicker.js';
+import { MoodReconciler } from './internal/MoodReconciler.js';
+import { AnimationReconciler } from './internal/AnimationReconciler.js';
+import { CognitionPipeline } from './internal/CognitionPipeline.js';
 
 const DEFAULT_TIME_SCALE = 1;
 
@@ -192,20 +176,37 @@ export class Agent {
   readonly skills: SkillRegistry;
   readonly needsPolicy: NeedsPolicy | undefined;
   readonly animation: AnimationStateMachine;
-  /** Id of the skill whose execution is currently driving the animation (if any). */
-  protected currentActiveSkillId: string | undefined;
+  /**
+   * Id of the skill whose execution is currently driving the animation
+   * (if any). Public for access by internal tick helpers under
+   * `src/agent/internal/`; consumers should not reach for it directly.
+   */
+  currentActiveSkillId: string | undefined;
   protected readonly autoSaveTracker: AutoSaveTracker | undefined;
-  protected currentMood: Mood | undefined;
+  /** Latest `Mood` evaluation — see `currentActiveSkillId` for the visibility rationale. */
+  currentMood: Mood | undefined;
   /** Cumulative virtual seconds tracked for random-event cooldown bookkeeping. */
   protected virtualNowSeconds = 0;
 
   protected readonly timeScale: number;
-  protected controlMode: ControlMode;
-  protected halted = false;
+  /** Current control mode — `autonomous` / `scripted` / `remote`. Mutable to support switching mid-run. */
+  controlMode: ControlMode;
+  /** `true` once the agent has died — ticks become no-ops. Public for helper access. */
+  halted = false;
   protected readonly reactiveHandlers: ReactiveHandler[] = [];
   protected readonly modules: AgentModule[] = [];
   /** Events queued for inclusion in the current tick's `emitted` field. */
   protected emittedThisTick: DomainEvent[] = [];
+
+  // =========================================================================
+  // Internal tick helpers (extracted under src/agent/internal/).
+  // =========================================================================
+  private readonly lifecycleTicker: LifecycleTicker;
+  private readonly modifiersTicker: ModifiersTicker;
+  private readonly needsTicker: NeedsTicker;
+  private readonly moodReconciler: MoodReconciler;
+  private readonly animationReconciler: AnimationReconciler;
+  private readonly cognitionPipeline: CognitionPipeline;
 
   constructor(deps: AgentDependencies) {
     if (!deps.identity) throw new MissingDependencyError('identity');
@@ -251,10 +252,38 @@ export class Agent {
       this.halted = true;
     }
 
+    // Wire up the tick-pipeline helpers. They keep a reference back to the
+    // agent and read/mutate state through the (now-public) field surface.
+    this.lifecycleTicker = new LifecycleTicker(this);
+    this.modifiersTicker = new ModifiersTicker(this);
+    this.needsTicker = new NeedsTicker(this);
+    this.moodReconciler = new MoodReconciler(this);
+    this.animationReconciler = new AnimationReconciler(this);
+    this.cognitionPipeline = new CognitionPipeline(this);
+
     // Install config-time modules.
     for (const mod of deps.modules ?? []) {
       this.installModule(mod);
     }
+  }
+
+  // =========================================================================
+  // Internal protocol (exposed for helper classes under src/agent/internal/).
+  // Underscore prefix signals "internal"; consumers should not call these.
+  // =========================================================================
+
+  /** @internal publish an event onto the bus and into the tick's emitted list. */
+  _internalPublish(event: DomainEvent): void {
+    this.publish(event);
+  }
+
+  /** @internal route the death path — used by NeedsTicker when health hits 0. */
+  _internalDie(
+    cause: 'health-depleted' | 'stage-transition' | 'explicit' | (string & {}),
+    reason: string | undefined,
+    at: number,
+  ): void {
+    this.die(cause, reason, at);
   }
 
   // =========================================================================
@@ -291,7 +320,7 @@ export class Agent {
     this.emittedThisTick = [];
 
     // Stage 0: advance age + life stages (catch-up-aware).
-    const stageTransitions = this.runLifecycleTick(virtualDtSeconds, tickStartedAt);
+    const stageTransitions = this.lifecycleTicker.run(virtualDtSeconds, tickStartedAt);
 
     // Stage 1: perceive — drain pending events from the bus.
     const perceived = this.eventBus.drain();
@@ -302,11 +331,11 @@ export class Agent {
     this.runRandomEventsTick(virtualDtSeconds, tickStartedAt);
 
     // Stage 2: modifier tick — expire time-bound modifiers.
-    const expired = this.runModifiersTick(tickStartedAt);
+    const expired = this.modifiersTicker.run(tickStartedAt);
 
     // Stage 2.5: needs tick. Decay (scaled by modifier multipliers), critical crossings → events.
     // If health just hit 0 during decay we die here and short-circuit.
-    const needsDeltas = this.runNeedsTick(virtualDtSeconds, tickStartedAt);
+    const needsDeltas = this.needsTicker.run(virtualDtSeconds, tickStartedAt);
     if (this.halted) {
       return {
         agentId: this.identity.id,
@@ -322,15 +351,18 @@ export class Agent {
     }
 
     // Stage 2.7: mood evaluate.
-    const moodChange = this.runMoodTick(tickStartedAt);
+    const moodChange = this.moodReconciler.run(tickStartedAt);
     // Stage 2.8: animation reconcile.
-    const animationTransition = this.runAnimationTick(tickStartedAt);
+    const animationTransition = this.animationReconciler.run(tickStartedAt);
 
     // Stage 3: dispatch by control mode.
-    const actions: AgentAction[] = await this.collectActions(tickStartedAt, perceived);
+    const actions: AgentAction[] = await this.cognitionPipeline.collectActions(
+      tickStartedAt,
+      perceived,
+    );
 
     // Stage 7: execute actions (skills + noops + custom).
-    await this.executeActions(actions, tickStartedAt);
+    await this.cognitionPipeline.executeActions(actions, tickStartedAt);
 
     // Stage 4-7: cognition (M7 wires UrgencyReasoner + DirectBehaviorRunner).
     // Stage 8:   score (learner) (M7 stub).
@@ -371,168 +403,6 @@ export class Agent {
     return trace;
   }
 
-  /** Collect actions for this tick based on `controlMode`. */
-  protected async collectActions(
-    wallNowMs: number,
-    perceived: readonly DomainEvent[],
-  ): Promise<AgentAction[]> {
-    switch (this.controlMode) {
-      case 'remote': {
-        if (!this.remote) return [];
-        const pulled = await this.remote.pull(this.identity.id, wallNowMs);
-        return [...pulled];
-      }
-      case 'scripted': {
-        if (!this.scripted) return [];
-        const next = this.scripted.next(this.identity.id, wallNowMs);
-        return next ? [...next] : [];
-      }
-      case 'autonomous':
-      default:
-        return this.runAutonomousCognition(perceived);
-    }
-  }
-
-  /** Autonomous cognition pipeline — Stage 4 (candidates) + 5 (select) + 6 (behavior). */
-  protected runAutonomousCognition(perceived: readonly DomainEvent[]): AgentAction[] {
-    const candidates: IntentionCandidate[] = [];
-    if (this.needs && this.needsPolicy) {
-      for (const c of this.needsPolicy.suggest(this.needs, this.identity.persona)) {
-        candidates.push(c);
-      }
-    }
-    const intention = this.reasoner.selectIntention({
-      perceived,
-      needs: this.needs,
-      modifiers: this.modifiers,
-      ...(this.identity.persona !== undefined ? { persona: this.identity.persona } : {}),
-      candidates,
-    });
-    if (!intention) return [];
-    return [...this.behavior.run(intention)];
-  }
-
-  /** Stage 7: dispatch actions — invoke-skill goes through the registry. */
-  protected async executeActions(
-    actions: readonly AgentAction[],
-    wallNowMs: number,
-  ): Promise<void> {
-    if (actions.length === 0) return;
-    const ctx = this.skillContext();
-    for (const action of actions) {
-      if (action.type === 'noop') continue;
-      if (isInvokeSkillAction(action)) {
-        await this.invokeSkillAction(action.skillId, action.params, ctx, wallNowMs);
-        continue;
-      }
-      if (action.type === 'emit-event' && 'event' in action) {
-        const event = (action as { event: DomainEvent }).event;
-        this.publish(event);
-        continue;
-      }
-      // Unknown action kinds are left for consumer modules to interpret;
-      // they can subscribe and react via reactive handlers next tick.
-    }
-  }
-
-  /**
-   * Invoke a skill through the registry, honoring stage capabilities + modifier
-   * effectiveness, and emit the appropriate SkillCompleted / SkillFailed event.
-   */
-  protected async invokeSkillAction(
-    skillId: string,
-    params: Record<string, unknown> | undefined,
-    ctx: SkillContext,
-    wallNowMs: number,
-  ): Promise<void> {
-    // Stage capability gate.
-    if (this.ageModel && this.stageCapabilities) {
-      if (!stageAllowsSkill(this.stageCapabilities, this.ageModel.stage, skillId)) {
-        const event: SkillFailedEvent = {
-          type: SKILL_FAILED,
-          at: wallNowMs,
-          agentId: this.identity.id,
-          skillId,
-          code: 'stage-blocked',
-          message: `Skill '${skillId}' is blocked at stage '${this.ageModel.stage}'.`,
-        };
-        this.publish(event);
-        return;
-      }
-    }
-    if (!this.skills.has(skillId)) {
-      const event: SkillFailedEvent = {
-        type: SKILL_FAILED,
-        at: wallNowMs,
-        agentId: this.identity.id,
-        skillId,
-        code: 'not-registered',
-        message: `No skill registered with id '${skillId}'.`,
-      };
-      this.publish(event);
-      return;
-    }
-    // Expose the running skill to the animation reconciler. Scoped to this
-    // invocation so multiple sequential skills don't leak state.
-    const previousActive = this.currentActiveSkillId;
-    this.currentActiveSkillId = skillId;
-    const result: Result<SkillOutcome, SkillError> = await this.skills
-      .invoke(skillId, params, ctx)
-      .finally(() => {
-        this.currentActiveSkillId = previousActive;
-      });
-    if (result.ok) {
-      const skill = this.skills.get(skillId);
-      const base = skill?.baseEffectiveness ?? 1;
-      const effectiveness =
-        (result.value.effectiveness ?? base) * this.modifiers.skillEffectiveness(skillId);
-      const event: SkillCompletedEvent = {
-        type: SKILL_COMPLETED,
-        at: wallNowMs,
-        agentId: this.identity.id,
-        skillId,
-        effectiveness,
-        ...(result.value.fxHint !== undefined ? { fxHint: result.value.fxHint } : {}),
-        ...(result.value.details !== undefined ? { details: result.value.details } : {}),
-      };
-      this.publish(event);
-      this.learner.score({
-        intention: { kind: 'satisfy', type: skillId },
-        actions: [{ type: 'invoke-skill', skillId, ...(params !== undefined ? { params } : {}) }],
-        details: { effectiveness },
-      });
-    } else {
-      const event: SkillFailedEvent = {
-        type: SKILL_FAILED,
-        at: wallNowMs,
-        agentId: this.identity.id,
-        skillId,
-        code: result.error.code,
-        message: result.error.message,
-        ...(result.error.details !== undefined ? { details: result.error.details } : {}),
-      };
-      this.publish(event);
-    }
-  }
-
-  /** Build the SkillContext passed to every skill execution. */
-  protected skillContext(): SkillContext {
-    return {
-      identity: this.identity,
-      clock: this.clock,
-      rng: this.rng,
-      satisfyNeed: (needId, amount) => {
-        this.needs?.satisfy(needId, amount);
-      },
-      applyModifier: (mod) => this.applyModifier(mod),
-      removeModifier: (id) => this.removeModifier(id),
-      publishEvent: (event) => {
-        this.publish(event);
-      },
-      ageSeconds: () => this.ageModel?.ageSeconds ?? 0,
-    };
-  }
-
   /** Publish random events onto the bus (step 1.5). */
   protected runRandomEventsTick(virtualDtSeconds: number, at: number): void {
     if (!this.randomEvents || virtualDtSeconds <= 0) return;
@@ -556,133 +426,6 @@ export class Agent {
     if (!this.autoSaveTracker.shouldSave()) return;
     await this.snapshotStore.save(this.autoSaveKey, this.snapshot());
     this.autoSaveTracker.markSaved();
-  }
-
-  /** Advance age + life stages; emit LifeStageChanged for each crossed threshold. */
-  protected runLifecycleTick(virtualDtSeconds: number, at: number): readonly LifeStageTransition[] {
-    if (!this.ageModel) return [];
-    const transitions = this.ageModel.advance(virtualDtSeconds);
-    for (const t of transitions) {
-      const event: LifeStageChangedEvent = {
-        type: LIFE_STAGE_CHANGED,
-        at,
-        agentId: this.identity.id,
-        from: t.from,
-        to: t.to,
-        atAgeSeconds: t.atAgeSeconds,
-      };
-      this.publish(event);
-    }
-    return transitions;
-  }
-
-  /** Reconcile the animation state machine and emit AnimationTransition if it rotated. */
-  protected runAnimationTick(at: number): { from: string; to: string; reason?: string } | null {
-    const transition = this.animation.reconcile({
-      modifiers: this.modifiers,
-      wallNowMs: at,
-      ...(this.currentActiveSkillId !== undefined
-        ? { activeSkillId: this.currentActiveSkillId }
-        : {}),
-      ...(this.currentMood?.category !== undefined ? { mood: this.currentMood.category } : {}),
-    });
-    if (!transition) return null;
-    const event: AnimationTransitionEvent = {
-      type: ANIMATION_TRANSITION,
-      at,
-      agentId: this.identity.id,
-      from: transition.from,
-      to: transition.to,
-      ...(transition.reason !== undefined ? { reason: transition.reason } : {}),
-      ...(transition.fxHint !== undefined ? { fxHint: transition.fxHint } : {}),
-    };
-    this.publish(event);
-    return {
-      from: transition.from,
-      to: transition.to,
-      ...(transition.reason !== undefined ? { reason: transition.reason } : {}),
-    };
-  }
-
-  /** Evaluate the mood model and emit MoodChanged if the category rotated. */
-  protected runMoodTick(
-    at: number,
-  ): { from: string | undefined; to: string; valence: number | undefined } | null {
-    if (!this.moodModel) return null;
-    const previous = this.currentMood;
-    const next = this.moodModel.evaluate({
-      needs: this.needs,
-      modifiers: this.modifiers,
-      persona: this.identity.persona,
-      wallNowMs: at,
-      previous,
-    });
-    this.currentMood = next;
-    if (previous && previous.category === next.category) return null;
-    const event: MoodChangedEvent = {
-      type: MOOD_CHANGED,
-      at,
-      agentId: this.identity.id,
-      from: previous?.category,
-      to: next.category,
-      valence: next.valence,
-    };
-    this.publish(event);
-    return { from: previous?.category, to: next.category, valence: next.valence };
-  }
-
-  /** Expire time-bound modifiers and publish `ModifierExpired` events. */
-  protected runModifiersTick(at: number): readonly ModifierRemoval[] {
-    const expired = this.modifiers.tick(at);
-    for (const removal of expired) {
-      const event: ModifierExpiredEvent = {
-        type: MODIFIER_EXPIRED,
-        at,
-        agentId: this.identity.id,
-        modifierId: removal.modifier.id,
-        source: removal.modifier.source,
-        ...(removal.modifier.visual?.fxHint !== undefined
-          ? { fxHint: removal.modifier.visual.fxHint }
-          : {}),
-      };
-      this.publish(event);
-    }
-    return expired;
-  }
-
-  /** Run the Needs.tick step and emit critical/safe events for threshold crossings. */
-  protected runNeedsTick(virtualDtSeconds: number, at: number): readonly NeedsDelta[] {
-    if (!this.needs || virtualDtSeconds <= 0) return [];
-    const deltas = this.needs.tick(virtualDtSeconds, (id) => this.modifiers.decayMultiplier(id));
-    let healthDepleted = false;
-    for (const delta of deltas) {
-      if (delta.crossedCritical) {
-        const event: NeedCriticalEvent = {
-          type: NEED_CRITICAL,
-          at,
-          agentId: this.identity.id,
-          needId: delta.needId,
-          level: delta.after,
-        };
-        this.publish(event);
-      } else if (delta.crossedSafe) {
-        const event: NeedSafeEvent = {
-          type: NEED_SAFE,
-          at,
-          agentId: this.identity.id,
-          needId: delta.needId,
-          level: delta.after,
-        };
-        this.publish(event);
-      }
-      if (delta.needId === 'health' && delta.after <= 0) {
-        healthDepleted = true;
-      }
-    }
-    if (healthDepleted && !this.halted) {
-      this.die('health-depleted', undefined, at);
-    }
-    return deltas;
   }
 
   /**
@@ -980,7 +723,12 @@ export class Agent {
         this.eventBus.publish(event);
       },
       invokeSkill: async (skillId, params) => {
-        await this.invokeSkillAction(skillId, params, this.skillContext(), this.clock.now());
+        await this.cognitionPipeline.invokeSkillAction(
+          skillId,
+          params,
+          this.cognitionPipeline.skillContext(),
+          this.clock.now(),
+        );
       },
     };
   }

--- a/src/agent/createAgent.ts
+++ b/src/agent/createAgent.ts
@@ -20,6 +20,7 @@ import { DefaultMoodModel } from '../mood/DefaultMoodModel.js';
 import type { Need } from '../needs/Need.js';
 import { Needs } from '../needs/Needs.js';
 import type { NeedsPolicy } from '../needs/NeedsPolicy.js';
+import { ExpressiveNeedsPolicy } from '../needs/ExpressiveNeedsPolicy.js';
 import type { Skill } from '../skills/Skill.js';
 import { SkillRegistry } from '../skills/SkillRegistry.js';
 import type { AutoSavePolicy } from '../persistence/AutoSavePolicy.js';
@@ -194,6 +195,7 @@ export function createAgent(config: CreateAgentConfig): Agent {
       : undefined;
 
   const moodModel = resolveMoodModel(config.moodModel, Boolean(needs ?? ageModel));
+  const needsPolicy = resolveNeedsPolicy(config.needsPolicy, needs);
   const randomEvents = resolveRandomEvents(config.randomEvents);
   const memory = config.memory ?? new InMemoryMemoryAdapter();
   const { snapshotStore, autoSave, autoSaveKey } = resolvePersistence(config.persistence);
@@ -258,7 +260,7 @@ export function createAgent(config: CreateAgentConfig): Agent {
     ...(config.reasoner !== undefined ? { reasoner: config.reasoner } : {}),
     ...(config.behavior !== undefined ? { behavior: config.behavior } : {}),
     ...(config.learner !== undefined ? { learner: config.learner } : {}),
-    ...(config.needsPolicy !== undefined ? { needsPolicy: config.needsPolicy } : {}),
+    ...(needsPolicy !== undefined ? { needsPolicy } : {}),
     ...(config.animation !== undefined ? { animation: config.animation } : {}),
     skills,
   });
@@ -345,6 +347,21 @@ function resolveNeeds(needs: Needs | readonly Need[] | undefined): Needs | undef
   if (needs === undefined) return undefined;
   if (needs instanceof Needs) return needs;
   return new Needs(needs);
+}
+
+/**
+ * Auto-wires an `ExpressiveNeedsPolicy` when the consumer configured
+ * `needs` but no explicit `needsPolicy`. Without this, the autonomous
+ * cognition pipeline silently produces zero candidates and the pet
+ * appears inert.
+ */
+function resolveNeedsPolicy(
+  explicit: NeedsPolicy | undefined,
+  needs: Needs | undefined,
+): NeedsPolicy | undefined {
+  if (explicit !== undefined) return explicit;
+  if (needs === undefined) return undefined;
+  return new ExpressiveNeedsPolicy();
 }
 
 function resolveRng(rng: Rng | number | string | undefined, fallbackSeed: string): Rng {

--- a/src/agent/errors.ts
+++ b/src/agent/errors.ts
@@ -60,7 +60,10 @@ export class SkillInvocationError extends AgentError {
   }
 }
 
-/** An LLM call would exceed its configured `LlmBudget`. Phase B. */
+/**
+ * An LLM or tool call would exceed its configured budget. Reserved for
+ * LLM-tool integrations; unused by the core tick pipeline.
+ */
 export class BudgetExceededError extends AgentError {
   constructor(message: string, options?: { cause?: unknown }) {
     super('E_BUDGET_EXCEEDED', message, options);

--- a/src/agent/internal/AnimationReconciler.ts
+++ b/src/agent/internal/AnimationReconciler.ts
@@ -1,0 +1,43 @@
+import {
+  ANIMATION_TRANSITION,
+  type AnimationTransitionEvent,
+} from '../../animation/AnimationTransitionEvent.js';
+import type { Agent } from '../Agent.js';
+
+/**
+ * Stage 2.8 of the tick pipeline: reconcile the animation state machine
+ * and emit `AnimationTransition` when it rotates.
+ *
+ * @internal
+ */
+export class AnimationReconciler {
+  constructor(private readonly agent: Agent) {}
+
+  run(at: number): { from: string; to: string; reason?: string } | null {
+    const agent = this.agent;
+    const transition = agent.animation.reconcile({
+      modifiers: agent.modifiers,
+      wallNowMs: at,
+      ...(agent.currentActiveSkillId !== undefined
+        ? { activeSkillId: agent.currentActiveSkillId }
+        : {}),
+      ...(agent.currentMood?.category !== undefined ? { mood: agent.currentMood.category } : {}),
+    });
+    if (!transition) return null;
+    const event: AnimationTransitionEvent = {
+      type: ANIMATION_TRANSITION,
+      at,
+      agentId: agent.identity.id,
+      from: transition.from,
+      to: transition.to,
+      ...(transition.reason !== undefined ? { reason: transition.reason } : {}),
+      ...(transition.fxHint !== undefined ? { fxHint: transition.fxHint } : {}),
+    };
+    agent._internalPublish(event);
+    return {
+      from: transition.from,
+      to: transition.to,
+      ...(transition.reason !== undefined ? { reason: transition.reason } : {}),
+    };
+  }
+}

--- a/src/agent/internal/CognitionPipeline.ts
+++ b/src/agent/internal/CognitionPipeline.ts
@@ -129,11 +129,30 @@ export class CognitionPipeline {
     // invocation so multiple sequential skills don't leak state.
     const previousActive = agent.currentActiveSkillId;
     agent.currentActiveSkillId = skillId;
-    const result: Result<SkillOutcome, SkillError> = await agent.skills
-      .invoke(skillId, params, ctx)
-      .finally(() => {
-        agent.currentActiveSkillId = previousActive;
-      });
+    let result: Result<SkillOutcome, SkillError>;
+    try {
+      result = await agent.skills.invoke(skillId, params, ctx);
+    } catch (cause) {
+      // Throws from inside a skill are treated as infrastructure failures:
+      // emit SkillFailed with `code: 'execution-threw'` and continue. Skills
+      // should return `err(...)` for expected failure modes — this path
+      // guards determinism: no RNG draws happen between the throw and the
+      // next tick, so replay stays byte-identical.
+      agent.currentActiveSkillId = previousActive;
+      const message = cause instanceof Error ? cause.message : String(cause);
+      const event: SkillFailedEvent = {
+        type: SKILL_FAILED,
+        at: wallNowMs,
+        agentId: agent.identity.id,
+        skillId,
+        code: 'execution-threw',
+        message,
+        details: { cause: message },
+      };
+      agent._internalPublish(event);
+      return;
+    }
+    agent.currentActiveSkillId = previousActive;
     if (result.ok) {
       const skill = agent.skills.get(skillId);
       const base = skill?.baseEffectiveness ?? 1;

--- a/src/agent/internal/CognitionPipeline.ts
+++ b/src/agent/internal/CognitionPipeline.ts
@@ -199,6 +199,7 @@ export class CognitionPipeline {
       },
       applyModifier: (mod) => agent.applyModifier(mod),
       removeModifier: (id) => agent.removeModifier(id),
+      hasModifier: (id) => agent.modifiers.has(id),
       publishEvent: (event) => {
         agent._internalPublish(event);
       },

--- a/src/agent/internal/CognitionPipeline.ts
+++ b/src/agent/internal/CognitionPipeline.ts
@@ -1,0 +1,189 @@
+import type { DomainEvent } from '../../events/DomainEvent.js';
+import {
+  SKILL_COMPLETED,
+  SKILL_FAILED,
+  type SkillCompletedEvent,
+  type SkillFailedEvent,
+} from '../../events/standardEvents.js';
+import type { IntentionCandidate } from '../../cognition/IntentionCandidate.js';
+import { stageAllowsSkill } from '../../lifecycle/StageCapabilities.js';
+import type { SkillContext } from '../../skills/SkillContext.js';
+import type { SkillError, SkillOutcome } from '../../skills/Skill.js';
+import type { Result } from '../result.js';
+import { isInvokeSkillAction, type AgentAction } from '../AgentAction.js';
+import type { Agent } from '../Agent.js';
+
+/**
+ * Stages 3–7 of the tick pipeline: collect actions (control-mode-dispatched),
+ * run autonomous cognition, execute resulting actions through the skill
+ * registry, and build the `SkillContext` passed to each skill invocation.
+ *
+ * @internal
+ */
+export class CognitionPipeline {
+  constructor(private readonly agent: Agent) {}
+
+  /** Collect actions for this tick based on the agent's current `controlMode`. */
+  async collectActions(
+    wallNowMs: number,
+    perceived: readonly DomainEvent[],
+  ): Promise<AgentAction[]> {
+    const agent = this.agent;
+    switch (agent.controlMode) {
+      case 'remote': {
+        if (!agent.remote) return [];
+        const pulled = await agent.remote.pull(agent.identity.id, wallNowMs);
+        return [...pulled];
+      }
+      case 'scripted': {
+        if (!agent.scripted) return [];
+        const next = agent.scripted.next(agent.identity.id, wallNowMs);
+        return next ? [...next] : [];
+      }
+      case 'autonomous':
+      default:
+        return this.runAutonomousCognition(perceived);
+    }
+  }
+
+  /** Autonomous cognition — Stage 4 (candidates) + 5 (select) + 6 (behavior). */
+  runAutonomousCognition(perceived: readonly DomainEvent[]): AgentAction[] {
+    const agent = this.agent;
+    const candidates: IntentionCandidate[] = [];
+    if (agent.needs && agent.needsPolicy) {
+      for (const c of agent.needsPolicy.suggest(agent.needs, agent.identity.persona)) {
+        candidates.push(c);
+      }
+    }
+    const intention = agent.reasoner.selectIntention({
+      perceived,
+      needs: agent.needs,
+      modifiers: agent.modifiers,
+      ...(agent.identity.persona !== undefined ? { persona: agent.identity.persona } : {}),
+      candidates,
+    });
+    if (!intention) return [];
+    return [...agent.behavior.run(intention)];
+  }
+
+  /** Stage 7: dispatch actions — invoke-skill goes through the registry. */
+  async executeActions(actions: readonly AgentAction[], wallNowMs: number): Promise<void> {
+    if (actions.length === 0) return;
+    const ctx = this.skillContext();
+    for (const action of actions) {
+      if (action.type === 'noop') continue;
+      if (isInvokeSkillAction(action)) {
+        await this.invokeSkillAction(action.skillId, action.params, ctx, wallNowMs);
+        continue;
+      }
+      if (action.type === 'emit-event' && 'event' in action) {
+        const event = (action as { event: DomainEvent }).event;
+        this.agent._internalPublish(event);
+        continue;
+      }
+      // Unknown action kinds are left for consumer modules to interpret;
+      // they can subscribe and react via reactive handlers next tick.
+    }
+  }
+
+  /**
+   * Invoke a skill through the registry, honoring stage capabilities +
+   * modifier effectiveness, and emit the appropriate SkillCompleted /
+   * SkillFailed event.
+   */
+  async invokeSkillAction(
+    skillId: string,
+    params: Record<string, unknown> | undefined,
+    ctx: SkillContext,
+    wallNowMs: number,
+  ): Promise<void> {
+    const agent = this.agent;
+    // Stage capability gate.
+    if (agent.ageModel && agent.stageCapabilities) {
+      if (!stageAllowsSkill(agent.stageCapabilities, agent.ageModel.stage, skillId)) {
+        const event: SkillFailedEvent = {
+          type: SKILL_FAILED,
+          at: wallNowMs,
+          agentId: agent.identity.id,
+          skillId,
+          code: 'stage-blocked',
+          message: `Skill '${skillId}' is blocked at stage '${agent.ageModel.stage}'.`,
+        };
+        agent._internalPublish(event);
+        return;
+      }
+    }
+    if (!agent.skills.has(skillId)) {
+      const event: SkillFailedEvent = {
+        type: SKILL_FAILED,
+        at: wallNowMs,
+        agentId: agent.identity.id,
+        skillId,
+        code: 'not-registered',
+        message: `No skill registered with id '${skillId}'.`,
+      };
+      agent._internalPublish(event);
+      return;
+    }
+    // Expose the running skill to the animation reconciler. Scoped to this
+    // invocation so multiple sequential skills don't leak state.
+    const previousActive = agent.currentActiveSkillId;
+    agent.currentActiveSkillId = skillId;
+    const result: Result<SkillOutcome, SkillError> = await agent.skills
+      .invoke(skillId, params, ctx)
+      .finally(() => {
+        agent.currentActiveSkillId = previousActive;
+      });
+    if (result.ok) {
+      const skill = agent.skills.get(skillId);
+      const base = skill?.baseEffectiveness ?? 1;
+      const effectiveness =
+        (result.value.effectiveness ?? base) * agent.modifiers.skillEffectiveness(skillId);
+      const event: SkillCompletedEvent = {
+        type: SKILL_COMPLETED,
+        at: wallNowMs,
+        agentId: agent.identity.id,
+        skillId,
+        effectiveness,
+        ...(result.value.fxHint !== undefined ? { fxHint: result.value.fxHint } : {}),
+        ...(result.value.details !== undefined ? { details: result.value.details } : {}),
+      };
+      agent._internalPublish(event);
+      agent.learner.score({
+        intention: { kind: 'satisfy', type: skillId },
+        actions: [{ type: 'invoke-skill', skillId, ...(params !== undefined ? { params } : {}) }],
+        details: { effectiveness },
+      });
+    } else {
+      const event: SkillFailedEvent = {
+        type: SKILL_FAILED,
+        at: wallNowMs,
+        agentId: agent.identity.id,
+        skillId,
+        code: result.error.code,
+        message: result.error.message,
+        ...(result.error.details !== undefined ? { details: result.error.details } : {}),
+      };
+      agent._internalPublish(event);
+    }
+  }
+
+  /** Build the SkillContext passed to every skill execution. */
+  skillContext(): SkillContext {
+    const agent = this.agent;
+    return {
+      identity: agent.identity,
+      clock: agent.clock,
+      rng: agent.rng,
+      satisfyNeed: (needId, amount) => {
+        agent.needs?.satisfy(needId, amount);
+      },
+      applyModifier: (mod) => agent.applyModifier(mod),
+      removeModifier: (id) => agent.removeModifier(id),
+      publishEvent: (event) => {
+        agent._internalPublish(event);
+      },
+      ageSeconds: () => agent.ageModel?.ageSeconds ?? 0,
+    };
+  }
+}

--- a/src/agent/internal/LifecycleTicker.ts
+++ b/src/agent/internal/LifecycleTicker.ts
@@ -1,0 +1,31 @@
+import { LIFE_STAGE_CHANGED, type LifeStageChangedEvent } from '../../events/standardEvents.js';
+import type { LifeStageTransition } from '../../lifecycle/AgeModel.js';
+import type { Agent } from '../Agent.js';
+
+/**
+ * Stage 0 of the tick pipeline: advance the age model and emit
+ * `LifeStageChanged` for each threshold crossed.
+ *
+ * @internal
+ */
+export class LifecycleTicker {
+  constructor(private readonly agent: Agent) {}
+
+  run(virtualDtSeconds: number, at: number): readonly LifeStageTransition[] {
+    const { ageModel } = this.agent;
+    if (!ageModel) return [];
+    const transitions = ageModel.advance(virtualDtSeconds);
+    for (const t of transitions) {
+      const event: LifeStageChangedEvent = {
+        type: LIFE_STAGE_CHANGED,
+        at,
+        agentId: this.agent.identity.id,
+        from: t.from,
+        to: t.to,
+        atAgeSeconds: t.atAgeSeconds,
+      };
+      this.agent._internalPublish(event);
+    }
+    return transitions;
+  }
+}

--- a/src/agent/internal/ModifiersTicker.ts
+++ b/src/agent/internal/ModifiersTicker.ts
@@ -1,0 +1,31 @@
+import { MODIFIER_EXPIRED, type ModifierExpiredEvent } from '../../events/standardEvents.js';
+import type { ModifierRemoval } from '../../modifiers/Modifiers.js';
+import type { Agent } from '../Agent.js';
+
+/**
+ * Stage 2 of the tick pipeline: expire time-bound modifiers and publish
+ * `ModifierExpired` events.
+ *
+ * @internal
+ */
+export class ModifiersTicker {
+  constructor(private readonly agent: Agent) {}
+
+  run(at: number): readonly ModifierRemoval[] {
+    const expired = this.agent.modifiers.tick(at);
+    for (const removal of expired) {
+      const event: ModifierExpiredEvent = {
+        type: MODIFIER_EXPIRED,
+        at,
+        agentId: this.agent.identity.id,
+        modifierId: removal.modifier.id,
+        source: removal.modifier.source,
+        ...(removal.modifier.visual?.fxHint !== undefined
+          ? { fxHint: removal.modifier.visual.fxHint }
+          : {}),
+      };
+      this.agent._internalPublish(event);
+    }
+    return expired;
+  }
+}

--- a/src/agent/internal/MoodReconciler.ts
+++ b/src/agent/internal/MoodReconciler.ts
@@ -1,0 +1,37 @@
+import { MOOD_CHANGED, type MoodChangedEvent } from '../../events/standardEvents.js';
+import type { Agent } from '../Agent.js';
+
+/**
+ * Stage 2.7 of the tick pipeline: evaluate the mood model and emit
+ * `MoodChanged` when the category rotates.
+ *
+ * @internal
+ */
+export class MoodReconciler {
+  constructor(private readonly agent: Agent) {}
+
+  run(at: number): { from: string | undefined; to: string; valence: number | undefined } | null {
+    const agent = this.agent;
+    if (!agent.moodModel) return null;
+    const previous = agent.currentMood;
+    const next = agent.moodModel.evaluate({
+      needs: agent.needs,
+      modifiers: agent.modifiers,
+      persona: agent.identity.persona,
+      wallNowMs: at,
+      previous,
+    });
+    agent.currentMood = next;
+    if (previous && previous.category === next.category) return null;
+    const event: MoodChangedEvent = {
+      type: MOOD_CHANGED,
+      at,
+      agentId: agent.identity.id,
+      from: previous?.category,
+      to: next.category,
+      valence: next.valence,
+    };
+    agent._internalPublish(event);
+    return { from: previous?.category, to: next.category, valence: next.valence };
+  }
+}

--- a/src/agent/internal/NeedsTicker.ts
+++ b/src/agent/internal/NeedsTicker.ts
@@ -1,0 +1,54 @@
+import {
+  NEED_CRITICAL,
+  NEED_SAFE,
+  type NeedCriticalEvent,
+  type NeedSafeEvent,
+} from '../../events/standardEvents.js';
+import type { NeedsDelta } from '../../needs/Need.js';
+import type { Agent } from '../Agent.js';
+
+/**
+ * Stage 2.5 of the tick pipeline: decay needs (scaled by modifier
+ * multipliers), publish critical/safe crossings, and route the
+ * "health depleted → kill" path.
+ *
+ * @internal
+ */
+export class NeedsTicker {
+  constructor(private readonly agent: Agent) {}
+
+  run(virtualDtSeconds: number, at: number): readonly NeedsDelta[] {
+    const agent = this.agent;
+    if (!agent.needs || virtualDtSeconds <= 0) return [];
+    const deltas = agent.needs.tick(virtualDtSeconds, (id) => agent.modifiers.decayMultiplier(id));
+    let healthDepleted = false;
+    for (const delta of deltas) {
+      if (delta.crossedCritical) {
+        const event: NeedCriticalEvent = {
+          type: NEED_CRITICAL,
+          at,
+          agentId: agent.identity.id,
+          needId: delta.needId,
+          level: delta.after,
+        };
+        agent._internalPublish(event);
+      } else if (delta.crossedSafe) {
+        const event: NeedSafeEvent = {
+          type: NEED_SAFE,
+          at,
+          agentId: agent.identity.id,
+          needId: delta.needId,
+          level: delta.after,
+        };
+        agent._internalPublish(event);
+      }
+      if (delta.needId === 'health' && delta.after <= 0) {
+        healthDepleted = true;
+      }
+    }
+    if (healthDepleted && !agent.halted) {
+      agent._internalDie('health-depleted', undefined, at);
+    }
+    return deltas;
+  }
+}

--- a/src/agent/internal/TickContext.ts
+++ b/src/agent/internal/TickContext.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared tick-time context passed between the `Agent.tick()` stages.
+ *
+ * Internal module — not re-exported from the library barrel.
+ *
+ * @internal
+ */
+export interface TickContext {
+  /** Wall-clock time at the start of the tick, in ms. */
+  readonly tickStartedAt: number;
+  /** Virtual seconds of dt after applying `timeScale`. */
+  readonly virtualDtSeconds: number;
+}

--- a/src/animation/AnimationStateMachine.ts
+++ b/src/animation/AnimationStateMachine.ts
@@ -115,7 +115,7 @@ export class AnimationStateMachine {
 
   /**
    * Derive the right state from context priority:
-   *   1. Deceased: forced 'dead' (caller sets reason = 'deceased').
+   *   1. Deceased: forced 'dead' (caller sets reason = DECEASED_STAGE).
    *   2. Modifier override wins (sick / stunned / etc).
    *   3. Running skill.
    *   4. Mood mapping.

--- a/src/animation/AnimationStateMachine.ts
+++ b/src/animation/AnimationStateMachine.ts
@@ -74,15 +74,22 @@ export class AnimationStateMachine {
   }
 
   /**
-   * Force an explicit transition. Skips reconciliation. Returns the
-   * transition (or null if we're already in `next`).
+   * Force an explicit transition. Skips reconciliation. `at` is the wall
+   * ms at which the transition occurred; callers MUST pass it rather than
+   * patching post-hoc. Returns the transition, or `null` if we're already
+   * in `next`.
    */
-  transition(next: AnimationState, reason?: string, fxHint?: string): AnimationTransition | null {
+  transition(
+    next: AnimationState,
+    at: number,
+    reason?: string,
+    fxHint?: string,
+  ): AnimationTransition | null {
     if (next === this.currentState) return null;
     const t: AnimationTransition = {
       from: this.currentState,
       to: next,
-      at: 0, // caller patches in wall ms — the Agent fills it in.
+      at,
       ...(reason !== undefined ? { reason } : {}),
       ...(fxHint !== undefined ? { fxHint } : {}),
     };

--- a/src/animation/AnimationStateMachine.ts
+++ b/src/animation/AnimationStateMachine.ts
@@ -29,13 +29,19 @@ export interface ReconcileContext {
  * - `moodMap` maps a mood category onto an animation state when no skill
  *   or modifier is driving.
  * - `idleState` is the fallback. Default `'idle'`.
+ * - `maxHistorySize` caps the in-memory transition log. Default `1000`.
+ *   On overflow the oldest entry is evicted. Guards long-running agents
+ *   against unbounded history growth.
  */
 export interface AnimationStateMachineOptions {
   skillMap?: Readonly<Record<string, AnimationState>>;
   modifierOverrides?: Readonly<Record<string, AnimationState>>;
   moodMap?: Readonly<Record<string, AnimationState>>;
   idleState?: AnimationState;
+  maxHistorySize?: number;
 }
+
+export const DEFAULT_ANIMATION_HISTORY_SIZE = 1000;
 
 /**
  * State machine routing (active skill + mood + modifiers) to a single
@@ -49,6 +55,7 @@ export class AnimationStateMachine {
   private readonly modifierOverrides: Readonly<Record<string, AnimationState>>;
   private readonly moodMap: Readonly<Record<string, AnimationState>>;
   private readonly idleState: AnimationState;
+  private readonly maxHistorySize: number;
 
   constructor(opts: AnimationStateMachineOptions = {}) {
     this.skillMap = opts.skillMap ?? {};
@@ -63,6 +70,14 @@ export class AnimationStateMachine {
     };
     this.idleState = opts.idleState ?? 'idle';
     this.currentState = this.idleState;
+    this.maxHistorySize = Math.max(1, opts.maxHistorySize ?? DEFAULT_ANIMATION_HISTORY_SIZE);
+  }
+
+  private pushHistory(t: AnimationTransition): void {
+    this.historyLog.push(t);
+    if (this.historyLog.length > this.maxHistorySize) {
+      this.historyLog.shift();
+    }
   }
 
   current(): AnimationState {
@@ -94,7 +109,7 @@ export class AnimationStateMachine {
       ...(fxHint !== undefined ? { fxHint } : {}),
     };
     this.currentState = next;
-    this.historyLog.push(t);
+    this.pushHistory(t);
     return t;
   }
 
@@ -116,7 +131,7 @@ export class AnimationStateMachine {
       reason: this.reasonFor(ctx, next),
     };
     this.currentState = next;
-    this.historyLog.push(t);
+    this.pushHistory(t);
     return t;
   }
 

--- a/src/cognition/Intention.ts
+++ b/src/cognition/Intention.ts
@@ -6,15 +6,16 @@
  * - `satisfy`   — active state-changing action (eat food, drink water).
  * - `idle`      — nothing to do right now.
  * - `react`     — responding to a specific perceived event.
- * - `do-task`   — executing a task from the queue (Phase B).
+ * - `do-task`   — executing a task from a queue. Reserved for jobs/tasks
+ *                 extensions; unused by the default `UrgencyReasoner`.
  * - `string & {}` escape hatch for consumer-defined kinds.
  */
 export type IntentionKind = 'express' | 'satisfy' | 'idle' | 'react' | 'do-task' | (string & {});
 
 /**
  * Structured description of "what I want to do next". Produced by
- * `NeedsPolicy` / reactive handlers / (Phase B) reasoners; consumed by the
- * `BehaviorRunner` to produce `AgentAction`s.
+ * `NeedsPolicy` / reactive handlers / consumer-supplied reasoners;
+ * consumed by the `BehaviorRunner` to produce `AgentAction`s.
  */
 export interface Intention {
   kind: IntentionKind;

--- a/src/cognition/behavior/BehaviorRunner.ts
+++ b/src/cognition/behavior/BehaviorRunner.ts
@@ -2,10 +2,10 @@ import type { AgentAction } from '../../agent/AgentAction.js';
 import type { Intention } from '../Intention.js';
 
 /**
- * Translator from "what I want to do" (`Intention`) into "how I actually do
- * it" (`AgentAction[]`). Default Phase A is a table-driven lookup
- * (`DirectBehaviorRunner`); Phase B swaps in `MistreevousBehavior` for
- * real behavior trees.
+ * Translator from "what I want to do" (`Intention`) into "how I actually
+ * do it" (`AgentAction[]`). The default runner is a table-driven lookup
+ * (`DirectBehaviorRunner`); consumers can plug in richer runners — e.g.,
+ * a mistreevous-backed behavior tree — through the same port.
  */
 export interface BehaviorRunner {
   run(intention: Intention): readonly AgentAction[];

--- a/src/cognition/learning/Learner.ts
+++ b/src/cognition/learning/Learner.ts
@@ -2,9 +2,9 @@ import type { AgentAction } from '../../agent/AgentAction.js';
 import type { Intention } from '../Intention.js';
 
 /**
- * Scoring / adaptation slot. Consumers who care about reinforcement pass a
- * concrete `Learner` (Phase B `BrainJsLearner` wraps brain.js); the default
- * is `NoopLearner`, which ignores outcomes.
+ * Scoring / adaptation slot. Consumers who care about reinforcement pass
+ * a concrete `Learner` (e.g., a brain.js-backed adapter); the default is
+ * `NoopLearner`, which ignores outcomes.
  *
  * Exposed now so the tick pipeline's Stage 8 (score) has a stable seam.
  */

--- a/src/cognition/personaBias.ts
+++ b/src/cognition/personaBias.ts
@@ -1,4 +1,5 @@
 import type { Persona } from '../agent/Persona.js';
+import { PERSONA_TRAIT_WEIGHTS } from './tuning.js';
 
 /**
  * Pure function mapping `(intentionType, persona)` to a bias scalar.
@@ -24,19 +25,19 @@ export const defaultPersonaBias: PersonaBiasFn = (intentionType, persona) => {
   let bias = 0;
 
   if (intentionType === 'do-task' || intentionType.startsWith('do-task:')) {
-    bias += (traits.ambition ?? 0) * 0.5;
+    bias += (traits.ambition ?? 0) * PERSONA_TRAIT_WEIGHTS.ambition;
   }
   if (intentionType.startsWith('react:greet') || intentionType.startsWith('react:talk')) {
-    bias += (traits.sociability ?? 0) * 0.4;
+    bias += (traits.sociability ?? 0) * PERSONA_TRAIT_WEIGHTS.sociability;
   }
   if (intentionType.startsWith('react:attack') || intentionType === 'satisfy-need:dominance') {
-    bias += (traits.aggression ?? 0) * 0.5;
+    bias += (traits.aggression ?? 0) * PERSONA_TRAIT_WEIGHTS.aggression;
   }
   if (intentionType.startsWith('explore') || intentionType.startsWith('investigate')) {
-    bias += (traits.curiosity ?? 0) * 0.4;
+    bias += (traits.curiosity ?? 0) * PERSONA_TRAIT_WEIGHTS.curiosity;
   }
   if (intentionType.includes('play')) {
-    bias += (traits.playfulness ?? 0) * 0.4;
+    bias += (traits.playfulness ?? 0) * PERSONA_TRAIT_WEIGHTS.playfulness;
   }
 
   return bias;

--- a/src/cognition/reasoning/UrgencyReasoner.ts
+++ b/src/cognition/reasoning/UrgencyReasoner.ts
@@ -3,13 +3,15 @@ import type { Intention } from '../Intention.js';
 import type { Reasoner, ReasonerContext } from './Reasoner.js';
 
 /**
- * The Phase A default reasoner. Takes all candidates from the context,
- * applies `personaBias(type, persona)` and `modifiers.intentionBonus(type)`,
- * picks the single highest-scored one above a threshold. If no candidate
- * clears the threshold, returns `null` (the agent is idle this tick).
+ * Default weighted-scoring reasoner. Takes all candidates from the
+ * context, applies `personaBias(type, persona)` and
+ * `modifiers.intentionBonus(type)`, picks the single highest-scored one
+ * above a threshold. If no candidate clears the threshold, returns
+ * `null` (the agent is idle this tick).
  *
  * No beliefs, no planning — just weighted scoring. Adequate for the MVP
- * nurture-pet; Phase B swaps in `JsSonReasoner` / BDI plugins.
+ * nurture-pet; consumers who want BDI / planning can plug in a richer
+ * `Reasoner` implementation through the same port.
  */
 export interface UrgencyReasonerOptions {
   /** Minimum weighted score to commit to an intention. Default: 0. */

--- a/src/cognition/tuning.ts
+++ b/src/cognition/tuning.ts
@@ -1,0 +1,121 @@
+/**
+ * Centralized tuning constants for the shipped default models and skills.
+ *
+ * Every numeric value here used to live as a magic literal inside a specific
+ * consumer (mood model, skill, needs policy, catch-up helper, persona bias).
+ * Extracting them here makes it trivial to inspect, audit, or override the
+ * defaults without patching the consumer files directly. Consumers retain
+ * their constructor-style config options; this module simply sources the
+ * default values.
+ *
+ * IMPORTANT: Changing a number here is a behavioral change for every
+ * consumer that doesn't override it — treat these as tuning knobs, not
+ * arbitrary constants.
+ */
+
+/**
+ * Thresholds used by `DefaultMoodModel` to pick a base `MoodCategory` from
+ * aggregated need urgencies, plus the minimum modifier-bias delta that can
+ * override the rule-based pick.
+ *
+ * - `critical` (0.85): any single need above this flips mood to 'sick' (for
+ *   the health need) or 'sad' — tipping point for a "something is wrong" read.
+ * - `sad` (0.6): average urgency above this → 'sad'.
+ * - `bored` (0.3): average urgency above this → 'bored'; below → 'happy'/'playful'.
+ * - `playfulTraitCutoff` (0.6): persona.traits.playfulness above this picks
+ *   'playful' over 'happy' when no need is pressing.
+ * - `biasOverrideDelta` (0.1): a modifier mood-bias must beat the rule pick
+ *   by more than this to win.
+ */
+export const MOOD_URGENCY_THRESHOLDS = {
+  critical: 0.85,
+  sad: 0.6,
+  bored: 0.3,
+  playfulTraitCutoff: 0.6,
+  biasOverrideDelta: 0.1,
+} as const;
+
+/**
+ * Per-trait weights applied by `defaultPersonaBias` when scaling intention
+ * candidates. Each weight multiplies the matching trait value (0..1) to
+ * produce the final additive bias passed to `UrgencyReasoner`.
+ */
+export const PERSONA_TRAIT_WEIGHTS = {
+  /** Boost applied to `do-task` / `do-task:*` intentions per unit ambition. */
+  ambition: 0.5,
+  /** Boost applied to `react:greet` / `react:talk` intentions per unit sociability. */
+  sociability: 0.4,
+  /** Boost applied to `react:attack` / `satisfy-need:dominance` per unit aggression. */
+  aggression: 0.5,
+  /** Boost applied to `explore` / `investigate` intentions per unit curiosity. */
+  curiosity: 0.4,
+  /** Boost applied to any intention whose type contains 'play' per unit playfulness. */
+  playfulness: 0.4,
+} as const;
+
+/**
+ * Numeric defaults for the shipped default skills under `src/skills/defaults/`.
+ * Keyed by skill id; each entry groups the magnitudes the skill applies to
+ * needs / modifiers. Only skills with meaningful numeric literals appear;
+ * the `express:*` reactions are state-less event emissions and are skipped.
+ */
+export const SKILL_DEFAULTS = {
+  /** `feed`: raises hunger and attaches a `well-fed` modifier (60s, 0.5x decay). */
+  feed: {
+    hungerSatisfy: 0.6,
+    wellFedDurationSeconds: 60,
+    wellFedDecayMultiplier: 0.5,
+  },
+  /** `play`: raises happiness, costs a bit of energy, adds a 30s playful mood-bias. */
+  play: {
+    happinessSatisfy: 0.5,
+    energyCost: 0.2,
+    happyGlowDurationSeconds: 30,
+    happyGlowMoodBias: 0.4,
+  },
+  /** `rest`: restores energy with a small hunger cost for the metabolic burn. */
+  rest: {
+    energySatisfy: 0.8,
+    hungerCost: 0.1,
+  },
+  /** `clean`: raises cleanliness and strips the `dirty` debuff. */
+  clean: {
+    cleanlinessSatisfy: 0.7,
+  },
+  /** `pet`: a gentler `play` — small happiness bump + 30s `happy-glow`. */
+  pet: {
+    happinessSatisfy: 0.3,
+    happyGlowDurationSeconds: 30,
+    happyGlowMoodBias: 0.4,
+  },
+  /** `scold`: drains happiness and applies a 60s `scolded` sad-bias modifier. */
+  scold: {
+    happinessCost: 0.3,
+    scoldedDurationSeconds: 60,
+    scoldedMoodBias: 0.3,
+  },
+  /** `medicate`: on success raises health (requires the `sick` modifier). */
+  medicate: {
+    healthSatisfy: 0.4,
+  },
+} as const;
+
+/**
+ * Defaults for `runCatchUp` — fixed chunk size and hard cap used when
+ * replaying a long offline period deterministically.
+ */
+export const OFFLINE_CATCHUP_DEFAULTS = {
+  /** Fixed chunk size in virtual seconds. */
+  chunkVirtualSeconds: 0.5,
+  /** Hard cap on chunks processed per call. */
+  maxChunks: 100_000,
+} as const;
+
+/**
+ * Defaults for `ExpressiveNeedsPolicy` — the urgency floor below which no
+ * expression fires (keeps the pet from meowing over trivial hunger).
+ */
+export const EXPRESSIVE_POLICY_DEFAULTS = {
+  /** Minimum need urgency before an `express:*` intention is suggested. */
+  minUrgency: 0.4,
+} as const;

--- a/src/events/standardEvents.ts
+++ b/src/events/standardEvents.ts
@@ -20,6 +20,7 @@ export interface NeedCriticalEvent extends DomainEvent {
   agentId: string;
   needId: string;
   level: number;
+  fxHint?: string;
 }
 
 export interface NeedSafeEvent extends DomainEvent {
@@ -27,6 +28,7 @@ export interface NeedSafeEvent extends DomainEvent {
   agentId: string;
   needId: string;
   level: number;
+  fxHint?: string;
 }
 
 export interface NeedSatisfiedEvent extends DomainEvent {
@@ -35,6 +37,7 @@ export interface NeedSatisfiedEvent extends DomainEvent {
   needId: string;
   before: number;
   after: number;
+  fxHint?: string;
 }
 
 // --- Modifiers (M4) ---
@@ -46,6 +49,7 @@ export interface ModifierAppliedEvent extends DomainEvent {
   type: typeof MODIFIER_APPLIED;
   agentId: string;
   modifier: Modifier;
+  fxHint?: string;
 }
 
 export interface ModifierExpiredEvent extends DomainEvent {
@@ -53,6 +57,7 @@ export interface ModifierExpiredEvent extends DomainEvent {
   agentId: string;
   modifierId: string;
   source: string;
+  fxHint?: string;
 }
 
 export interface ModifierRemovedEvent extends DomainEvent {
@@ -61,6 +66,7 @@ export interface ModifierRemovedEvent extends DomainEvent {
   modifierId: string;
   source: string;
   reason: 'removed' | 'replaced';
+  fxHint?: string;
 }
 
 // --- Lifecycle (M5) ---
@@ -73,6 +79,7 @@ export interface LifeStageChangedEvent extends DomainEvent {
   from: LifeStage;
   to: LifeStage;
   atAgeSeconds: number;
+  fxHint?: string;
 }
 
 export interface AgentDiedEvent extends DomainEvent {
@@ -81,6 +88,7 @@ export interface AgentDiedEvent extends DomainEvent {
   cause: 'health-depleted' | 'stage-transition' | 'explicit' | (string & {});
   reason?: string;
   atAgeSeconds: number;
+  fxHint?: string;
 }
 
 // --- Skills (M7) ---
@@ -93,6 +101,7 @@ export interface SkillCompletedEvent extends DomainEvent {
   skillId: string;
   effectiveness: number;
   details?: Record<string, unknown>;
+  fxHint?: string;
 }
 
 export interface SkillFailedEvent extends DomainEvent {
@@ -102,6 +111,7 @@ export interface SkillFailedEvent extends DomainEvent {
   code: string;
   message: string;
   details?: Record<string, unknown>;
+  fxHint?: string;
 }
 
 // --- Mood (M5) ---
@@ -113,4 +123,5 @@ export interface MoodChangedEvent extends DomainEvent {
   from: MoodCategory | undefined;
   to: MoodCategory;
   valence: number | undefined;
+  fxHint?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,7 +151,7 @@ export type { LocomotionMode } from './body/LocomotionMode.js';
 export { type Appearance, type AgentShape, defaultAppearance } from './body/Appearance.js';
 export { type Embodiment, defaultEmbodiment } from './body/Embodiment.js';
 
-// Memory (M10 — Markdown adapter is Phase B).
+// Memory (M10).
 export type { MemoryKind, MemoryRecord } from './memory/MemoryRecord.js';
 export type { MemoryFilter, MemoryRepository } from './memory/MemoryRepository.js';
 export { InMemoryMemoryAdapter } from './memory/InMemoryMemoryAdapter.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,11 +49,14 @@ export type { Need, NeedsDelta } from './needs/Need.js';
 export { DEFAULT_URGENCY_CURVE } from './needs/Need.js';
 export { Needs, type DecayMultiplierFn } from './needs/Needs.js';
 export type { NeedsPolicy } from './needs/NeedsPolicy.js';
+/** Needs policy that emits expressive intentions ("meow", "look sad") when a need is critical; no side effects. */
 export {
   ExpressiveNeedsPolicy,
   type ExpressiveNeedsPolicyOptions,
 } from './needs/ExpressiveNeedsPolicy.js';
+/** Needs policy that emits state-changing "satisfy-need" intentions — the autonomous-action cousin of `ExpressiveNeedsPolicy`. */
 export { ActiveNeedsPolicy, type ActiveNeedsPolicyOptions } from './needs/ActiveNeedsPolicy.js';
+/** Composite policy that fans a needs context out to multiple child policies and concatenates their candidates. */
 export { ComposedNeedsPolicy } from './needs/ComposedNeedsPolicy.js';
 
 // Cognition (M3 types + M7 defaults + ports).
@@ -61,18 +64,23 @@ export type { Intention, IntentionKind } from './cognition/Intention.js';
 export type { IntentionCandidate } from './cognition/IntentionCandidate.js';
 export { defaultPersonaBias, type PersonaBiasFn } from './cognition/personaBias.js';
 export type { Reasoner, ReasonerContext } from './cognition/reasoning/Reasoner.js';
+/** Reasoner that picks no intention. Default when no `Reasoner` is wired. */
 export { NoopReasoner } from './cognition/reasoning/NoopReasoner.js';
+/** Default weighted-scoring reasoner: applies persona bias + modifier bonus, picks the highest-scoring intention above a threshold. */
 export {
   UrgencyReasoner,
   type UrgencyReasonerOptions,
 } from './cognition/reasoning/UrgencyReasoner.js';
 export type { BehaviorRunner } from './cognition/behavior/BehaviorRunner.js';
+/** Table-driven behavior runner: maps `Intention` ids to concrete `AgentAction[]` via a consumer-supplied lookup. */
 export {
   DirectBehaviorRunner,
   type DirectBehaviorRunnerOptions,
 } from './cognition/behavior/DirectBehaviorRunner.js';
+/** Behavior runner that produces no actions. Default when no runner is wired. */
 export { NoopBehavior } from './cognition/behavior/NoopBehavior.js';
 export type { Learner, LearningOutcome } from './cognition/learning/Learner.js';
+/** Learner that ignores outcomes. Default when no learner is wired. */
 export { NoopLearner } from './cognition/learning/NoopLearner.js';
 
 // Skills (M7).
@@ -129,6 +137,7 @@ export {
 // Mood (M5).
 export type { Mood, MoodCategory } from './mood/Mood.js';
 export type { MoodModel, MoodEvaluationContext } from './mood/MoodModel.js';
+/** Default mood model: blends normalized needs + modifier bias to pick a `MoodCategory` ({ happy, sad, playful, sleepy, bored, sick }). */
 export { DefaultMoodModel } from './mood/DefaultMoodModel.js';
 
 // Control modes (M6).

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,15 @@ export type { Learner, LearningOutcome } from './cognition/learning/Learner.js';
 /** Learner that ignores outcomes. Default when no learner is wired. */
 export { NoopLearner } from './cognition/learning/NoopLearner.js';
 
+// Tuning constants.
+export {
+  MOOD_URGENCY_THRESHOLDS,
+  PERSONA_TRAIT_WEIGHTS,
+  SKILL_DEFAULTS,
+  OFFLINE_CATCHUP_DEFAULTS,
+  EXPRESSIVE_POLICY_DEFAULTS,
+} from './cognition/tuning.js';
+
 // Skills (M7).
 export type { Skill, SkillOutcome, SkillError } from './skills/Skill.js';
 export type { SkillContext } from './skills/SkillContext.js';

--- a/src/lifecycle/AgeModel.ts
+++ b/src/lifecycle/AgeModel.ts
@@ -53,7 +53,7 @@ export class AgeModel {
   /**
    * Advance age by `virtualDtSeconds`. Returns every schedule transition the
    * age crossed during this advance (zero or more, ordered by threshold).
-   * No-op if the agent is already `'deceased'`.
+   * No-op if the agent is already at `DECEASED_STAGE`.
    */
   advance(virtualDtSeconds: number): readonly LifeStageTransition[] {
     if (this._stage === DECEASED_STAGE || virtualDtSeconds <= 0) return [];
@@ -73,7 +73,7 @@ export class AgeModel {
     return transitions;
   }
 
-  /** Force the agent into `'deceased'`. Returns the transition if it changed. */
+  /** Force the agent into `DECEASED_STAGE`. Returns the transition if it changed. */
   markDeceased(): LifeStageTransition | null {
     if (this._stage === DECEASED_STAGE) return null;
     const from = this._stage;

--- a/src/memory/MemoryRepository.ts
+++ b/src/memory/MemoryRepository.ts
@@ -20,8 +20,9 @@ export interface MemoryFilter {
 
 /**
  * Port for memory persistence. Implementations decide storage format and
- * indexing strategy. The library ships an `InMemoryMemoryAdapter` in Phase A
- * and a `MarkdownMemoryAdapter` in Phase B.
+ * indexing strategy. The library ships an `InMemoryMemoryAdapter` out of
+ * the box; other adapters (filesystem, IndexedDB, Markdown) can be
+ * supplied by consumers.
  */
 export interface MemoryRepository {
   save(record: MemoryRecord): Promise<void>;

--- a/src/modifiers/Modifiers.ts
+++ b/src/modifiers/Modifiers.ts
@@ -1,5 +1,7 @@
 import type { Modifier } from './Modifier.js';
+import type { ModifierEffect } from './ModifierEffect.js';
 import type { ModifierTarget } from './ModifierTarget.js';
+import { NumericModifierResolver } from './NumericModifierResolver.js';
 
 /**
  * Reason a modifier left the collection — used by `Modifiers.tick(...)` to
@@ -19,6 +21,7 @@ export interface ModifierRemoval {
 export class Modifiers {
   private readonly entries: { key: string; mod: Modifier }[] = [];
   private ordinal = 0;
+  private readonly numericResolver = new NumericModifierResolver();
 
   /**
    * Apply a modifier. Returns the new or updated `Modifier` instance, plus
@@ -161,42 +164,21 @@ export class Modifiers {
 
   /**
    * Flat multiplier/bonus resolver. `identity` is the neutral value returned
-   * when no effect matches (0 for additive, 1 for multiplicative).
+   * when no effect matches (0 for additive, 1 for multiplicative). The actual
+   * set/multiply/add/clamp folding lives on `NumericModifierResolver` (R-18);
+   * this method is a thin adapter that flattens the active modifiers' effects
+   * into the resolver's input.
    */
   private resolveNumeric(match: (target: ModifierTarget) => boolean, identity: number): number {
-    let setValue: number | null = null;
-    let product = 1;
-    let sum = 0;
-    let clamp: number | null = null;
-    let matched = false;
+    return this.numericResolver.resolve(this.iterEffects(), identity, match);
+  }
 
+  /** Lazy iterator over every active modifier's effects, in apply order. */
+  private *iterEffects(): IterableIterator<ModifierEffect> {
     for (const entry of this.entries) {
       for (const effect of entry.mod.effects) {
-        if (!match(effect.target)) continue;
-        matched = true;
-        switch (effect.kind) {
-          case 'set':
-            setValue = effect.value;
-            break;
-          case 'multiply':
-            product *= effect.value;
-            break;
-          case 'add':
-            sum += effect.value;
-            break;
-          case 'clamp':
-            clamp = clamp === null ? effect.value : Math.min(clamp, effect.value);
-            break;
-        }
+        yield effect;
       }
     }
-
-    if (!matched) return identity;
-    if (setValue !== null) {
-      return clamp !== null ? Math.min(setValue, clamp) : setValue;
-    }
-    // Treat identity=1 as multiplicative base and identity=0 as additive base.
-    const base = identity === 0 ? sum : product * identity + sum;
-    return clamp !== null ? Math.min(base, clamp) : base;
   }
 }

--- a/src/modifiers/NumericModifierResolver.ts
+++ b/src/modifiers/NumericModifierResolver.ts
@@ -1,0 +1,76 @@
+import type { ModifierEffect } from './ModifierEffect.js';
+import type { ModifierTarget } from './ModifierTarget.js';
+
+/**
+ * Predicate used by `NumericModifierResolver` to decide whether a given
+ * effect's target participates in a numeric resolution pass.
+ */
+export type ModifierTargetMatcher = (target: ModifierTarget) => boolean;
+
+/**
+ * Composes the numeric effects contributed by a stream of `ModifierEffect`s
+ * into a single scalar value.
+ *
+ * Extracted from `Modifiers` (R-18) so the set/multiply/add/clamp branching
+ * can be exercised and evolved independently of the collection/stacking
+ * concerns that live on the owning `Modifiers` class.
+ *
+ * Composition order mirrors the contract documented on `ModifierEffect`:
+ *   1. `set` effects win and short-circuit all `multiply`/`add` work.
+ *   2. `multiply` effects are multiplied together (multiplicative identity).
+ *   3. `add` effects are summed onto the result.
+ *   4. `clamp` effects bound the output (lowest `clamp` wins as ceiling).
+ *
+ * `identity` distinguishes the neutral return value when nothing matches:
+ * `1` for multiplicative resolvers (decay, skill effectiveness, locomotion)
+ * and `0` for additive resolvers (mood bias, intention bonus).
+ */
+export class NumericModifierResolver {
+  /**
+   * Fold the matching effects from `effects` into a scalar.
+   *
+   * @param effects  Flat stream of effects to consider (callers pass the
+   *                 concatenation of every active modifier's `effects`).
+   * @param identity Neutral value returned when no effect matches — also
+   *                 determines additive vs. multiplicative base.
+   * @param match    Predicate narrowing the relevant `ModifierTarget`s.
+   */
+  resolve(
+    effects: Iterable<ModifierEffect>,
+    identity: number,
+    match: ModifierTargetMatcher,
+  ): number {
+    let setValue: number | null = null;
+    let product = 1;
+    let sum = 0;
+    let clamp: number | null = null;
+    let matched = false;
+
+    for (const effect of effects) {
+      if (!match(effect.target)) continue;
+      matched = true;
+      switch (effect.kind) {
+        case 'set':
+          setValue = effect.value;
+          break;
+        case 'multiply':
+          product *= effect.value;
+          break;
+        case 'add':
+          sum += effect.value;
+          break;
+        case 'clamp':
+          clamp = clamp === null ? effect.value : Math.min(clamp, effect.value);
+          break;
+      }
+    }
+
+    if (!matched) return identity;
+    if (setValue !== null) {
+      return clamp !== null ? Math.min(setValue, clamp) : setValue;
+    }
+    // Treat identity=1 as multiplicative base and identity=0 as additive base.
+    const base = identity === 0 ? sum : product * identity + sum;
+    return clamp !== null ? Math.min(base, clamp) : base;
+  }
+}

--- a/src/mood/DefaultMoodModel.ts
+++ b/src/mood/DefaultMoodModel.ts
@@ -1,3 +1,4 @@
+import { MOOD_URGENCY_THRESHOLDS } from '../cognition/tuning.js';
 import type { Mood, MoodCategory } from './Mood.js';
 import type { MoodEvaluationContext, MoodModel } from './MoodModel.js';
 
@@ -43,15 +44,15 @@ function computeAvgUrgency(ctx: MoodEvaluationContext): number {
 function pickBaseCategory(avg: number, ctx: MoodEvaluationContext): MoodCategory {
   if (ctx.needs) {
     for (const need of ctx.needs.list()) {
-      if (ctx.needs.urgency(need.id) > 0.85) {
+      if (ctx.needs.urgency(need.id) > MOOD_URGENCY_THRESHOLDS.critical) {
         return need.id === 'health' ? 'sick' : 'sad';
       }
     }
   }
-  if (avg > 0.6) return 'sad';
-  if (avg > 0.3) return 'bored';
+  if (avg > MOOD_URGENCY_THRESHOLDS.sad) return 'sad';
+  if (avg > MOOD_URGENCY_THRESHOLDS.bored) return 'bored';
   const playfulness = ctx.persona?.traits.playfulness ?? 0;
-  return playfulness > 0.6 ? 'playful' : 'happy';
+  return playfulness > MOOD_URGENCY_THRESHOLDS.playfulTraitCutoff ? 'playful' : 'happy';
 }
 
 function applyModifierBias(base: MoodCategory, ctx: MoodEvaluationContext): MoodCategory {
@@ -70,7 +71,7 @@ function applyModifierBias(base: MoodCategory, ctx: MoodEvaluationContext): Mood
   let winningBias = 0;
   for (const category of candidates) {
     const bias = ctx.modifiers.moodBias(category);
-    if (bias > winningBias + 0.1) {
+    if (bias > winningBias + MOOD_URGENCY_THRESHOLDS.biasOverrideDelta) {
       winning = category;
       winningBias = bias;
     }

--- a/src/needs/ExpressiveNeedsPolicy.ts
+++ b/src/needs/ExpressiveNeedsPolicy.ts
@@ -1,4 +1,5 @@
 import type { IntentionCandidate } from '../cognition/IntentionCandidate.js';
+import { EXPRESSIVE_POLICY_DEFAULTS } from '../cognition/tuning.js';
 import type { Persona } from '../agent/Persona.js';
 import type { Needs } from './Needs.js';
 import type { NeedsPolicy } from './NeedsPolicy.js';
@@ -24,7 +25,7 @@ export class ExpressiveNeedsPolicy implements NeedsPolicy {
   private readonly expressionByNeed: Readonly<Record<string, string>>;
 
   constructor(opts: ExpressiveNeedsPolicyOptions = {}) {
-    this.minUrgency = opts.minUrgency ?? 0.4;
+    this.minUrgency = opts.minUrgency ?? EXPRESSIVE_POLICY_DEFAULTS.minUrgency;
     this.expressionByNeed = opts.expressionByNeed ?? {};
   }
 

--- a/src/persistence/AgentSnapshot.ts
+++ b/src/persistence/AgentSnapshot.ts
@@ -1,4 +1,5 @@
 import type { AgentIdentity } from '../agent/AgentIdentity.js';
+import type { AnimationState } from '../animation/AnimationState.js';
 import type { DomainEvent } from '../events/DomainEvent.js';
 import type { LifeStage } from '../lifecycle/LifeStage.js';
 import type { MemoryRecord } from '../memory/MemoryRecord.js';
@@ -14,6 +15,7 @@ export type SnapshotPart =
   | 'needs'
   | 'modifiers'
   | 'mood'
+  | 'animation'
   | 'memory'
   | 'beliefs'
   | 'custom';
@@ -45,6 +47,17 @@ export interface AgentSnapshot {
   modifiers?: readonly Modifier[];
 
   mood?: Mood;
+
+  /**
+   * Animation state machine slice + the id of the skill (if any) currently
+   * driving the animation. Persisted so a fresh agent rehydrated from a
+   * snapshot mid-skill doesn't emit a spurious `AnimationTransition` on
+   * the first post-restore tick.
+   */
+  animation?: {
+    state: AnimationState;
+    activeSkillId: string | undefined;
+  };
 
   memory?: readonly MemoryRecord[];
 

--- a/src/persistence/offlineCatchUp.ts
+++ b/src/persistence/offlineCatchUp.ts
@@ -1,3 +1,5 @@
+import { OFFLINE_CATCHUP_DEFAULTS } from '../cognition/tuning.js';
+
 /**
  * Shared helper for catch-up sub-stepping when restoring an agent after a
  * long offline period. The Agent owns the actual integration in its
@@ -34,8 +36,8 @@ export async function runCatchUp(
   step: (chunkSeconds: number, index: number) => Promise<void>,
   opts: CatchUpOptions = {},
 ): Promise<CatchUpResult> {
-  const chunkSize = opts.chunkVirtualSeconds ?? 0.5;
-  const maxChunks = opts.maxChunks ?? 100_000;
+  const chunkSize = opts.chunkVirtualSeconds ?? OFFLINE_CATCHUP_DEFAULTS.chunkVirtualSeconds;
+  const maxChunks = opts.maxChunks ?? OFFLINE_CATCHUP_DEFAULTS.maxChunks;
 
   if (!(totalVirtualDtSeconds > 0)) {
     return { chunksProcessed: 0, totalVirtualSeconds: 0, truncated: false };

--- a/src/ports/Validator.ts
+++ b/src/ports/Validator.ts
@@ -24,7 +24,13 @@ export interface ValidationIssue {
   code?: string;
 }
 
-/** No-op validator: accepts everything unchanged. Default when no validator is wired. */
+/**
+ * No-op validator: accepts every input unchanged. Intended as a no-op /
+ * testing utility and the zero-config default when no `Validator` is wired
+ * into `createAgent`. Production consumers typically inject a zod-,
+ * valibot-, or ajv-backed implementation that actually enforces the
+ * schema contract on skill parameters, tool inputs, and remote commands.
+ */
 export class PassthroughValidator implements Validator {
   validate<T = unknown>(_schema: unknown, input: unknown): ValidationResult<T> {
     return { ok: true, value: input as T };

--- a/src/skills/SkillContext.ts
+++ b/src/skills/SkillContext.ts
@@ -27,6 +27,9 @@ export interface SkillContext {
   /** Remove a modifier by id. Returns the removed Modifier or `null`. */
   removeModifier(id: string): Modifier | null;
 
+  /** True if a modifier with this id is currently active on the agent. */
+  hasModifier(id: string): boolean;
+
   /** Publish an event onto the bus. */
   publishEvent(event: DomainEvent): void;
 

--- a/src/skills/defaults/CleanSkill.ts
+++ b/src/skills/defaults/CleanSkill.ts
@@ -1,4 +1,5 @@
 import { ok, type Result } from '../../agent/result.js';
+import { SKILL_DEFAULTS } from '../../cognition/tuning.js';
 import type { Skill, SkillError, SkillOutcome } from '../Skill.js';
 import type { SkillContext } from '../SkillContext.js';
 import { effectivenessFor } from './effectiveness.js';
@@ -13,7 +14,7 @@ export const CleanSkill: Skill = {
   baseEffectiveness: 1,
   execute(_params, ctx: SkillContext): Promise<Result<SkillOutcome, SkillError>> {
     const effectiveness = effectivenessFor(CleanSkill, ctx);
-    ctx.satisfyNeed('cleanliness', 0.7 * effectiveness);
+    ctx.satisfyNeed('cleanliness', SKILL_DEFAULTS.clean.cleanlinessSatisfy * effectiveness);
     ctx.removeModifier('dirty');
     return Promise.resolve(ok({ fxHint: 'bubble-blue', effectiveness }));
   },

--- a/src/skills/defaults/FeedSkill.ts
+++ b/src/skills/defaults/FeedSkill.ts
@@ -1,4 +1,5 @@
 import { ok, type Result } from '../../agent/result.js';
+import { SKILL_DEFAULTS } from '../../cognition/tuning.js';
 import { defineModifier } from '../../modifiers/defineModifier.js';
 import { SKILL_COMPLETED, type SkillCompletedEvent } from '../../events/standardEvents.js';
 import type { Skill, SkillError, SkillOutcome } from '../Skill.js';
@@ -9,8 +10,14 @@ const wellFed = defineModifier({
   id: 'well-fed',
   source: 'skill:feed',
   stack: 'refresh',
-  durationSeconds: 60,
-  effects: [{ target: { type: 'need-decay', needId: 'hunger' }, kind: 'multiply', value: 0.5 }],
+  durationSeconds: SKILL_DEFAULTS.feed.wellFedDurationSeconds,
+  effects: [
+    {
+      target: { type: 'need-decay', needId: 'hunger' },
+      kind: 'multiply',
+      value: SKILL_DEFAULTS.feed.wellFedDecayMultiplier,
+    },
+  ],
   visual: { hudIcon: 'icon-wellfed', fxHint: 'sparkle-green' },
 });
 
@@ -24,7 +31,7 @@ export const FeedSkill: Skill = {
   baseEffectiveness: 1,
   execute(_params, ctx: SkillContext): Promise<Result<SkillOutcome, SkillError>> {
     const effectiveness = effectivenessFor(FeedSkill, ctx);
-    ctx.satisfyNeed('hunger', 0.6 * effectiveness);
+    ctx.satisfyNeed('hunger', SKILL_DEFAULTS.feed.hungerSatisfy * effectiveness);
     ctx.applyModifier(wellFed.instantiate(ctx.clock.now()));
     const completed: SkillCompletedEvent = {
       type: SKILL_COMPLETED,

--- a/src/skills/defaults/FeedSkill.ts
+++ b/src/skills/defaults/FeedSkill.ts
@@ -9,14 +9,14 @@ const wellFed = defineModifier({
   id: 'well-fed',
   source: 'skill:feed',
   stack: 'refresh',
-  durationSeconds: 120,
+  durationSeconds: 60,
   effects: [{ target: { type: 'need-decay', needId: 'hunger' }, kind: 'multiply', value: 0.5 }],
   visual: { hudIcon: 'icon-wellfed', fxHint: 'sparkle-green' },
 });
 
 /**
  * Default `feed` skill. Raises the `hunger` need and applies a `well-fed`
- * buff that slows hunger decay for 120s.
+ * buff that slows hunger decay for 60s.
  */
 export const FeedSkill: Skill = {
   id: 'feed',

--- a/src/skills/defaults/MedicateSkill.ts
+++ b/src/skills/defaults/MedicateSkill.ts
@@ -1,4 +1,5 @@
 import { err, ok, type Result } from '../../agent/result.js';
+import { SKILL_DEFAULTS } from '../../cognition/tuning.js';
 import type { Skill, SkillError, SkillOutcome } from '../Skill.js';
 import type { SkillContext } from '../SkillContext.js';
 import { effectivenessFor } from './effectiveness.js';
@@ -17,7 +18,7 @@ export const MedicateSkill: Skill = {
       return Promise.resolve(err({ code: 'not-sick', message: 'Not sick.' }));
     }
     const effectiveness = effectivenessFor(MedicateSkill, ctx);
-    ctx.satisfyNeed('health', 0.4 * effectiveness);
+    ctx.satisfyNeed('health', SKILL_DEFAULTS.medicate.healthSatisfy * effectiveness);
     return Promise.resolve(ok({ fxHint: 'flash-white', effectiveness }));
   },
 };

--- a/src/skills/defaults/PetSkill.ts
+++ b/src/skills/defaults/PetSkill.ts
@@ -1,4 +1,5 @@
 import { ok, type Result } from '../../agent/result.js';
+import { SKILL_DEFAULTS } from '../../cognition/tuning.js';
 import { defineModifier } from '../../modifiers/defineModifier.js';
 import type { Skill, SkillError, SkillOutcome } from '../Skill.js';
 import type { SkillContext } from '../SkillContext.js';
@@ -8,8 +9,14 @@ const happyGlow = defineModifier({
   id: 'happy-glow',
   source: 'skill:pet',
   stack: 'refresh',
-  durationSeconds: 30,
-  effects: [{ target: { type: 'mood-bias', category: 'playful' }, kind: 'add', value: 0.4 }],
+  durationSeconds: SKILL_DEFAULTS.pet.happyGlowDurationSeconds,
+  effects: [
+    {
+      target: { type: 'mood-bias', category: 'playful' },
+      kind: 'add',
+      value: SKILL_DEFAULTS.pet.happyGlowMoodBias,
+    },
+  ],
   visual: { hudIcon: 'icon-happy', fxHint: 'hearts-soft' },
 });
 
@@ -23,7 +30,7 @@ export const PetSkill: Skill = {
   baseEffectiveness: 1,
   execute(_params, ctx: SkillContext): Promise<Result<SkillOutcome, SkillError>> {
     const effectiveness = effectivenessFor(PetSkill, ctx);
-    ctx.satisfyNeed('happiness', 0.3 * effectiveness);
+    ctx.satisfyNeed('happiness', SKILL_DEFAULTS.pet.happinessSatisfy * effectiveness);
     ctx.applyModifier(happyGlow.instantiate(ctx.clock.now()));
     return Promise.resolve(ok({ fxHint: 'hearts-soft', effectiveness }));
   },

--- a/src/skills/defaults/PlaySkill.ts
+++ b/src/skills/defaults/PlaySkill.ts
@@ -1,4 +1,5 @@
 import { ok, type Result } from '../../agent/result.js';
+import { SKILL_DEFAULTS } from '../../cognition/tuning.js';
 import { defineModifier } from '../../modifiers/defineModifier.js';
 import type { Skill, SkillError, SkillOutcome } from '../Skill.js';
 import type { SkillContext } from '../SkillContext.js';
@@ -8,8 +9,14 @@ const happyGlow = defineModifier({
   id: 'happy-glow',
   source: 'skill:play',
   stack: 'refresh',
-  durationSeconds: 30,
-  effects: [{ target: { type: 'mood-bias', category: 'playful' }, kind: 'add', value: 0.4 }],
+  durationSeconds: SKILL_DEFAULTS.play.happyGlowDurationSeconds,
+  effects: [
+    {
+      target: { type: 'mood-bias', category: 'playful' },
+      kind: 'add',
+      value: SKILL_DEFAULTS.play.happyGlowMoodBias,
+    },
+  ],
   visual: { hudIcon: 'icon-happy', fxHint: 'hearts-pink' },
 });
 
@@ -23,8 +30,8 @@ export const PlaySkill: Skill = {
   baseEffectiveness: 1,
   execute(_params, ctx: SkillContext): Promise<Result<SkillOutcome, SkillError>> {
     const effectiveness = effectivenessFor(PlaySkill, ctx);
-    ctx.satisfyNeed('happiness', 0.5 * effectiveness);
-    ctx.satisfyNeed('energy', -0.2 * effectiveness);
+    ctx.satisfyNeed('happiness', SKILL_DEFAULTS.play.happinessSatisfy * effectiveness);
+    ctx.satisfyNeed('energy', -SKILL_DEFAULTS.play.energyCost * effectiveness);
     ctx.applyModifier(happyGlow.instantiate(ctx.clock.now()));
     return Promise.resolve(ok({ fxHint: 'hearts-pink', effectiveness }));
   },

--- a/src/skills/defaults/RestSkill.ts
+++ b/src/skills/defaults/RestSkill.ts
@@ -1,4 +1,5 @@
 import { ok, type Result } from '../../agent/result.js';
+import { SKILL_DEFAULTS } from '../../cognition/tuning.js';
 import type { Skill, SkillError, SkillOutcome } from '../Skill.js';
 import type { SkillContext } from '../SkillContext.js';
 import { effectivenessFor } from './effectiveness.js';
@@ -13,8 +14,8 @@ export const RestSkill: Skill = {
   baseEffectiveness: 1,
   execute(_params, ctx: SkillContext): Promise<Result<SkillOutcome, SkillError>> {
     const effectiveness = effectivenessFor(RestSkill, ctx);
-    ctx.satisfyNeed('energy', 0.8 * effectiveness);
-    ctx.satisfyNeed('hunger', -0.1);
+    ctx.satisfyNeed('energy', SKILL_DEFAULTS.rest.energySatisfy * effectiveness);
+    ctx.satisfyNeed('hunger', -SKILL_DEFAULTS.rest.hungerCost);
     return Promise.resolve(ok({ fxHint: 'zzz', effectiveness }));
   },
 };

--- a/src/skills/defaults/ScoldSkill.ts
+++ b/src/skills/defaults/ScoldSkill.ts
@@ -1,9 +1,16 @@
-import { ok, type Result } from '../../agent/result.js';
+import { err, ok, type Result } from '../../agent/result.js';
 import { SKILL_DEFAULTS } from '../../cognition/tuning.js';
 import { defineModifier } from '../../modifiers/defineModifier.js';
 import type { Skill, SkillError, SkillOutcome } from '../Skill.js';
 import type { SkillContext } from '../SkillContext.js';
 import { effectivenessFor } from './effectiveness.js';
+
+/**
+ * Modifier id the agent must be carrying for `ScoldSkill` to fire.
+ * Consumers who want unconditional scolding can either replace the skill
+ * or apply a matching modifier manually before invoking.
+ */
+export const SCOLD_GATE_MODIFIER_ID = 'disobedient';
 
 const scolded = defineModifier({
   id: 'scolded',
@@ -22,16 +29,29 @@ const scolded = defineModifier({
 
 /**
  * Default `scold` skill. Pushes mood toward `sad` and drains a chunk of
- * happiness — a rebuke the reasoner can feel.
+ * happiness — a rebuke the reasoner can feel. Gated on the
+ * `disobedient` modifier so consumers can only scold when the pet
+ * actually misbehaved; invoking without the gate returns
+ * `err({ code: 'not-misbehaving' })`. The skill also clears
+ * `disobedient` on success so the gate closes behind the scold.
  */
 export const ScoldSkill: Skill = {
   id: 'scold',
   label: 'Scold',
   baseEffectiveness: 1,
   execute(_params, ctx: SkillContext): Promise<Result<SkillOutcome, SkillError>> {
+    if (!ctx.hasModifier(SCOLD_GATE_MODIFIER_ID)) {
+      return Promise.resolve(
+        err({
+          code: 'not-misbehaving',
+          message: `Scold requires the '${SCOLD_GATE_MODIFIER_ID}' modifier; the pet isn't misbehaving.`,
+        }),
+      );
+    }
     const effectiveness = effectivenessFor(ScoldSkill, ctx);
     ctx.applyModifier(scolded.instantiate(ctx.clock.now()));
     ctx.satisfyNeed('happiness', -SKILL_DEFAULTS.scold.happinessCost);
+    ctx.removeModifier(SCOLD_GATE_MODIFIER_ID);
     return Promise.resolve(ok({ fxHint: 'cloud-gray', effectiveness }));
   },
 };

--- a/src/skills/defaults/ScoldSkill.ts
+++ b/src/skills/defaults/ScoldSkill.ts
@@ -1,4 +1,5 @@
 import { ok, type Result } from '../../agent/result.js';
+import { SKILL_DEFAULTS } from '../../cognition/tuning.js';
 import { defineModifier } from '../../modifiers/defineModifier.js';
 import type { Skill, SkillError, SkillOutcome } from '../Skill.js';
 import type { SkillContext } from '../SkillContext.js';
@@ -8,8 +9,14 @@ const scolded = defineModifier({
   id: 'scolded',
   source: 'skill:scold',
   stack: 'replace',
-  durationSeconds: 60,
-  effects: [{ target: { type: 'mood-bias', category: 'sad' }, kind: 'add', value: 0.3 }],
+  durationSeconds: SKILL_DEFAULTS.scold.scoldedDurationSeconds,
+  effects: [
+    {
+      target: { type: 'mood-bias', category: 'sad' },
+      kind: 'add',
+      value: SKILL_DEFAULTS.scold.scoldedMoodBias,
+    },
+  ],
   visual: { hudIcon: 'icon-scolded', fxHint: 'cloud-gray' },
 });
 
@@ -24,7 +31,7 @@ export const ScoldSkill: Skill = {
   execute(_params, ctx: SkillContext): Promise<Result<SkillOutcome, SkillError>> {
     const effectiveness = effectivenessFor(ScoldSkill, ctx);
     ctx.applyModifier(scolded.instantiate(ctx.clock.now()));
-    ctx.satisfyNeed('happiness', -0.3);
+    ctx.satisfyNeed('happiness', -SKILL_DEFAULTS.scold.happinessCost);
     return Promise.resolve(ok({ fxHint: 'cloud-gray', effectiveness }));
   },
 };

--- a/src/species/SpeciesDescriptor.ts
+++ b/src/species/SpeciesDescriptor.ts
@@ -32,7 +32,11 @@ export interface SpeciesDescriptor {
   appearance?: Appearance;
   /** Default locomotion mode. */
   locomotion?: LocomotionMode;
-  /** Whether agents of this species can engage in dialogue (Phase B). */
+  /**
+   * Whether agents of this species can engage in dialogue. Reserved for a
+   * future dialogue / LLM tool extension; currently informational — the
+   * core library does not gate any behavior on this flag.
+   */
   dialogueCapable?: boolean;
   /**
    * If non-empty, only these skill ids are permitted at runtime across all

--- a/tests/integration/nurture-pet-deterministic.test.ts
+++ b/tests/integration/nurture-pet-deterministic.test.ts
@@ -2,17 +2,23 @@ import { describe, expect, it } from 'vitest';
 import {
   createAgent,
   defaultPetInteractionModule,
+  defineModifier,
   defineRandomEvent,
   defineSpecies,
+  err,
   ExpressMeowSkill,
   InMemoryMemoryAdapter,
   ManualClock,
+  NEED_CRITICAL,
   RandomEventTicker,
   SeededRng,
+  SKILL_FAILED,
   SkillRegistry,
   type Agent,
+  type AgentModule,
   type DecisionTrace,
   type DomainEvent,
+  type Skill,
 } from '../../src/index.js';
 
 /**
@@ -178,5 +184,148 @@ describe('nurture-pet deterministic replay', () => {
     expect(second.getState().ageSeconds).toBeCloseTo(first.getState().ageSeconds);
     expect(second.getState().needs).toEqual(first.getState().needs);
     expect(second.getState().stage).toBe(first.getState().stage);
+  });
+
+  // ---------------------------------------------------------------------
+  // R-02 — deepen the determinism claim: reactive handlers, skill failures,
+  // and long replays. Every it-block runs the same scripted scenario twice
+  // with a fixed seed and asserts byte-identical outputs.
+  // ---------------------------------------------------------------------
+
+  it('reactive handler applying a modifier on NeedCritical — 100 s byte-identical', async () => {
+    const panicBuff = defineModifier({
+      id: 'panic',
+      source: 'reactive:need-critical',
+      stack: 'refresh',
+      durationSeconds: 5,
+      effects: [{ target: { type: 'mood-bias', category: 'sad' }, kind: 'add', value: 0.3 }],
+    });
+
+    function buildWithReactive(): {
+      agent: Agent;
+      clock: ManualClock;
+      events: DomainEvent[];
+      traces: DecisionTrace[];
+    } {
+      const { agent, clock, events } = buildPet();
+      const reactive: AgentModule = {
+        id: 'panic-on-critical',
+        reactiveHandlers: [
+          {
+            on: NEED_CRITICAL,
+            handle: (_event, facade) => {
+              facade.publishEvent({
+                type: 'ApplyingPanic',
+                at: facade.clock.now(),
+                agentId: facade.identity.id,
+              });
+              // Apply via facade → deterministic, no RNG draw.
+              agent.applyModifier(panicBuff.instantiate(facade.clock.now()));
+            },
+          },
+        ],
+      };
+      agent.installModule(reactive);
+      return { agent, clock, events, traces: [] };
+    }
+
+    async function run(): Promise<{ traces: DecisionTrace[]; events: DomainEvent[] }> {
+      const { agent, clock, traces, events } = buildWithReactive();
+      for (let i = 0; i < 100; i++) {
+        clock.advance(1_000);
+        traces.push(await agent.tick(1));
+      }
+      return { traces, events };
+    }
+
+    const runA = await run();
+    const runB = await run();
+    expect(runA.traces).toEqual(runB.traces);
+    expect(runA.events).toEqual(runB.events);
+  });
+
+  it('skill always returning err() produces identical SkillFailed ordering and RNG draws', async () => {
+    const forcedFail: Skill = {
+      id: 'forced',
+      label: 'Forced',
+      baseEffectiveness: 1,
+      execute() {
+        return Promise.resolve(err({ code: 'forced-fail', message: 'nope' }));
+      },
+    };
+
+    async function runOnce(): Promise<{ failures: DomainEvent[]; rngDraws: number[] }> {
+      const clock = new ManualClock(1_700_000_000_000);
+      const rng = new SeededRng('forced-fail-fixture');
+      const skills = new SkillRegistry();
+      skills.register(forcedFail);
+      const router: AgentModule = {
+        id: 'force-router',
+        reactiveHandlers: [
+          {
+            on: 'InteractionRequested',
+            handle: async (event, facade) => {
+              if ((event as { verb?: string }).verb === 'forced') {
+                await facade.invokeSkill('forced', undefined);
+              }
+            },
+          },
+        ],
+      };
+      const agent = createAgent({
+        id: 'whiskers',
+        species: defineSpecies({ id: 'cat' }),
+        clock,
+        rng,
+        skills,
+        modules: [router],
+        persistence: false,
+      });
+      const events: DomainEvent[] = [];
+      agent.subscribe((e) => events.push({ ...e }));
+
+      for (let i = 0; i < 3; i++) {
+        agent.interact('forced');
+        clock.advance(16);
+        await agent.tick(0.016);
+        // Second tick lets the reactive handler fire (perceived events come
+        // from the prior tick's bus drain).
+        clock.advance(16);
+        await agent.tick(0.016);
+      }
+
+      const failures = events.filter((e) => e.type === SKILL_FAILED);
+      const rngDraws = Array.from({ length: 6 }, () => agent.rng.next());
+      return { failures, rngDraws };
+    }
+
+    const a = await runOnce();
+    const b = await runOnce();
+    expect(a.failures).toEqual(b.failures);
+    expect(a.failures.length).toBe(3);
+    expect(a.rngDraws).toEqual(b.rngDraws);
+  });
+
+  it('long replay — 1000 virtual seconds with random events + modifiers is byte-identical', async () => {
+    async function longRun(): Promise<ReplayResult> {
+      const { agent, clock, events } = buildPet();
+      const traces: DecisionTrace[] = [];
+      for (let i = 0; i < 200; i++) {
+        clock.advance(5_000);
+        traces.push(await agent.tick(5));
+        // Sprinkle interactions at regular intervals to exercise mood +
+        // modifier rotations + skill flow alongside the random-event ticker.
+        if (i % 7 === 0) agent.interact('feed');
+        if (i % 11 === 0) agent.interact('play');
+        if (i % 13 === 0) agent.interact('clean');
+      }
+      return { traces, events, finalState: agent.getState() };
+    }
+
+    const a = await longRun();
+    const b = await longRun();
+    expect(a.traces).toEqual(b.traces);
+    expect(a.events).toEqual(b.events);
+    expect(a.finalState).toEqual(b.finalState);
   });
 });

--- a/tests/unit/agent/Agent-persistence.test.ts
+++ b/tests/unit/agent/Agent-persistence.test.ts
@@ -133,4 +133,50 @@ describe('Agent snapshot/restore — R-01 animation + mood + active skill', () =
     const withoutAnim = agent.snapshot({ include: ['lifecycle'] });
     expect(withoutAnim.animation).toBeUndefined();
   });
+
+  it('R-16: modifier with expiresAt at clock.now drops on restore and emits ModifierExpired once', async () => {
+    const clockA = new ManualClock(1_000);
+    const a = new Agent(baseDeps({ clock: clockA }));
+    // Apply a modifier whose expiresAt is exactly now.
+    a.applyModifier({
+      id: 'just-expired',
+      source: 'test',
+      appliedAt: clockA.now(),
+      expiresAt: clockA.now(),
+      stack: 'replace',
+      effects: [],
+    });
+    const snap = a.snapshot();
+    expect(snap.modifiers?.some((m) => m.id === 'just-expired')).toBe(true);
+
+    const busB = new InMemoryEventBus();
+    const clockB = new ManualClock(1_000);
+    const b = new Agent(baseDeps({ eventBus: busB, clock: clockB }));
+    const seen: DomainEvent[] = [];
+    busB.subscribe((e) => seen.push(e));
+
+    await b.restore(snap);
+
+    // The modifier is not active on the restored agent.
+    expect(b.modifiers.list().map((m) => m.id)).not.toContain('just-expired');
+
+    // Exactly one ModifierExpired fires for the boundary modifier.
+    const expiredEvents = seen.filter(
+      (e) =>
+        e.type === 'ModifierExpired' &&
+        (e as { modifierId?: string }).modifierId === 'just-expired',
+    );
+    expect(expiredEvents).toHaveLength(1);
+
+    // A subsequent tick doesn't re-fire the event.
+    seen.length = 0;
+    await b.tick(0.016);
+    expect(
+      seen.filter(
+        (e) =>
+          e.type === 'ModifierExpired' &&
+          (e as { modifierId?: string }).modifierId === 'just-expired',
+      ),
+    ).toHaveLength(0);
+  });
 });

--- a/tests/unit/agent/Agent-persistence.test.ts
+++ b/tests/unit/agent/Agent-persistence.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { Agent, type AgentDependencies } from '../../../src/agent/Agent.js';
+import type { AgentIdentity } from '../../../src/agent/AgentIdentity.js';
+import { AnimationStateMachine } from '../../../src/animation/AnimationStateMachine.js';
+import { ANIMATION_TRANSITION } from '../../../src/animation/AnimationTransitionEvent.js';
+import type { DomainEvent } from '../../../src/events/DomainEvent.js';
+import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
+import { MOOD_CHANGED } from '../../../src/events/standardEvents.js';
+import { DefaultMoodModel } from '../../../src/mood/DefaultMoodModel.js';
+import { Needs } from '../../../src/needs/Needs.js';
+import { ManualClock } from '../../../src/ports/ManualClock.js';
+import { SeededRng } from '../../../src/ports/SeededRng.js';
+
+function baseDeps(overrides: Partial<AgentDependencies> = {}): AgentDependencies {
+  const identity: AgentIdentity = {
+    id: 'whiskers',
+    name: 'Whiskers',
+    version: '0.0.0',
+    role: 'npc',
+    species: 'cat',
+  };
+  return {
+    identity,
+    eventBus: new InMemoryEventBus(),
+    clock: new ManualClock(1_000),
+    rng: new SeededRng('seed'),
+    ...overrides,
+  };
+}
+
+describe('Agent snapshot/restore — R-01 animation + mood + active skill', () => {
+  it('snapshot captures animation state + activeSkillId', () => {
+    const anim = new AnimationStateMachine({ skillMap: { feed: 'eating' } });
+    const agent = new Agent(baseDeps({ animation: anim }));
+    // Simulate a skill becoming active + an animation transition.
+    agent.currentActiveSkillId = 'feed';
+    anim.reconcile({
+      activeSkillId: 'feed',
+      modifiers: agent.modifiers,
+      wallNowMs: 1_000,
+    });
+
+    const snap = agent.snapshot();
+    expect(snap.animation).toBeDefined();
+    expect(snap.animation?.state).toBe('eating');
+    expect(snap.animation?.activeSkillId).toBe('feed');
+  });
+
+  it('restore rehydrates animation + activeSkillId without emitting a spurious transition', async () => {
+    // Snapshot mid-skill in agent A.
+    const animA = new AnimationStateMachine({ skillMap: { feed: 'eating' } });
+    const a = new Agent(baseDeps({ animation: animA }));
+    a.currentActiveSkillId = 'feed';
+    animA.reconcile({ activeSkillId: 'feed', modifiers: a.modifiers, wallNowMs: 1_000 });
+    const snap = a.snapshot();
+
+    // Fresh agent B.
+    const busB = new InMemoryEventBus();
+    const animB = new AnimationStateMachine({ skillMap: { feed: 'eating' } });
+    const b = new Agent(baseDeps({ eventBus: busB, animation: animB }));
+
+    const seen: DomainEvent[] = [];
+    busB.subscribe((e) => seen.push(e));
+
+    await b.restore(snap);
+    expect(b.getState().animation).toBe('eating');
+    expect(b.currentActiveSkillId).toBe('feed');
+
+    // First post-restore tick must not emit a redundant AnimationTransition.
+    // The reconciler sees activeSkillId: 'feed' and current: 'eating' — no
+    // rotation, no event.
+    seen.length = 0;
+    await b.tick(0.016);
+    const animTransitions = seen.filter((e) => e.type === ANIMATION_TRANSITION);
+    expect(animTransitions).toEqual([]);
+  });
+
+  it('mood carries across snapshot without re-emitting MoodChanged for the same category', async () => {
+    const needs = new Needs([
+      { id: 'hunger', level: 0.1, decayPerSec: 0, criticalThreshold: 0.2 },
+      { id: 'energy', level: 0.8, decayPerSec: 0 },
+    ]);
+
+    // Agent A establishes a mood via a real tick.
+    const busA = new InMemoryEventBus();
+    const a = new Agent(baseDeps({ eventBus: busA, needs, moodModel: new DefaultMoodModel() }));
+    await a.tick(0.016);
+    const moodA = a.currentMood;
+    expect(moodA).toBeDefined();
+
+    const snap = a.snapshot();
+    expect(snap.mood?.category).toBe(moodA?.category);
+
+    // Agent B restores.
+    const needsB = new Needs([
+      { id: 'hunger', level: 0.1, decayPerSec: 0, criticalThreshold: 0.2 },
+      { id: 'energy', level: 0.8, decayPerSec: 0 },
+    ]);
+    const busB = new InMemoryEventBus();
+    const b = new Agent(
+      baseDeps({
+        eventBus: busB,
+        needs: needsB,
+        moodModel: new DefaultMoodModel(),
+      }),
+    );
+    const seen: DomainEvent[] = [];
+    busB.subscribe((e) => seen.push(e));
+
+    await b.restore(snap);
+    await b.tick(0.016);
+
+    // A MoodChanged event would only fire if the category rotated. Since the
+    // mood was already the correct category post-restore, the first tick
+    // must NOT emit MoodChanged.
+    const moodEvents = seen.filter((e) => e.type === MOOD_CHANGED);
+    expect(moodEvents).toEqual([]);
+  });
+
+  it('snapshot without explicit include populates animation by default', () => {
+    const agent = new Agent(baseDeps());
+    const snap = agent.snapshot();
+    expect(snap.animation).toBeDefined();
+    expect(snap.animation?.state).toBe('idle');
+    expect(snap.animation?.activeSkillId).toBeUndefined();
+  });
+
+  it('snapshot with include filter honors the "animation" part key', () => {
+    const agent = new Agent(baseDeps());
+    const withAnim = agent.snapshot({ include: ['animation'] });
+    expect(withAnim.animation).toBeDefined();
+
+    const withoutAnim = agent.snapshot({ include: ['lifecycle'] });
+    expect(withoutAnim.animation).toBeUndefined();
+  });
+});

--- a/tests/unit/agent/Agent-skills.test.ts
+++ b/tests/unit/agent/Agent-skills.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import { Agent, type AgentDependencies } from '../../../src/agent/Agent.js';
+import type { AgentIdentity } from '../../../src/agent/AgentIdentity.js';
+import { err, ok } from '../../../src/agent/result.js';
+import type { DomainEvent } from '../../../src/events/DomainEvent.js';
+import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
+import { SKILL_FAILED } from '../../../src/events/standardEvents.js';
+import { DirectBehaviorRunner } from '../../../src/cognition/behavior/DirectBehaviorRunner.js';
+import { INTERACTION_REQUESTED } from '../../../src/interaction/InteractionRequestedEvent.js';
+import { ManualClock } from '../../../src/ports/ManualClock.js';
+import { SeededRng } from '../../../src/ports/SeededRng.js';
+import type { Skill } from '../../../src/skills/Skill.js';
+import { SkillRegistry } from '../../../src/skills/SkillRegistry.js';
+
+function baseDeps(overrides: Partial<AgentDependencies> = {}): AgentDependencies {
+  const identity: AgentIdentity = {
+    id: 'whiskers',
+    name: 'Whiskers',
+    version: '0.0.0',
+    role: 'npc',
+    species: 'cat',
+  };
+  return {
+    identity,
+    eventBus: new InMemoryEventBus(),
+    clock: new ManualClock(1_000),
+    rng: new SeededRng('skill-test-seed'),
+    ...overrides,
+  };
+}
+
+/**
+ * Wire an agent so `agent.interact(verb)` → a reactive handler → an
+ * `invoke-skill` action that hits `skillId`. Mirrors how consumers typically
+ * route UI verbs to skills without going through the default pet-interaction
+ * module.
+ */
+function agentWithSkill(skill: Skill, extra: Partial<AgentDependencies> = {}): Agent {
+  const registry = new SkillRegistry();
+  registry.register(skill);
+  const agent = new Agent(
+    baseDeps({
+      skills: registry,
+      behavior: new DirectBehaviorRunner(),
+      modules: [
+        {
+          id: 'interaction-router',
+          reactiveHandlers: [
+            {
+              on: INTERACTION_REQUESTED,
+              handle: async (event, facade) => {
+                const verb = (event as { verb?: string }).verb;
+                if (verb === skill.id) {
+                  await facade.invokeSkill(skill.id, undefined);
+                }
+              },
+            },
+          ],
+        },
+      ],
+      ...extra,
+    }),
+  );
+  return agent;
+}
+
+describe('Agent skill-invocation error handling — R-03', () => {
+  it('sync-throwing skill emits SkillFailed with code "execution-threw"', async () => {
+    const thrower: Skill = {
+      id: 'boom',
+      label: 'Boom',
+      baseEffectiveness: 1,
+      execute() {
+        throw new Error('kaboom');
+      },
+    };
+    const agent = agentWithSkill(thrower);
+    const seen: DomainEvent[] = [];
+    agent.subscribe((e) => seen.push(e));
+
+    agent.interact('boom');
+    // First tick: perceive + reactive handler fires the skill (which throws).
+    await agent.tick(0.016);
+
+    const failures = seen.filter((e) => e.type === SKILL_FAILED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      skillId: 'boom',
+      code: 'execution-threw',
+      message: 'kaboom',
+    });
+  });
+
+  it('async-throwing skill emits SkillFailed with code "execution-threw"', async () => {
+    const asyncThrower: Skill = {
+      id: 'boom-async',
+      label: 'Boom Async',
+      baseEffectiveness: 1,
+      execute() {
+        return Promise.reject(new Error('async kaboom'));
+      },
+    };
+    const agent = agentWithSkill(asyncThrower);
+    const seen: DomainEvent[] = [];
+    agent.subscribe((e) => seen.push(e));
+
+    agent.interact('boom-async');
+    await agent.tick(0.016);
+
+    const failures = seen.filter((e) => e.type === SKILL_FAILED);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      skillId: 'boom-async',
+      code: 'execution-threw',
+      message: 'async kaboom',
+    });
+  });
+
+  it('RNG state after a throwing skill matches RNG state after an equivalent err-returning skill', async () => {
+    // Both skills should produce identical side effects on the agent's RNG:
+    // namely, zero. A throw must not stealth-draw.
+    const throwing: Skill = {
+      id: 'fail',
+      label: 'Fail',
+      baseEffectiveness: 1,
+      execute() {
+        throw new Error('boom');
+      },
+    };
+    const returning: Skill = {
+      id: 'fail',
+      label: 'Fail',
+      baseEffectiveness: 1,
+      execute() {
+        return Promise.resolve(err({ code: 'forced-fail', message: 'boom' }));
+      },
+    };
+
+    async function runWith(skill: Skill): Promise<number[]> {
+      const agent = agentWithSkill(skill, { rng: new SeededRng('determinism-probe') });
+      agent.interact('fail');
+      await agent.tick(0.016);
+      return Array.from({ length: 4 }, () => agent.rng.next());
+    }
+
+    const rngThrow = await runWith(throwing);
+    const rngReturn = await runWith(returning);
+    expect(rngThrow).toEqual(rngReturn);
+  });
+
+  it('subsequent ticks proceed normally after a throwing skill', async () => {
+    const toggling = {
+      shouldThrow: true,
+    };
+    const skill: Skill = {
+      id: 'flaky',
+      label: 'Flaky',
+      baseEffectiveness: 1,
+      execute() {
+        if (toggling.shouldThrow) {
+          toggling.shouldThrow = false;
+          throw new Error('first call explodes');
+        }
+        return Promise.resolve(ok({ effectiveness: 1 }));
+      },
+    };
+    const agent = agentWithSkill(skill);
+    const seen: DomainEvent[] = [];
+    agent.subscribe((e) => seen.push(e));
+
+    agent.interact('flaky');
+    await agent.tick(0.016);
+    agent.interact('flaky');
+    const trace = await agent.tick(0.016);
+
+    // The second invocation succeeds — the agent is not wedged by the throw.
+    expect(trace.halted).toBe(false);
+    expect(seen.filter((e) => e.type === SKILL_FAILED)).toHaveLength(1);
+    // And SkillCompleted fires exactly once, for the second call.
+    const completed = seen.filter((e) => e.type === 'SkillCompleted');
+    expect(completed).toHaveLength(1);
+  });
+});

--- a/tests/unit/agent/Agent.test.ts
+++ b/tests/unit/agent/Agent.test.ts
@@ -173,6 +173,58 @@ describe('Agent (M2 shell)', () => {
     expect(warn).toHaveBeenCalled();
   });
 
+  it('bus + RNG remain consistent after a reactive handler throws', async () => {
+    // After a handler throws, a healthy handler on the same event type
+    // must still receive subsequent events, and the RNG state must match
+    // an equivalent run without any throwing handler (throws consume no
+    // RNG draws).
+    const healthyA = vi.fn();
+    const healthyB = vi.fn();
+
+    async function runWith(handlers: AgentModule['reactiveHandlers']): Promise<number[]> {
+      const bus = new InMemoryEventBus();
+      const agent = new Agent(
+        baseDeps({
+          eventBus: bus,
+          rng: new SeededRng('fixed-seed'),
+          modules: [{ id: 'scenario', reactiveHandlers: handlers }],
+          logger: {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+          },
+        }),
+      );
+
+      bus.publish({ type: 'ping', at: 0 });
+      await agent.tick(0.016);
+      bus.publish({ type: 'ping', at: 10 });
+      await agent.tick(0.016);
+
+      return Array.from({ length: 4 }, () => agent.rng.next());
+    }
+
+    const throwing: AgentModule['reactiveHandlers'] = [
+      {
+        on: 'ping',
+        handle: () => {
+          throw new Error('oh no');
+        },
+      },
+      { on: 'ping', handle: healthyA },
+    ];
+    const clean: AgentModule['reactiveHandlers'] = [{ on: 'ping', handle: healthyB }];
+
+    const rngAfterThrow = await runWith(throwing);
+    const rngAfterClean = await runWith(clean);
+
+    // Healthy handler still sees both events despite the earlier handler throwing.
+    expect(healthyA).toHaveBeenCalledTimes(2);
+    // Throws don't touch the RNG → byte-identical sequences.
+    expect(rngAfterThrow).toEqual(rngAfterClean);
+  });
+
   it('runs onInstall() for modules at construction', () => {
     const onInstall = vi.fn();
     const mod: AgentModule = { id: 'hook', onInstall };

--- a/tests/unit/agent/Agent.test.ts
+++ b/tests/unit/agent/Agent.test.ts
@@ -181,7 +181,9 @@ describe('Agent (M2 shell)', () => {
     const healthyA = vi.fn();
     const healthyB = vi.fn();
 
-    async function runWith(handlers: AgentModule['reactiveHandlers']): Promise<number[]> {
+    async function runWith(
+      handlers: NonNullable<AgentModule['reactiveHandlers']>,
+    ): Promise<number[]> {
       const bus = new InMemoryEventBus();
       const agent = new Agent(
         baseDeps({
@@ -205,7 +207,7 @@ describe('Agent (M2 shell)', () => {
       return Array.from({ length: 4 }, () => agent.rng.next());
     }
 
-    const throwing: AgentModule['reactiveHandlers'] = [
+    const throwing: NonNullable<AgentModule['reactiveHandlers']> = [
       {
         on: 'ping',
         handle: () => {
@@ -214,7 +216,7 @@ describe('Agent (M2 shell)', () => {
       },
       { on: 'ping', handle: healthyA },
     ];
-    const clean: AgentModule['reactiveHandlers'] = [{ on: 'ping', handle: healthyB }];
+    const clean: NonNullable<AgentModule['reactiveHandlers']> = [{ on: 'ping', handle: healthyB }];
 
     const rngAfterThrow = await runWith(throwing);
     const rngAfterClean = await runWith(clean);

--- a/tests/unit/agent/createAgent.test.ts
+++ b/tests/unit/agent/createAgent.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { createAgent } from '../../../src/agent/createAgent.js';
 import { ManualClock } from '../../../src/ports/ManualClock.js';
 import { SeededRng } from '../../../src/ports/SeededRng.js';
+import { Needs } from '../../../src/needs/Needs.js';
+import { DEFAULT_URGENCY_CURVE } from '../../../src/needs/Need.js';
 
 describe('createAgent (M2 builder)', () => {
   it('builds a running agent with only id + species', async () => {
@@ -38,6 +40,29 @@ describe('createAgent (M2 builder)', () => {
 
     const trace = await agent.tick(0);
     expect(trace.tickStartedAt).toBe(500);
+  });
+
+  it('auto-wires ExpressiveNeedsPolicy when needs are set but no policy is given', async () => {
+    // With a critical hunger need and no explicit policy, the autonomous
+    // cognition pipeline should still produce a candidate intention.
+    // Previously this path silently dropped to zero candidates, leaving
+    // the pet inert. We assert the DecisionTrace records a chosen
+    // intention rather than asserting on the emitted events (the exact
+    // event shape depends on the configured behavior runner).
+    const needs = new Needs([
+      {
+        id: 'hunger',
+        level: 0.05, // fully critical
+        decayPerSec: 0,
+        urgencyCurve: DEFAULT_URGENCY_CURVE,
+        criticalThreshold: 0.2,
+      },
+    ]);
+
+    const agent = createAgent({ id: 'hungry', species: 'cat', needs });
+    const trace = await agent.tick(1);
+
+    expect(trace.actions.length + trace.emitted.length).toBeGreaterThan(0);
   });
 
   it('honors role, persona, name, version overrides', () => {

--- a/tests/unit/animation/AnimationStateMachine.test.ts
+++ b/tests/unit/animation/AnimationStateMachine.test.ts
@@ -56,23 +56,24 @@ describe('AnimationStateMachine', () => {
 
   it('explicit transition() bypasses reconciliation and records history', () => {
     const sm = new AnimationStateMachine();
-    const t = sm.transition('dead', 'deceased');
+    const t = sm.transition('dead', 42, 'deceased');
     expect(t?.to).toBe('dead');
+    expect(t?.at).toBe(42);
     expect(sm.history()).toHaveLength(1);
     expect(sm.history()[0]?.reason).toBe('deceased');
   });
 
   it('history accumulates transitions', () => {
     const sm = new AnimationStateMachine();
-    sm.transition('happy');
-    sm.transition('playing');
-    sm.transition('idle');
+    sm.transition('happy', 1);
+    sm.transition('playing', 2);
+    sm.transition('idle', 3);
     expect(sm.history().map((t) => t.to)).toEqual(['happy', 'playing', 'idle']);
   });
 
   it('snapshot + restore preserves state', () => {
     const sm = new AnimationStateMachine();
-    sm.transition('playing');
+    sm.transition('playing', 0);
     const snap = sm.snapshot();
 
     const copy = new AnimationStateMachine();

--- a/tests/unit/animation/AnimationStateMachine.test.ts
+++ b/tests/unit/animation/AnimationStateMachine.test.ts
@@ -71,6 +71,18 @@ describe('AnimationStateMachine', () => {
     expect(sm.history().map((t) => t.to)).toEqual(['happy', 'playing', 'idle']);
   });
 
+  it('caps history at maxHistorySize and evicts oldest on overflow', () => {
+    const sm = new AnimationStateMachine({ maxHistorySize: 3 });
+    sm.transition('happy', 1);
+    sm.transition('idle', 2);
+    sm.transition('happy', 3);
+    sm.transition('idle', 4);
+    sm.transition('happy', 5);
+    const history = sm.history();
+    expect(history).toHaveLength(3);
+    expect(history.map((t) => t.at)).toEqual([3, 4, 5]);
+  });
+
   it('snapshot + restore preserves state', () => {
     const sm = new AnimationStateMachine();
     sm.transition('playing', 0);

--- a/tests/unit/cognition/behavior/DirectBehaviorRunner.test.ts
+++ b/tests/unit/cognition/behavior/DirectBehaviorRunner.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { DirectBehaviorRunner } from '../../../../src/cognition/behavior/DirectBehaviorRunner.js';
+
+describe('DirectBehaviorRunner.run — R-28 coverage', () => {
+  it('falls back to a noop action when no mapping is registered', () => {
+    const runner = new DirectBehaviorRunner();
+    const actions = runner.run({ kind: 'satisfy', type: 'eat' });
+    expect(actions).toEqual([{ type: 'noop' }]);
+  });
+
+  it('emits an invoke-skill action when a mapping exists', () => {
+    const runner = new DirectBehaviorRunner({
+      skillByIntentionType: { 'satisfy-need:hunger': 'feed' },
+    });
+    const actions = runner.run({ kind: 'satisfy', type: 'satisfy-need:hunger' });
+    expect(actions).toEqual([{ type: 'invoke-skill', skillId: 'feed' }]);
+  });
+
+  it('forwards intention.params into the action', () => {
+    const runner = new DirectBehaviorRunner({
+      skillByIntentionType: { 'consume-food': 'feed' },
+    });
+    const actions = runner.run({
+      kind: 'satisfy',
+      type: 'consume-food',
+      params: { item: 'kibble' },
+    });
+    expect(actions).toEqual([
+      { type: 'invoke-skill', skillId: 'feed', params: { item: 'kibble' } },
+    ]);
+  });
+
+  it('custom fallback is invoked when no mapping is set', () => {
+    const runner = new DirectBehaviorRunner({
+      fallback: (intention) => [
+        {
+          type: 'emit-event',
+          event: { type: 'UnhandledIntention', at: 0, intentionType: intention.type },
+        },
+      ],
+    });
+    const actions = runner.run({ kind: 'react', type: 'hear-noise' });
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.type).toBe('emit-event');
+  });
+
+  it('mapIntention registers a mapping at runtime', () => {
+    const runner = new DirectBehaviorRunner();
+    expect(runner.run({ kind: 'express', type: 'meow' })).toEqual([{ type: 'noop' }]);
+    runner.mapIntention('meow', 'express-meow');
+    expect(runner.run({ kind: 'express', type: 'meow' })).toEqual([
+      { type: 'invoke-skill', skillId: 'express-meow' },
+    ]);
+  });
+
+  it('mapIntention overrides an existing mapping', () => {
+    const runner = new DirectBehaviorRunner({
+      skillByIntentionType: { fight: 'claws' },
+    });
+    runner.mapIntention('fight', 'bite');
+    const actions = runner.run({ kind: 'react', type: 'fight' });
+    expect(actions).toEqual([{ type: 'invoke-skill', skillId: 'bite' }]);
+  });
+});

--- a/tests/unit/cognition/reasoning/UrgencyReasoner.test.ts
+++ b/tests/unit/cognition/reasoning/UrgencyReasoner.test.ts
@@ -7,6 +7,7 @@ import { Modifiers } from '../../../../src/modifiers/Modifiers.js';
 function ctx(candidates: readonly IntentionCandidate[]): ReasonerContext {
   return {
     perceived: [],
+    needs: undefined,
     modifiers: new Modifiers(),
     candidates,
   };
@@ -21,7 +22,7 @@ describe('UrgencyReasoner.selectIntention — R-28 coverage', () => {
   it('returns null when the only candidate scores below the threshold', () => {
     const r = new UrgencyReasoner({ threshold: 1 });
     const pick = r.selectIntention(
-      ctx([{ intention: { kind: 'satisfy', type: 'eat' }, score: 0.5 }]),
+      ctx([{ intention: { kind: 'satisfy', type: 'eat' }, score: 0.5, source: 'needs' }]),
     );
     expect(pick).toBeNull();
   });
@@ -30,9 +31,9 @@ describe('UrgencyReasoner.selectIntention — R-28 coverage', () => {
     const r = new UrgencyReasoner();
     const pick = r.selectIntention(
       ctx([
-        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.3 },
-        { intention: { kind: 'satisfy', type: 'sleep' }, score: 0.9 },
-        { intention: { kind: 'express', type: 'meow' }, score: 0.1 },
+        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.3, source: 'needs' },
+        { intention: { kind: 'satisfy', type: 'sleep' }, score: 0.9, source: 'needs' },
+        { intention: { kind: 'express', type: 'meow' }, score: 0.1, source: 'needs' },
       ]),
     );
     expect(pick?.type).toBe('sleep');
@@ -42,8 +43,8 @@ describe('UrgencyReasoner.selectIntention — R-28 coverage', () => {
     const r = new UrgencyReasoner();
     const pick = r.selectIntention(
       ctx([
-        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.5 },
-        { intention: { kind: 'satisfy', type: 'sleep' }, score: 0.5 },
+        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.5, source: 'needs' },
+        { intention: { kind: 'satisfy', type: 'sleep' }, score: 0.5, source: 'needs' },
       ]),
     );
     expect(pick?.type).toBe('eat');
@@ -63,10 +64,11 @@ describe('UrgencyReasoner.selectIntention — R-28 coverage', () => {
     });
     const pick = r.selectIntention({
       perceived: [],
+      needs: undefined,
       modifiers: mods,
       candidates: [
-        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.6 },
-        { intention: { kind: 'satisfy', type: 'sleep' }, score: 0.3 },
+        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.6, source: 'needs' },
+        { intention: { kind: 'satisfy', type: 'sleep' }, score: 0.3, source: 'needs' },
       ],
     });
     // Without the modifier, 'eat' (0.6) wins. With +1 on 'sleep' (0.3+1=1.3), sleep wins.
@@ -79,11 +81,12 @@ describe('UrgencyReasoner.selectIntention — R-28 coverage', () => {
     });
     const pick = r.selectIntention({
       perceived: [],
+      needs: undefined,
       modifiers: new Modifiers(),
       persona: { traits: { playfulness: 1 } },
       candidates: [
-        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.5 },
-        { intention: { kind: 'satisfy', type: 'play' }, score: 0.3 },
+        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.5, source: 'needs' },
+        { intention: { kind: 'satisfy', type: 'play' }, score: 0.3, source: 'needs' },
       ],
     });
     // eat: 0.5 * (1+0) = 0.5. play: 0.3 * (1+1) = 0.6. play wins.
@@ -94,8 +97,8 @@ describe('UrgencyReasoner.selectIntention — R-28 coverage', () => {
     const r = new UrgencyReasoner({ threshold: 0.5 });
     const pick = r.selectIntention(
       ctx([
-        { intention: { kind: 'satisfy', type: 'a' }, score: 0.4 },
-        { intention: { kind: 'satisfy', type: 'b' }, score: 0.6 },
+        { intention: { kind: 'satisfy', type: 'a' }, score: 0.4, source: 'needs' },
+        { intention: { kind: 'satisfy', type: 'b' }, score: 0.6, source: 'needs' },
       ]),
     );
     expect(pick?.type).toBe('b');

--- a/tests/unit/cognition/reasoning/UrgencyReasoner.test.ts
+++ b/tests/unit/cognition/reasoning/UrgencyReasoner.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { IntentionCandidate } from '../../../../src/cognition/IntentionCandidate.js';
+import type { ReasonerContext } from '../../../../src/cognition/reasoning/Reasoner.js';
+import { UrgencyReasoner } from '../../../../src/cognition/reasoning/UrgencyReasoner.js';
+import { Modifiers } from '../../../../src/modifiers/Modifiers.js';
+
+function ctx(candidates: readonly IntentionCandidate[]): ReasonerContext {
+  return {
+    perceived: [],
+    modifiers: new Modifiers(),
+    candidates,
+  };
+}
+
+describe('UrgencyReasoner.selectIntention — R-28 coverage', () => {
+  it('returns null for an empty candidate list', () => {
+    const r = new UrgencyReasoner();
+    expect(r.selectIntention(ctx([]))).toBeNull();
+  });
+
+  it('returns null when the only candidate scores below the threshold', () => {
+    const r = new UrgencyReasoner({ threshold: 1 });
+    const pick = r.selectIntention(
+      ctx([{ intention: { kind: 'satisfy', type: 'eat' }, score: 0.5 }]),
+    );
+    expect(pick).toBeNull();
+  });
+
+  it('picks the highest-scoring candidate', () => {
+    const r = new UrgencyReasoner();
+    const pick = r.selectIntention(
+      ctx([
+        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.3 },
+        { intention: { kind: 'satisfy', type: 'sleep' }, score: 0.9 },
+        { intention: { kind: 'express', type: 'meow' }, score: 0.1 },
+      ]),
+    );
+    expect(pick?.type).toBe('sleep');
+  });
+
+  it('ties: first candidate wins because strict > is used', () => {
+    const r = new UrgencyReasoner();
+    const pick = r.selectIntention(
+      ctx([
+        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.5 },
+        { intention: { kind: 'satisfy', type: 'sleep' }, score: 0.5 },
+      ]),
+    );
+    expect(pick?.type).toBe('eat');
+  });
+
+  it('modifier bonus can swing the pick', () => {
+    const r = new UrgencyReasoner();
+    const mods = new Modifiers();
+    mods.apply({
+      id: 'crave-sleep',
+      source: 'test',
+      appliedAt: 0,
+      stack: 'replace',
+      effects: [
+        { target: { type: 'intention-score', intentionType: 'sleep' }, kind: 'add', value: 1 },
+      ],
+    });
+    const pick = r.selectIntention({
+      perceived: [],
+      modifiers: mods,
+      candidates: [
+        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.6 },
+        { intention: { kind: 'satisfy', type: 'sleep' }, score: 0.3 },
+      ],
+    });
+    // Without the modifier, 'eat' (0.6) wins. With +1 on 'sleep' (0.3+1=1.3), sleep wins.
+    expect(pick?.type).toBe('sleep');
+  });
+
+  it('persona bias is applied multiplicatively to the baseline score', () => {
+    const r = new UrgencyReasoner({
+      personaBias: (type) => (type === 'play' ? 1 : 0),
+    });
+    const pick = r.selectIntention({
+      perceived: [],
+      modifiers: new Modifiers(),
+      persona: { traits: { playfulness: 1 } },
+      candidates: [
+        { intention: { kind: 'satisfy', type: 'eat' }, score: 0.5 },
+        { intention: { kind: 'satisfy', type: 'play' }, score: 0.3 },
+      ],
+    });
+    // eat: 0.5 * (1+0) = 0.5. play: 0.3 * (1+1) = 0.6. play wins.
+    expect(pick?.type).toBe('play');
+  });
+
+  it('custom threshold filters out low-score candidates', () => {
+    const r = new UrgencyReasoner({ threshold: 0.5 });
+    const pick = r.selectIntention(
+      ctx([
+        { intention: { kind: 'satisfy', type: 'a' }, score: 0.4 },
+        { intention: { kind: 'satisfy', type: 'b' }, score: 0.6 },
+      ]),
+    );
+    expect(pick?.type).toBe('b');
+  });
+});

--- a/tests/unit/modifiers/NumericModifierResolver.test.ts
+++ b/tests/unit/modifiers/NumericModifierResolver.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import type { ModifierEffect } from '../../../src/modifiers/ModifierEffect.js';
+import { NumericModifierResolver } from '../../../src/modifiers/NumericModifierResolver.js';
+
+/**
+ * All tests target a synthetic `need-decay` stream so the match predicate is
+ * a simple type check — the resolver's logic is independent of the target
+ * kind being composed.
+ */
+const matchDecay = (t: { type: string }): boolean => t.type === 'need-decay';
+
+function decay(kind: ModifierEffect['kind'], value: number, needId = 'hunger'): ModifierEffect {
+  return { target: { type: 'need-decay', needId }, kind, value };
+}
+
+describe('NumericModifierResolver', () => {
+  it('returns the identity when there are no effects at all', () => {
+    const resolver = new NumericModifierResolver();
+    expect(resolver.resolve([], 1, matchDecay)).toBe(1);
+    expect(resolver.resolve([], 0, matchDecay)).toBe(0);
+  });
+
+  it('returns the identity when no effect matches the predicate', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [
+      { target: { type: 'mood-bias', category: 'playful' }, kind: 'add', value: 5 },
+    ];
+    expect(resolver.resolve(effects, 1, matchDecay)).toBe(1);
+    expect(resolver.resolve(effects, 0, matchDecay)).toBe(0);
+  });
+
+  it('only-set: a single set effect short-circuits to its value', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [decay('set', 0.25)];
+    // Identity is ignored once a `set` effect matched.
+    expect(resolver.resolve(effects, 1, matchDecay)).toBe(0.25);
+    expect(resolver.resolve(effects, 0, matchDecay)).toBe(0.25);
+  });
+
+  it('only-add: sums additive effects on top of additive identity (0)', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [decay('add', 0.3), decay('add', 0.2), decay('add', -0.1)];
+    expect(resolver.resolve(effects, 0, matchDecay)).toBeCloseTo(0.4);
+  });
+
+  it('only-multiply: multiplies effects against the multiplicative identity (1)', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [decay('multiply', 0.5), decay('multiply', 0.8)];
+    expect(resolver.resolve(effects, 1, matchDecay)).toBeCloseTo(0.4);
+  });
+
+  it('only-clamp: a clamp effect caps the identity as the ceiling', () => {
+    const resolver = new NumericModifierResolver();
+    // Matching clamp with identity=1 — the lone matched effect forces matched=true,
+    // so the resolver falls through to the base calc: 1 * 1 + 0 = 1, capped at 0.7.
+    expect(resolver.resolve([decay('clamp', 0.7)], 1, matchDecay)).toBeCloseTo(0.7);
+    // Lowest clamp wins.
+    expect(resolver.resolve([decay('clamp', 0.9), decay('clamp', 0.5)], 1, matchDecay)).toBeCloseTo(
+      0.5,
+    );
+  });
+
+  it('combination: set + clamp — set value is still capped by clamp', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [decay('set', 2), decay('clamp', 1.5)];
+    expect(resolver.resolve(effects, 1, matchDecay)).toBeCloseTo(1.5);
+    // If set is already below the clamp, it wins unchanged.
+    expect(resolver.resolve([decay('set', 0.1), decay('clamp', 1.5)], 1, matchDecay)).toBeCloseTo(
+      0.1,
+    );
+  });
+
+  it('combination: set short-circuits multiply and add entirely', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [decay('multiply', 10), decay('add', 100), decay('set', 0.5)];
+    expect(resolver.resolve(effects, 1, matchDecay)).toBeCloseTo(0.5);
+  });
+
+  it('combination: multiply + add compose as `identity * product + sum`', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [decay('multiply', 0.5), decay('add', 0.25)];
+    // 1 * 0.5 + 0.25 = 0.75
+    expect(resolver.resolve(effects, 1, matchDecay)).toBeCloseTo(0.75);
+  });
+
+  it('combination: multiply + clamp — product is capped', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [
+      decay('multiply', 3),
+      decay('multiply', 2),
+      decay('clamp', 4),
+    ];
+    // 1 * 6 = 6, clamped to 4.
+    expect(resolver.resolve(effects, 1, matchDecay)).toBeCloseTo(4);
+  });
+
+  it('combination: add + clamp on additive identity', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [decay('add', 0.6), decay('add', 0.6), decay('clamp', 1)];
+    // sum = 1.2, clamped to 1.
+    expect(resolver.resolve(effects, 0, matchDecay)).toBeCloseTo(1);
+  });
+
+  it('ignores effects whose targets do not match the predicate while composing the rest', () => {
+    const resolver = new NumericModifierResolver();
+    const effects: ModifierEffect[] = [
+      { target: { type: 'mood-bias', category: 'playful' }, kind: 'multiply', value: 0.01 },
+      decay('multiply', 0.5),
+      { target: { type: 'locomotion-speed' }, kind: 'add', value: 99 },
+      decay('add', 0.1),
+    ];
+    // Only the two decay effects matter: 1 * 0.5 + 0.1 = 0.6.
+    expect(resolver.resolve(effects, 1, matchDecay)).toBeCloseTo(0.6);
+  });
+});

--- a/tests/unit/persistence/offlineCatchUp.test.ts
+++ b/tests/unit/persistence/offlineCatchUp.test.ts
@@ -43,4 +43,23 @@ describe('runCatchUp', () => {
     expect(r2.chunksProcessed).toBe(0);
     expect(step).not.toHaveBeenCalled();
   });
+
+  it('preserves total virtual-dt under long, tiny-chunk catch-up (no float drift)', async () => {
+    // Pathological case: 10 000 virtual seconds split into 0.001 s chunks
+    // is 10 million iterations of repeated subtraction. We assert the sum
+    // of chunks handed to `step` recovers the total to within 1e-9.
+    const total = 10_000;
+    let sum = 0;
+    const result = await runCatchUp(
+      total,
+      (dt) => {
+        sum += dt;
+        return Promise.resolve();
+      },
+      { chunkVirtualSeconds: 0.001, maxChunks: 100_000_000 },
+    );
+    expect(result.truncated).toBe(false);
+    expect(Math.abs(sum - total)).toBeLessThan(1e-9);
+    expect(Math.abs(result.totalVirtualSeconds - total)).toBeLessThan(1e-9);
+  });
 });

--- a/tests/unit/skills/defaults.test.ts
+++ b/tests/unit/skills/defaults.test.ts
@@ -47,12 +47,23 @@ function makeCtx(): {
       return m;
     },
     removeModifier: (id) => modifiers.remove(id),
+    hasModifier: (id) => modifiers.has(id),
     publishEvent: (e) => {
       published.push(e);
     },
     ageSeconds: () => 0,
   };
   return { ctx, needs, modifiers, published, clock };
+}
+
+function applyDisobedient(modifiers: Modifiers): void {
+  modifiers.apply({
+    id: 'disobedient',
+    source: 'test-fixture',
+    appliedAt: 0,
+    stack: 'replace',
+    effects: [],
+  });
 }
 
 describe('FeedSkill', () => {
@@ -126,8 +137,9 @@ describe('RestSkill', () => {
 });
 
 describe('ScoldSkill', () => {
-  it('applies scolded modifier and drains happiness', async () => {
+  it('applies scolded modifier and drains happiness when disobedient is present', async () => {
     const { ctx, needs, modifiers } = makeCtx();
+    applyDisobedient(modifiers);
     const result = await ScoldSkill.execute(undefined, ctx);
     expect(result.ok).toBe(true);
     expect(modifiers.has('scolded')).toBe(true);
@@ -135,11 +147,20 @@ describe('ScoldSkill', () => {
     if (result.ok) expect(result.value.fxHint).toBe('cloud-gray');
   });
 
-  it('uses replace stacking (new scold evicts old)', async () => {
+  it('returns err("not-misbehaving") when disobedient is absent', async () => {
     const { ctx, modifiers } = makeCtx();
-    await ScoldSkill.execute(undefined, ctx);
-    await ScoldSkill.execute(undefined, ctx);
-    expect(modifiers.list().filter((m) => m.id === 'scolded')).toHaveLength(1);
+    const result = await ScoldSkill.execute(undefined, ctx);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('not-misbehaving');
+    expect(modifiers.has('scolded')).toBe(false);
+  });
+
+  it('clears disobedient on success', async () => {
+    const { ctx, modifiers } = makeCtx();
+    applyDisobedient(modifiers);
+    const result = await ScoldSkill.execute(undefined, ctx);
+    expect(result.ok).toBe(true);
+    expect(modifiers.has('disobedient')).toBe(false);
   });
 });
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,7 @@
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["src/index.ts", "src/integrations/excalibur/index.ts"],
   "entryPointStrategy": "expand",
-  "out": "docs",
+  "out": "docs/api",
   "tsconfig": "./tsconfig.build.json",
   "readme": "README.md",
   "name": "agentonomous",


### PR DESCRIPTION
## Summary

Phase A.1 remediation — the gate between the M0–M15 MVP (on `develop` at
`2731bf5`) and V1.0.0. Twenty-seven of twenty-eight `R-XX` items from the
consolidated reviewer plan land here; **R-08 (invasive subsystem snapshot
versioning) is deferred** — see *Deferred* below.

## What's in the box

### Persistence
- **R-01** — `AgentSnapshot` carries animation state + activeSkillId;
  `SnapshotPart` grows `'animation'`. First post-restore tick no longer
  emits a spurious `AnimationTransition` or `MoodChanged`.
- **R-16** — `Agent.restore()` emits a `ModifierExpired` event for modifiers
  whose `expiresAt` has passed at restore-time (previously silently
  dropped).

### Determinism
- **R-02** — integration tests extended with reactive-handler,
  skill-failure, and 1000-virtual-second replay cases. Byte-identical
  traces + events + final state across runs.
- **R-03** — `CognitionPipeline.invokeSkillAction` catches throws from
  `Skill.execute` and emits `SkillFailed` with `code: 'execution-threw'`.
  RNG state is not mutated between the throw and the next tick.
- **R-14** — float-drift test: 10 000 s in 10 M chunks, sum within 1e-9.
- **R-15** — reactive-handler throw leaves bus + RNG consistent;
  byte-identical to an equivalent clean run.

### Architecture
- **R-05** — `Agent.ts` 1010 → 758 lines. Tick-pipeline stages extracted
  into `src/agent/internal/{Lifecycle,Modifiers,Needs}Ticker.ts`,
  `{Mood,Animation}Reconciler.ts`, and `CognitionPipeline.ts`. No public
  API changes. Internal helpers are not re-exported from the barrel.
- **R-18** — `NumericModifierResolver` extracted from `Modifiers.ts` with
  12 targeted unit tests covering set / multiply / add / clamp combos.

### Tuning
- **R-06** — numeric literals centralized in `src/cognition/tuning.ts` as
  `MOOD_URGENCY_THRESHOLDS`, `PERSONA_TRAIT_WEIGHTS`, `SKILL_DEFAULTS`,
  `OFFLINE_CATCHUP_DEFAULTS`, `EXPRESSIVE_POLICY_DEFAULTS`. All values
  identical; tests unmodified.

### Gameplay + Demo
- **R-09** — `AnimationStateMachine` history capped at 1000 (configurable).
- **R-10 + R-11** — nurture-pet `messyPlay` random event applies a `dirty`
  modifier (giving Clean a real purpose); mildIllness / surpriseTreat
  raised to 0.01/s with 30 s cooldowns.
- **R-12** — `ScoldSkill` gated on the `disobedient` modifier;
  `SkillContext.hasModifier(id)` is the new introspection surface. Scold
  clears `disobedient` on success.
- **R-13** — `well-fed` buff duration 120 → 60 s.
- **R-20** — `createAgent` auto-wires an `ExpressiveNeedsPolicy` when
  `needs` is configured without an explicit policy (previously inert).
- **R-21** — `AnimationStateMachine.transition(at)` now requires the
  timestamp explicitly; caller no longer patches it post-hoc.
- **R-26** — life-summary modal on `AgentDied` with ate/petted/scolded/
  illness counters aggregated from observed events.

### Ergonomics
- **R-07** — every standard event interface explicitly declares `fxHint?`.
- **R-17** — `'deceased'` literal gone from `src/` except in its defining
  file; everything uses `DECEASED_STAGE`.
- **R-22** — every `Phase B` reference removed from library JSDoc.
- **R-23** — `PassthroughValidator` JSDoc clarifies it as a no-op /
  testing default.
- **R-25** — barrel JSDoc for `ExpressiveNeedsPolicy`,
  `ActiveNeedsPolicy`, `ComposedNeedsPolicy`, `NoopReasoner`,
  `UrgencyReasoner`, `DirectBehaviorRunner`, `NoopBehavior`,
  `NoopLearner`, `DefaultMoodModel`.

### Coverage
- **R-28** — dedicated `UrgencyReasoner` (7 tests) + `DirectBehaviorRunner`
  (6 tests) unit tests cover tie-breaking, threshold, persona bias,
  modifier bonus swings, fallback runner, runtime `mapIntention`.

### Docs
- **R-04 + R-19 + R-24** — README gains a complete Pinia mini-example, a
  "Running the example" section with the `npm run build`-first sequence,
  an interaction-flow callout, an "Advanced: random events + custom
  skills" snippet exercising `ctx.hasModifier()`, and a bundle-size
  budget note. Stale `LlmProviderPort` reference removed. New `analyze`
  script (zero new devDeps).
- **R-27** — `STYLE_GUIDE.md` codifying TypeScript + file layout + export
  + import + JSDoc + naming + testing conventions, plus flagged files
  from sub-agent-authored sections.
- **CONTRIBUTING.md** — branch model (`main` / `develop` / topic branches),
  commit style, PR conventions, release flow.
- **PUBLISHING.md** — updated to reflect `develop`-first release PRs.

## Deferred

**R-08** (subsystem snapshot versioning) — MED severity. Would wrap every
subsystem's snapshot slice in `{ version: 1, state: {...} }` + migration
registry. Declined in this PR because the plumbing touches every
persistence surface and risks a second round of review; best landed as a
dedicated follow-up once the Phase A.1 baseline is merged.

## Numbers

- **288 tests** passing (was 245 on base). 50 test files.
- **`npm run verify`** — green (format:check + lint + typecheck + test +
  build).
- **Agent.ts** — 758 lines (was 1010). Plan target was <700; the
  remainder is snapshot/restore + public verbs + death path, out of
  scope for the R-05 extraction.

## Independent review

A reviewer agent audited the full diff against six focus areas (R-05
correctness, R-03 RNG claim, R-16 boundary behavior, R-01 typing under
`exactOptionalPropertyTypes`, test flakiness, docs drift). Findings:
zero HIGH, zero MED, one LOW (stale "Stage 4-7" comment label after
R-05 — fixed in the final `polish:` commit).

## Branch workflow note

This PR targets `develop`, per the `main` / `develop` / topic branch
model documented in `CONTRIBUTING.md`. After merge, a release PR can
be cut from `develop` → `main` when we're ready to tag `v1.0.0`.

## Test plan

- [ ] `npm run verify` passes locally on the reviewer's machine.
- [ ] `npm run demo:install && npm run demo:dev` → play the pet for
  ~2 minutes: observe random events fire, feed / clean / pet flow,
  scold blocked without `disobedient`, scold allowed after messyPlay,
  death → life-summary modal.
- [ ] `npm run analyze` reports dist/ sizes sensibly.
- [ ] Deterministic replay test (`tests/integration/nurture-pet-deterministic.test.ts`)
  still byte-identical across two runs.

https://claude.ai/code/session_01RnaVtvGe6LYDDntRUAxuyA