### PR TITLE
feat: freeze modifier/mood/animation reconciliation at scale 0 (Option A)

### DIFF
--- a/.changeset/pause-freeze-reconciliation.md
+++ b/.changeset/pause-freeze-reconciliation.md
@@ -1,0 +1,21 @@
+---
+'agentonomous': minor
+---
+
+`setTimeScale(0)` now genuinely freezes the agent — modifier expiry
+(Stage 2), mood reconciliation (Stage 2.7), and animation reconciliation
+(Stage 2.8) are skipped while the scale is zero, so no
+`ModifierExpired`, `MoodChanged`, or `AnimationTransition` events leak
+during a pause.
+
+`Modifier.expiresAt` is still an absolute wall-clock ms. If a modifier
+would have expired during the pause, `ModifiersTicker` detects it on
+the first post-resume tick and emits `ModifierExpired` then — the event
+is deferred, not cancelled, and not duplicated.
+
+Adopts **Option A** of `.claude/plans/pause-semantics.md`. The more
+invasive virtual-time-based expiry (Option B) remains a Phase B
+consideration alongside R-08.
+
+Additive: agents that never call `setTimeScale(0)` see identical
+behaviour.

--- a/.claude/plans/pause-semantics.md
+++ b/.claude/plans/pause-semantics.md
@@ -1,0 +1,67 @@
+# Pause semantics for `setTimeScale(0)`
+
+Status: **Option A adopted for Phase A**. Option B is the documented
+Phase B upgrade path.
+
+## Problem
+
+`Agent.setTimeScale(0)` was introduced as a soft pause — virtual-time
+progress (needs decay, aging, random events) halts without the terminal
+effects of `kill(reason)`. However, three reconciliation stages still run
+every wall-clock tick at scale 0:
+
+| Stage | Component             | Driven by                  |
+| ----- | --------------------- | -------------------------- |
+| 2     | `ModifiersTicker`     | wall-clock `tickStartedAt` |
+| 2.7   | `MoodReconciler`      | wall-clock `tickStartedAt` |
+| 2.8   | `AnimationReconciler` | wall-clock `tickStartedAt` |
+
+A paused pet therefore still emits `ModifierExpired`,
+`MoodChanged`, and `AnimationTransition` events. The nurture-pet demo
+works around this with a "paused" HUD badge, but the underlying
+asymmetry surprises consumers (scripted playback, UI-paused cutscenes)
+and leaks wall-clock-driven state changes into what consumers reasonably
+expect to be a frozen snapshot of the agent.
+
+## Option A — Skip reconciliation stages at scale 0 (Phase A)
+
+- **Change:** `tick()` short-circuits Stages 2, 2.7, and 2.8 when
+  `this.timeScale === 0`. Other stages (perception drain, autosave,
+  cognition dispatch) still run — scripted and remote controllers can
+  drive actions during a pause because they don't rely on virtual dt.
+- **Modifier expiry semantics:** `expiresAt` remains an absolute
+  wall-clock ms. If a modifier would have expired during a pause,
+  `ModifiersTicker` detects it on the first post-resume tick and emits
+  `ModifierExpired` then — the event is deferred, not cancelled, and
+  not duplicated. This matches how consumers already treat the tick as
+  the unit of observable state change.
+- **Animation:** `AnimationStateMachine.current()` is unchanged during a
+  pause; no `AnimationTransition` fires. Rotation that _would have_ been
+  triggered by dwelling in a state past `minDwellMs` resumes on the
+  first post-resume tick.
+- **Mood:** category stays latched until the next post-resume
+  reconciliation.
+- **Additive, no breaking change.** Consumers that don't pause see
+  identical behaviour.
+
+## Option B — Virtual-time-based reconciliation (Phase B)
+
+- **Change:** re-base `expiresAt`, `minDwellMs`, and mood reconciliation
+  windows on `virtualNowSeconds` instead of wall-clock `tickStartedAt`.
+- **Implication:** pausing genuinely _extends_ modifier lifetimes —
+  `expiresAt` becomes a virtual-time cursor and doesn't advance while
+  the agent is paused.
+- **Breaking change.** Consumers who relied on `Modifier.expiresAt`
+  being an absolute wall-clock ms (e.g. HUD countdowns computed as
+  `expiresAt - wallNow`) must migrate to `virtualExpiresAt - virtualNow`.
+- **Tracking:** revisit alongside R-08 per-subsystem snapshot
+  versioning, since the modifier snapshot shape changes too.
+
+## Why Option A now
+
+- No schema change, no consumer migration, no new field.
+- Closes the "paused pets still emit events" bug for the demo path and
+  Phase B's scripted-playback use cases.
+- Preserves the existing `Modifier.expiresAt` contract. Option B's
+  shift can be planned deliberately once virtual-time exposure in the
+  public API is ready.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,9 @@ the same PR.
   and lives in its own bundle entry.
 - **Random events:** `emit()` receives a factory — seed comes from the
   context, never `Math.random()`.
