### PR TITLE
fix: persist timeScale in AgentSnapshot (catchUp divergence) — v1 blocker

### DIFF
--- a/.changeset/snapshot-persist-timescale.md
+++ b/.changeset/snapshot-persist-timescale.md
@@ -1,0 +1,19 @@
+---
+'agentonomous': minor
+---
+
+Persist `timeScale` in `AgentSnapshot` so `restore({ catchUp: true })` uses
+the snapshotted cadence instead of the rehydrating agent's constructor
+value.
+
+Previously a consumer who saved at scale 60 and rehydrated into a fresh
+agent at scale 1 saw a divergent catch-up: the elapsed wall time was
+scaled by the **current** agent's `timeScale`, not the one in effect at
+save time. The snapshot schema now carries `timeScale` explicitly, and
+`restore()` applies it before the catch-up block.
+
+Bumps `AgentSnapshot.schemaVersion` from `1` to `2`. Pre-v2 snapshots
+migrate forward unchanged; their missing `timeScale` falls through to the
+constructor value, preserving legacy behaviour.
+
+Groundwork for R-08 per-subsystem snapshot versioning.

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -577,9 +577,12 @@ export class Agent {
     // Apply the snapshotted timeScale first so catch-up (below) and any
     // subsequent ticks run at the cadence the snapshot was taken at, not
     // the fresh agent's constructor value. Pre-v2 snapshots omit this
-    // field and keep the constructor value.
+    // field and keep the constructor value. Routed through
+    // `setTimeScale` so a corrupted snapshot (negative / NaN / Infinity)
+    // throws `InvalidTimeScaleError` instead of silently poisoning the
+    // tick loop.
     if (snapshot.timeScale !== undefined) {
-      this.timeScale = snapshot.timeScale;
+      this.setTimeScale(snapshot.timeScale);
     }
     if (snapshot.lifecycle && this.ageModel) {
       this.ageModel.restore({

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -533,6 +533,7 @@ export class Agent {
       schemaVersion: CURRENT_SNAPSHOT_VERSION,
       snapshotAt: this.clock.now(),
       identity: this.identity,
+      timeScale: this.timeScale,
     };
     if (this.ageModel && wanted('lifecycle')) {
       snap.lifecycle = this.ageModel.snapshot();
@@ -573,6 +574,13 @@ export class Agent {
     snapshot: AgentSnapshot,
     opts: { catchUp?: boolean | { chunkVirtualSeconds?: number } } = {},
   ): Promise<void> {
+    // Apply the snapshotted timeScale first so catch-up (below) and any
+    // subsequent ticks run at the cadence the snapshot was taken at, not
+    // the fresh agent's constructor value. Pre-v2 snapshots omit this
+    // field and keep the constructor value.
+    if (snapshot.timeScale !== undefined) {
+      this.timeScale = snapshot.timeScale;
+    }
     if (snapshot.lifecycle && this.ageModel) {
       this.ageModel.restore({
         ageSeconds: snapshot.lifecycle.ageSeconds,

--- a/src/persistence/AgentSnapshot.ts
+++ b/src/persistence/AgentSnapshot.ts
@@ -36,6 +36,16 @@ export interface AgentSnapshot {
 
   identity: AgentIdentity;
 
+  /**
+   * Wall-to-virtual time multiplier in effect at save time. Restored onto
+   * the rehydrating agent before offline catch-up runs, so a pet saved at
+   * scale 60 rehydrates into its own virtual-time cadence rather than the
+   * fresh agent's (typically default) scale. Undefined on snapshots taken
+   * before schemaVersion 2 — the restoring agent's constructor value wins
+   * in that case.
+   */
+  timeScale?: number;
+
   lifecycle?: {
     bornAt: number;
     ageSeconds: number;
@@ -74,4 +84,4 @@ export interface AgentSnapshot {
   pendingEvents?: readonly DomainEvent[];
 }
 
-export const CURRENT_SNAPSHOT_VERSION = 1 as const;
+export const CURRENT_SNAPSHOT_VERSION = 2 as const;

--- a/src/persistence/migrateSnapshot.ts
+++ b/src/persistence/migrateSnapshot.ts
@@ -9,10 +9,15 @@ export type SnapshotMigration = (snapshot: unknown) => unknown;
 
 /**
  * Registry of migrations keyed by the target schema version. Populated as
- * we bump the snapshot shape across library releases. V1 has no predecessors
- * yet, so the registry is empty; the plumbing exists for the first bump.
+ * we bump the snapshot shape across library releases.
+ *
+ * V1 → V2: introduces optional `timeScale`. Old snapshots are forwarded
+ * unchanged; `timeScale` stays undefined, which lets `restore()` fall back
+ * to the constructor value and preserves pre-v2 behaviour.
  */
-export const SNAPSHOT_MIGRATIONS: Readonly<Record<number, SnapshotMigration>> = {};
+export const SNAPSHOT_MIGRATIONS: Readonly<Record<number, SnapshotMigration>> = {
+  2: (raw) => raw,
+};
 
 /**
  * Step a snapshot forward to `target` (or `CURRENT_SNAPSHOT_VERSION`) by

--- a/tests/unit/agent/Agent-persistence.test.ts
+++ b/tests/unit/agent/Agent-persistence.test.ts
@@ -269,8 +269,8 @@ describe('Agent snapshot/restore — timeScale round-trip', () => {
   it('pre-v2 snapshots without timeScale keep the restoring agent’s constructor value', async () => {
     // Simulate a legacy snapshot: no timeScale field.
     const a = new Agent(baseDeps({ timeScale: 4 }));
-    const snap = a.snapshot();
-    const legacy = { ...snap, timeScale: undefined };
+    const { timeScale: _dropped, ...legacy } = a.snapshot();
+    void _dropped;
 
     const b = new Agent(baseDeps({ timeScale: 2 }));
     await b.restore(legacy);

--- a/tests/unit/agent/Agent-persistence.test.ts
+++ b/tests/unit/agent/Agent-persistence.test.ts
@@ -6,6 +6,7 @@ import { ANIMATION_TRANSITION } from '../../../src/animation/AnimationTransition
 import type { DomainEvent } from '../../../src/events/DomainEvent.js';
 import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
 import { MOOD_CHANGED } from '../../../src/events/standardEvents.js';
+import { AgeModel } from '../../../src/lifecycle/AgeModel.js';
 import { DefaultMoodModel } from '../../../src/mood/DefaultMoodModel.js';
 import { Needs } from '../../../src/needs/Needs.js';
 import { ManualClock } from '../../../src/ports/ManualClock.js';
@@ -178,5 +179,101 @@ describe('Agent snapshot/restore — R-01 animation + mood + active skill', () =
           (e as { modifierId?: string }).modifierId === 'just-expired',
       ),
     ).toHaveLength(0);
+  });
+});
+
+describe('Agent snapshot/restore — timeScale round-trip', () => {
+  it('snapshot captures the agent’s current timeScale', () => {
+    const agent = new Agent(baseDeps({ timeScale: 4 }));
+    expect(agent.snapshot().timeScale).toBe(4);
+
+    agent.setTimeScale(8);
+    expect(agent.snapshot().timeScale).toBe(8);
+  });
+
+  it('restore applies the snapshotted timeScale onto the fresh agent', async () => {
+    const a = new Agent(baseDeps({ timeScale: 4 }));
+    const snap = a.snapshot();
+
+    const b = new Agent(baseDeps({ timeScale: 1 }));
+    expect(b.getTimeScale()).toBe(1);
+    await b.restore(snap);
+    expect(b.getTimeScale()).toBe(4);
+  });
+
+  it('catchUp uses the snapshotted timeScale, not the fresh agent’s constructor value', async () => {
+    // Schedule with no transitions in range, so ageSeconds advances freely.
+    const schedule = [{ atSeconds: 0, stage: 'adult' as const }];
+
+    // Agent A: scale 4, snapshots at wall-clock t=1000.
+    const clockA = new ManualClock(1_000);
+    const a = new Agent(
+      baseDeps({
+        clock: clockA,
+        timeScale: 4,
+        ageModel: new AgeModel({ bornAt: 0, schedule, initialAgeSeconds: 0 }),
+      }),
+    );
+    const snap = a.snapshot();
+
+    // Agent B: scale 1 constructor value. Fresh clock 2 wall seconds later.
+    // Pre-fix: catch-up scaled 2000 ms by 1 → 2 virtual seconds of aging.
+    // Post-fix: scales by the snapshotted 4 → 8 virtual seconds.
+    const clockB = new ManualClock(3_000);
+    const b = new Agent(
+      baseDeps({
+        clock: clockB,
+        timeScale: 1,
+        ageModel: new AgeModel({ bornAt: 0, schedule, initialAgeSeconds: 0 }),
+      }),
+    );
+
+    await b.restore(snap, { catchUp: { chunkVirtualSeconds: 1_000 } });
+
+    expect(b.getTimeScale()).toBe(4);
+    expect(b.getState().ageSeconds).toBeCloseTo(8, 9);
+  });
+
+  it('setTimeScale(0) with catchUp: true completes cleanly (no NaN, no throw)', async () => {
+    // Snapshot at scale 0, then restore into a fresh agent with catchUp.
+    // elapsedSec = elapsedMs * 0 = 0, so runCatchUp is a no-op. Contract:
+    // no division-by-zero leaks out and the fresh agent adopts scale 0.
+    const schedule = [{ atSeconds: 0, stage: 'adult' as const }];
+    const clockA = new ManualClock(1_000);
+    const a = new Agent(
+      baseDeps({
+        clock: clockA,
+        timeScale: 60,
+        ageModel: new AgeModel({ bornAt: 0, schedule, initialAgeSeconds: 0 }),
+      }),
+    );
+    a.setTimeScale(0);
+    const snap = a.snapshot();
+    expect(snap.timeScale).toBe(0);
+
+    const clockB = new ManualClock(5_000);
+    const b = new Agent(
+      baseDeps({
+        clock: clockB,
+        timeScale: 1,
+        ageModel: new AgeModel({ bornAt: 0, schedule, initialAgeSeconds: 0 }),
+      }),
+    );
+    await b.restore(snap, { catchUp: true });
+
+    expect(b.getTimeScale()).toBe(0);
+    expect(Number.isNaN(b.getState().ageSeconds)).toBe(false);
+    expect(b.getState().ageSeconds).toBe(0);
+  });
+
+  it('pre-v2 snapshots without timeScale keep the restoring agent’s constructor value', async () => {
+    // Simulate a legacy snapshot: no timeScale field.
+    const a = new Agent(baseDeps({ timeScale: 4 }));
+    const snap = a.snapshot();
+    const legacy = { ...snap, timeScale: undefined };
+
+    const b = new Agent(baseDeps({ timeScale: 2 }));
+    await b.restore(legacy);
+    expect(b.getTimeScale()).toBe(2);
   });
 });

--- a/tests/unit/agent/Agent-persistence.test.ts
+++ b/tests/unit/agent/Agent-persistence.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Agent, type AgentDependencies } from '../../../src/agent/Agent.js';
+import { InvalidTimeScaleError } from '../../../src/agent/errors.js';
 import type { AgentIdentity } from '../../../src/agent/AgentIdentity.js';
 import { AnimationStateMachine } from '../../../src/animation/AnimationStateMachine.js';
 import { ANIMATION_TRANSITION } from '../../../src/animation/AnimationTransitionEvent.js';
@@ -264,6 +265,24 @@ describe('Agent snapshot/restore — timeScale round-trip', () => {
     expect(b.getTimeScale()).toBe(0);
     expect(Number.isNaN(b.getState().ageSeconds)).toBe(false);
     expect(b.getState().ageSeconds).toBe(0);
+  });
+
+  it('restore rejects a snapshot whose timeScale is corrupted', async () => {
+    const a = new Agent(baseDeps({ timeScale: 4 }));
+    const snap = a.snapshot();
+
+    const b = new Agent(baseDeps({ timeScale: 1 }));
+    await expect(b.restore({ ...snap, timeScale: -1 })).rejects.toBeInstanceOf(
+      InvalidTimeScaleError,
+    );
+    // Failed restore must not have mutated the agent's timeScale.
+    expect(b.getTimeScale()).toBe(1);
+
+    const c = new Agent(baseDeps({ timeScale: 1 }));
+    await expect(c.restore({ ...snap, timeScale: Number.NaN })).rejects.toBeInstanceOf(
+      InvalidTimeScaleError,
+    );
+    expect(c.getTimeScale()).toBe(1);
   });
 
   it('pre-v2 snapshots without timeScale keep the restoring agent’s constructor value', async () => {


### PR DESCRIPTION
## Summary

Closes **Priority 1** of `.claude/plans/pre-v1-next-session.md` — the v1 blocker.

`restore({ catchUp: true })` previously scaled elapsed wall time by the **rehydrating** agent's `timeScale` rather than the one in effect at save time. A consumer who snapshotted at scale 60 and restored into a fresh agent at scale 1 therefore saw a divergent catch-up.

- Add optional `timeScale` to `AgentSnapshot`; bump `schemaVersion` 1 → 2.
- Register a v1 → v2 no-op migration; missing field falls back to the constructor value, preserving legacy behaviour for pre-v2 snapshots.
- `snapshot()` captures `this.timeScale`; `restore()` applies it **before** the catch-up block so the catch-up runs at the snapshotted cadence.
- +5 persistence tests: round-trip, catchUp uses snapshotted scale, scale 0 + catchUp is a clean no-op, pre-v2 fallback.

Groundwork for R-08 per-subsystem snapshot versioning.

## Test plan

- [x] `npm test` — 298 passing (+5 over 293 baseline)
- [x] `npm run typecheck` — strict + `exactOptionalPropertyTypes` clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] Changeset added (`.changeset/snapshot-persist-timescale.md`, minor bump)

## Risk

Low. Schema change is covered by the migration registry and is additive. Agents that never snapshot/restore see identical behaviour.

https://claude.ai/code/session_0184U834WsqhLeZBq7D675pJ