### PR TITLE
feat(demo): add Export / Import snapshot buttons to nurture-pet

### DIFF
--- a/examples/nurture-pet/index.html
+++ b/examples/nurture-pet/index.html
@@ -167,6 +167,14 @@
       .reset-button:hover {
         background: #64748b;
       }
+      .io-button {
+        padding: 6px 10px;
+        font-size: 13px;
+        background: #64748b;
+      }
+      .io-button:hover {
+        background: #475569;
+      }
       .modifiers li {
         display: inline-flex;
         align-items: center;
@@ -217,6 +225,9 @@
       <div class="speed">
         <span class="speed-label">Speed</span>
         <div class="speed-buttons" id="speed-picker"></div>
+        <button id="export-button" class="io-button" type="button">💾 Export</button>
+        <button id="import-button" class="io-button" type="button">📂 Import</button>
+        <input id="import-file" type="file" accept="application/json,.json" hidden />
         <button id="reset-button" class="reset-button" type="button">🔄 Reset</button>
       </div>
       <div class="bars" id="bars"></div>

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -11,7 +11,7 @@ import {
   bindAgentToStore,
 } from 'agentonomous';
 import { catSpecies } from './species.js';
-import { mountHud, mountResetButton, mountSpeedPicker } from './ui.js';
+import { mountExportImport, mountHud, mountResetButton, mountSpeedPicker } from './ui.js';
 
 const STORAGE_KEY = 'whiskers';
 const SPEED_STORAGE_KEY = 'whiskers:speed';
@@ -67,6 +67,7 @@ const pet = createAgent({
 // --- Mount UI + reactive binding ----------------------------------------------
 const hud = mountHud(pet);
 mountSpeedPicker(pet, { baseScale: BASE_TIME_SCALE, storageKey: SPEED_STORAGE_KEY });
+mountExportImport(pet);
 mountResetButton(pet);
 bindAgentToStore(pet, (state) => {
   hud.update(state);

--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -245,6 +245,75 @@ export function resetSimulation(agentId: string): void {
 }
 
 /**
+ * Mount Export / Import buttons that let the player save the current pet
+ * to a JSON file and restore it later. Export serializes
+ * `agent.snapshot()` to JSON and triggers a browser download; Import
+ * reads a JSON file, parses it, and hands the payload to
+ * `agent.restore(snapshot, { catchUp: false })`. `catchUp: false` keeps
+ * the imported snapshot's virtual-time cursor stable — the player sees
+ * the pet exactly as it was at save time, not fast-forwarded by the wall
+ * clock that elapsed between export and import.
+ *
+ * Errors are surfaced via `alert()` — intentional Phase A ergonomics;
+ * the demo never blocks on a Promise rejection during the import flow.
+ */
+export function mountExportImport(agent: Agent): void {
+  const exportBtn = document.getElementById('export-button');
+  const importBtn = document.getElementById('import-button');
+  const fileInput = document.getElementById('import-file') as HTMLInputElement | null;
+  if (!exportBtn || !importBtn || !fileInput) return;
+
+  exportBtn.setAttribute('aria-label', `Export ${agent.identity.name ?? agent.identity.id}`);
+  importBtn.setAttribute(
+    'aria-label',
+    `Import a saved ${agent.identity.name ?? agent.identity.id}`,
+  );
+
+  exportBtn.addEventListener('click', () => {
+    try {
+      const snap = agent.snapshot();
+      const blob = new Blob([JSON.stringify(snap, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `${agent.identity.id}.json`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      globalThis.alert?.(`Export failed: ${(err as Error).message}`);
+    }
+  });
+
+  importBtn.addEventListener('click', () => {
+    fileInput.click();
+  });
+
+  fileInput.addEventListener('change', () => {
+    const file = fileInput.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = typeof reader.result === 'string' ? reader.result : '';
+      fileInput.value = ''; // allow re-importing the same file name
+      try {
+        const parsed = JSON.parse(text) as Parameters<Agent['restore']>[0];
+        void agent.restore(parsed, { catchUp: false }).catch((err: Error) => {
+          globalThis.alert?.(`Import failed: ${err.message}`);
+        });
+      } catch (err) {
+        globalThis.alert?.(`Import failed: ${(err as Error).message}`);
+      }
+    };
+    reader.onerror = () => {
+      globalThis.alert?.('Import failed: could not read file.');
+    };
+    reader.readAsText(file);
+  });
+}
+
+/**
  * Mount the persistent "Reset" button. Clicking it confirms the action,
  * then calls `resetSimulation(agentId)`. The confirm dialog guards against
  * accidental clicks since reset is destructive (lifetime stats lost).

--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -299,6 +299,14 @@ export function mountExportImport(agent: Agent): void {
       fileInput.value = ''; // allow re-importing the same file name
       try {
         const parsed = JSON.parse(text) as Parameters<Agent['restore']>[0];
+        // `snapshot()` omits the `modifiers` field when the list is empty,
+        // and `restore()` only touches modifiers when the field is present.
+        // That means importing a clean save over a sick/dirty pet would
+        // leave stale modifiers active. Clear them explicitly before
+        // restore so the imported state wins cleanly.
+        for (const mod of agent.modifiers.list()) {
+          agent.removeModifier(mod.id);
+        }
         void agent.restore(parsed, { catchUp: false }).catch((err: Error) => {
           globalThis.alert?.(`Import failed: ${err.message}`);
         });


### PR DESCRIPTION
## Summary

Closes **Priority 3** of `.claude/plans/pre-v1-next-session.md` — the last meaningful P2 item from the original session brief. Demo-only; **no library changes, no changeset.**

The nurture-pet demo can now save the current pet to a JSON file and restore one from disk.

- `mountExportImport(agent)` in `ui.ts` wires two HUD buttons.
  - **💾 Export** — `agent.snapshot()` → pretty-printed JSON → `<a download="whiskers.json">` click, with automatic URL revocation.
  - **📂 Import** — hidden `<input type="file">` → `FileReader.readAsText` → `JSON.parse` → `agent.restore(snap, { catchUp: false })`. Errors surface via `alert()` (intentional Phase A ergonomics).
- `catchUp: false` keeps the imported snapshot's virtual-time cursor stable — the player sees the pet exactly as it was at save time, not fast-forwarded by elapsed wall time between export and import.
- Add `💾 Export`, `📂 Import`, and a hidden file input next to the reset button in `index.html`, with `.io-button` styling that matches the existing speed row.
- Wired from `main.ts`.

## Test plan

- [x] `npm run demo:build` — library + demo build clean
- [x] Library tests still green (no library files touched)
- [ ] Manual smoke: export → refresh → import round-trips pet state

## Risk

Demo-only. The library's `snapshot()` / `restore()` surface is already battle-tested by 14 persistence unit tests. No new failure modes introduced.

**Depends on nothing in #7 or #8** — builds against `develop` HEAD directly. `restore({ catchUp: false })` avoids the bug that #7 fixes, so this PR is safe to land before #7.

https://claude.ai/code/session_0184U834WsqhLeZBq7D675pJ