+- **`setTimeScale(0)` pause semantics:** Stage 2 / 2.7 / 2.8 (modifier
+  expiry, mood, animation reconciliation) are skipped at scale 0 to
+  keep the pause observably frozen. `Modifier.expiresAt` is still an
+  absolute wall-clock ms — deferred expiry fires on the first
+  post-resume tick. Phase B may re-base expiry on virtual time;
+  see `.claude/plans/pause-semantics.md`.

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -301,7 +301,12 @@ export class Agent {
    */
   async tick(dtSeconds: number): Promise<DecisionTrace> {
     const tickStartedAt = this.clock.now();
-    const virtualDtSeconds = Math.max(0, dtSeconds) * this.timeScale;
+    // Snapshot timeScale once at tick entry so a mid-tick setTimeScale()
+    // from a reactive handler (Stage 1) takes effect on the NEXT tick,
+    // as documented on `setTimeScale()`. Both `virtualDtSeconds` and the
+    // Stage 2/2.7/2.8 pause gate read from this local.
+    const tickTimeScale = this.timeScale;
+    const virtualDtSeconds = Math.max(0, dtSeconds) * tickTimeScale;
 
     // Stage -1: halted short-circuit.
     if (this.halted) {
@@ -336,7 +341,9 @@ export class Agent {
     // (modifier expiry, mood, animation), so consumers see a consistently
     // frozen agent while paused. Deferred expiries fire on the first
     // post-resume tick — see `.claude/plans/pause-semantics.md` (Option A).
-    const paused = this.timeScale === 0;
+    // Read from the tick-entry snapshot so a reactive handler that called
+    // `setTimeScale(0)` during Stage 1 doesn't flip the gate mid-tick.
+    const paused = tickTimeScale === 0;
 
     // Stage 2: modifier tick — expire time-bound modifiers. Skipped at
     // scale 0; `expiresAt` is still absolute wall-clock ms, so any

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -331,8 +331,18 @@ export class Agent {
     this.virtualNowSeconds += virtualDtSeconds;
     this.runRandomEventsTick(virtualDtSeconds, tickStartedAt);
 
-    // Stage 2: modifier tick — expire time-bound modifiers.
-    const expired = this.modifiersTicker.run(tickStartedAt);
+    // Pause short-circuit: `setTimeScale(0)` freezes not just virtual-time
+    // progress but also the three wall-clock-driven reconciliation stages
+    // (modifier expiry, mood, animation), so consumers see a consistently
+    // frozen agent while paused. Deferred expiries fire on the first
+    // post-resume tick — see `.claude/plans/pause-semantics.md` (Option A).
+    const paused = this.timeScale === 0;
+
+    // Stage 2: modifier tick — expire time-bound modifiers. Skipped at
+    // scale 0; `expiresAt` is still absolute wall-clock ms, so any
+    // modifier whose window elapses during the pause is detected here
+    // on the first post-resume tick.
+    const expired = paused ? [] : this.modifiersTicker.run(tickStartedAt);
 
     // Stage 2.5: needs tick. Decay (scaled by modifier multipliers), critical crossings → events.
     // If health just hit 0 during decay we die here and short-circuit.
@@ -351,10 +361,10 @@ export class Agent {
       };
     }
 
-    // Stage 2.7: mood evaluate.
-    const moodChange = this.moodReconciler.run(tickStartedAt);
-    // Stage 2.8: animation reconcile.
-    const animationTransition = this.animationReconciler.run(tickStartedAt);
+    // Stage 2.7: mood evaluate. Skipped at scale 0.
+    const moodChange = paused ? null : this.moodReconciler.run(tickStartedAt);
+    // Stage 2.8: animation reconcile. Skipped at scale 0.
+    const animationTransition = paused ? null : this.animationReconciler.run(tickStartedAt);
 
     // Stages 3–7: cognition pipeline. `collectActions` dispatches by
     // control mode (autonomous → reasoner + behavior runner, else
@@ -492,11 +502,12 @@ export class Agent {
    *
    * Applies from the NEXT `tick()` onward — the in-flight tick (if any)
    * keeps its original scale, so determinism under a fixed clock + rng is
-   * preserved. Pass `0` to freeze virtual-time-driven progress (needs
-   * decay, aging, random events) without killing the agent. Note that
-   * modifier expiry, mood reconciliation, and animation transitions are
-   * keyed off wall-clock time and therefore continue to advance even at
-   * scale `0`. Use `kill(reason)` for terminal halts.
+   * preserved. Pass `0` to freeze the agent: virtual-time-driven progress
+   * (needs decay, aging, random events) halts AND the wall-clock-driven
+   * reconciliation stages (modifier expiry, mood, animation) are skipped,
+   * so no state transitions leak while paused. `Modifier.expiresAt` is
+   * still an absolute wall-clock ms — deferred expiries fire on the first
+   * post-resume tick. Use `kill(reason)` for terminal halts.
    *
    * Throws `InvalidTimeScaleError` if `scale` is not finite or is
    * negative.

--- a/tests/unit/agent/Agent-pause.test.ts
+++ b/tests/unit/agent/Agent-pause.test.ts
@@ -125,6 +125,71 @@ describe('Agent pause semantics (setTimeScale(0) — Option A)', () => {
     expect(types.filter((t) => t === ANIMATION_TRANSITION)).toEqual([]);
   });
 
+  it('a reactive handler calling setTimeScale(0) does NOT flip the pause gate mid-tick', async () => {
+    // Contract (see setTimeScale JSDoc): a scale change applies from the
+    // NEXT tick. If a Stage-1 reactive handler calls setTimeScale(0), the
+    // current tick must still run Stages 2/2.7/2.8 using the tick-entry
+    // scale. Otherwise a single handler could desynchronize virtual-time
+    // progress (already committed in this tick) from reconciliation
+    // (skipped by a mid-tick flip).
+    const clock = new ManualClock(0);
+    const bus = new InMemoryEventBus();
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock,
+      rng: 0,
+      eventBus: bus,
+      lifecycle: [{ stage: 'adult', atSeconds: 0 }],
+      modules: [
+        {
+          id: 'pause-trap',
+          reactiveHandlers: [
+            {
+              on: 'TestTrigger',
+              handle: () => {
+                // Flip scale to 0 during Stage 1 of the current tick.
+                agent.setTimeScale(0);
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    // Seed an expiring modifier so Stage 2 has work to do.
+    agent.applyModifier({
+      id: 'well-fed',
+      source: 'skill:feed',
+      appliedAt: 0,
+      expiresAt: 1_000,
+      stack: 'replace',
+      effects: [],
+    });
+
+    // Queue the trigger event so it's drained in Stage 1 of the next tick.
+    bus.publish({ type: 'TestTrigger', at: 0 } as never);
+
+    // Advance wall clock past the modifier's expiresAt so Stage 2 has a
+    // real expiry to surface if the gate is NOT flipped.
+    clock.set(2_000);
+
+    const listener = vi.fn();
+    bus.subscribe(listener);
+
+    const trace = await agent.tick(0.016);
+
+    // The tick started with scale == 1, so reconciliation must have run
+    // and the modifier must have expired in this same tick.
+    const types = listener.mock.calls.map((a) => (a[0] as { type: string }).type);
+    expect(types.filter((t) => t === MODIFIER_EXPIRED)).toHaveLength(1);
+    expect(trace.deltas?.modifiersExpired).toEqual(['well-fed']);
+    expect(agent.modifiers.has('well-fed')).toBe(false);
+
+    // The scale flip persists for the NEXT tick.
+    expect(agent.getTimeScale()).toBe(0);
+  });
+
   it('resumes reconciliation cleanly on the first tick after scale becomes positive', async () => {
     const clock = new ManualClock(0);
     const bus = new InMemoryEventBus();

--- a/tests/unit/agent/Agent-pause.test.ts
+++ b/tests/unit/agent/Agent-pause.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAgent } from '../../../src/agent/createAgent.js';
+import { ANIMATION_TRANSITION } from '../../../src/animation/AnimationTransitionEvent.js';
+import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
+import { MODIFIER_EXPIRED, MOOD_CHANGED } from '../../../src/events/standardEvents.js';
+import { ManualClock } from '../../../src/ports/ManualClock.js';
+
+describe('Agent pause semantics (setTimeScale(0) — Option A)', () => {
+  it('defers ModifierExpired while paused and fires it on the first post-resume tick', async () => {
+    const clock = new ManualClock(0);
+    const bus = new InMemoryEventBus();
+    const listener = vi.fn();
+    bus.subscribe(listener);
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock,
+      rng: 0,
+      eventBus: bus,
+    });
+    agent.applyModifier({
+      id: 'well-fed',
+      source: 'skill:feed',
+      appliedAt: 0,
+      expiresAt: 1_000,
+      stack: 'replace',
+      effects: [],
+    });
+
+    agent.setTimeScale(0);
+
+    // Advance wall-clock past the modifier's expiresAt while paused.
+    clock.set(2_000);
+    const pausedTrace = await agent.tick(0.016);
+
+    const pausedTypes = listener.mock.calls.map((a) => (a[0] as { type: string }).type);
+    expect(pausedTypes.filter((t) => t === MODIFIER_EXPIRED)).toEqual([]);
+    expect(pausedTrace.deltas?.modifiersExpired).toBeUndefined();
+    // Modifier remains on the agent during the pause.
+    expect(agent.modifiers.has('well-fed')).toBe(true);
+
+    listener.mockClear();
+
+    // Resume. The first post-resume tick detects the expiry and emits.
+    agent.setTimeScale(1);
+    clock.set(2_100);
+    const resumedTrace = await agent.tick(0.016);
+
+    const resumedTypes = listener.mock.calls.map((a) => (a[0] as { type: string }).type);
+    expect(resumedTypes.filter((t) => t === MODIFIER_EXPIRED)).toHaveLength(1);
+    expect(resumedTrace.deltas?.modifiersExpired).toEqual(['well-fed']);
+    expect(agent.modifiers.has('well-fed')).toBe(false);
+  });
+
+  it('does not emit MoodChanged while paused', async () => {
+    const clock = new ManualClock(0);
+    const bus = new InMemoryEventBus();
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock,
+      rng: 0,
+      eventBus: bus,
+      needs: [
+        { id: 'hunger', level: 0.9, decayPerSec: 0, criticalThreshold: 0.2 },
+        { id: 'energy', level: 0.9, decayPerSec: 0 },
+      ],
+      lifecycle: [{ stage: 'adult', atSeconds: 0 }],
+    });
+
+    // First tick establishes initial mood category.
+    await agent.tick(0.016);
+    const initialMood = agent.getState().mood?.category;
+    expect(initialMood).toBeDefined();
+
+    const listener = vi.fn();
+    bus.subscribe(listener);
+
+    // Flip a need into a state that would normally rotate the mood on the
+    // next reconciliation tick.
+    agent.needs?.restore({ hunger: 0.05, energy: 0.9 });
+
+    agent.setTimeScale(0);
+    clock.set(1_000);
+    await agent.tick(0.016);
+
+    const types = listener.mock.calls.map((a) => (a[0] as { type: string }).type);
+    expect(types.filter((t) => t === MOOD_CHANGED)).toEqual([]);
+    // Mood category is latched across the pause.
+    expect(agent.getState().mood?.category).toBe(initialMood);
+  });
+
+  it('does not emit AnimationTransition while paused', async () => {
+    const clock = new ManualClock(0);
+    const bus = new InMemoryEventBus();
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock,
+      rng: 0,
+      eventBus: bus,
+      lifecycle: [{ stage: 'adult', atSeconds: 0 }],
+    });
+
+    // Warm up — let the first tick run any initial animation rotation.
+    await agent.tick(0.016);
+
+    const listener = vi.fn();
+    bus.subscribe(listener);
+
+    agent.setTimeScale(0);
+    // Applying a modifier that would normally drive a forced animation
+    // (e.g. sick) still doesn't emit a transition during the pause.
+    agent.applyModifier({
+      id: 'sick',
+      source: 'event:illness',
+      appliedAt: 0,
+      stack: 'replace',
+      effects: [],
+    });
+    clock.set(500);
+    await agent.tick(0.016);
+
+    const types = listener.mock.calls.map((a) => (a[0] as { type: string }).type);
+    expect(types.filter((t) => t === ANIMATION_TRANSITION)).toEqual([]);
+  });
+
+  it('resumes reconciliation cleanly on the first tick after scale becomes positive', async () => {
+    const clock = new ManualClock(0);
+    const bus = new InMemoryEventBus();
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock,
+      rng: 0,
+      eventBus: bus,
+      lifecycle: [{ stage: 'adult', atSeconds: 0 }],
+    });
+    await agent.tick(0.016);
+
+    agent.setTimeScale(0);
+    agent.applyModifier({
+      id: 'sick',
+      source: 'event:illness',
+      appliedAt: 0,
+      stack: 'replace',
+      effects: [],
+    });
+    clock.set(500);
+    await agent.tick(0.016);
+
+    const listener = vi.fn();
+    bus.subscribe(listener);
+
+    agent.setTimeScale(1);
+    clock.set(600);
+    await agent.tick(0.016);
+
+    // Post-resume, the animation reconciler fires and rotates to 'sick'.
+    const animEvents = listener.mock.calls
+      .map((a) => a[0] as { type: string; to?: string })
+      .filter((e) => e.type === ANIMATION_TRANSITION);
+    expect(animEvents.some((e) => e.to === 'sick')).toBe(true);
+    expect(agent.getState().animation).toBe('sick');
+  });
+});


### PR DESCRIPTION
## Summary

Closes **Priority 2** of `.claude/plans/pre-v1-next-session.md`.

`setTimeScale(0)` previously left three wall-clock-driven stages of the tick pipeline running: modifier expiry (Stage 2), mood reconciliation (Stage 2.7), and animation reconciliation (Stage 2.8). A paused pet therefore still emitted `ModifierExpired`, `MoodChanged`, and `AnimationTransition` events, which surprised consumers expecting a truly frozen agent.

**Adopts Option A** of the design note (additive, no breaking change):

- Short-circuit Stages 2 / 2.7 / 2.8 when `this.timeScale === 0`.
- **Deferred expiry:** `Modifier.expiresAt` remains an absolute wall-clock ms. If a modifier's window elapses during the pause, `ModifiersTicker` detects it on the first post-resume tick — the event is deferred, not cancelled, and not duplicated.
- Refreshed `setTimeScale` JSDoc to document the new semantics.
- CLAUDE.md pitfalls section now points at `.claude/plans/pause-semantics.md`.

Option B (virtual-time-based expiry, breaking change) is documented in the design note as the Phase B upgrade path, tracked alongside R-08.

## Commits

1. `docs: design note for setTimeScale(0) pause semantics (Option A vs B)` — adds `.claude/plans/pause-semantics.md` + CLAUDE.md cross-reference.
2. `feat: freeze modifier/mood/animation reconciliation at scale 0 (Option A)` — implementation + 4 new tests in `Agent-pause.test.ts`.

## Test plan

- [x] `npm test` — 297 passing (+4 `Agent-pause.test.ts` cases)
  - defers `ModifierExpired` while paused; fires on first post-resume tick
  - no `MoodChanged` during pause even when the mood would rotate
  - no `AnimationTransition` during pause even with a forced-animation modifier
  - post-resume reconciliation fires cleanly
- [x] `npm run typecheck`, `lint`, `format:check`, `build` — clean
- [x] Changeset added (`.changeset/pause-freeze-reconciliation.md`, minor bump)

## Risk

Low / additive. Agents that never call `setTimeScale(0)` see identical behaviour. The nurture-pet demo's "paused" chip label continues to work without change; the underlying tick stream just no longer contradicts it.

**Note:** this PR stacks logically on top of #7 but does not conflict with it — tested against `develop` HEAD directly. Either can land first.

https://claude.ai/code/session_0184U834WsqhLeZBq7D675pJ