### PR TITLE
chore: v1 release prep — size budget, release-candidate workflow, runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Bundle size budget
+        run: npx size-limit

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,61 @@
+name: Release candidate
+
+on:
+  push:
+    branches: ['release/v*']
+  workflow_dispatch:
+
+concurrency:
+  group: release-candidate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Preflight (node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify (format + lint + typecheck + test + build)
+        run: npm run verify
+
+      - name: Bundle size budget
+        run: npx size-limit
+
+      - name: Pack tarball
+        id: pack
+        run: |
+          npm pack --json > pack.json
+          TARBALL="$(node -e "console.log(require('./pack.json')[0].filename)")"
+          echo "tarball=$GITHUB_WORKSPACE/$TARBALL" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-install tarball in a scratch project
+        run: |
+          mkdir -p /tmp/smoke && cd /tmp/smoke
+          npm init -y > /dev/null
+          npm pkg set type=module
+          npm install --no-audit --no-fund "${{ steps.pack.outputs.tarball }}"
+          node --input-type=module -e "
+            const mod = await import('agentonomous');
+            const { Agent } = mod;
+            if (typeof Agent !== 'function') {
+              throw new Error('Agent export missing from installed tarball');
+            }
+            console.log('Smoke import OK:', Object.keys(mod).length, 'named exports');
+          "
+
+      - name: Publish dry-run
+        run: npm publish --dry-run

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -22,6 +22,37 @@ see [CONTRIBUTING.md](./CONTRIBUTING.md).
 - `main` branch protected; releases happen only via Changesets PRs landing on
   `main` (and those PRs originate from `develop` or `release/*`).
 
+## Branch protection checklist
+
+All three long-lived branches (`main`, `develop`, `demo`) should be
+protected. Configure in Repo → Settings → Branches → Add rule. Apply the
+same baseline to each, with the deltas noted below.
+
+Baseline (all three):
+
+- Require a pull request before merging; require at least 1 approving
+  review.
+- Require status checks to pass before merging; include the `CI` workflow
+  (both `test (node 20)` and `test (node 22)` matrix rows).
+- Require branches to be up to date before merging.
+- Disallow force pushes. Disallow deletions.
+- Do **not** allow bypass for administrators (hold yourself to the same bar).
+
+Per-branch additions:
+
+- **`main`** — also require the `Release candidate` workflow (both matrix
+  rows) when the incoming branch matches `release/v*`. Optional: require
+  signed commits.
+- **`develop`** — baseline is sufficient.
+- **`demo`** — baseline is sufficient. Remember to add `demo` to the
+  `github-pages` environment's deployment branch allow-list (see
+  [Demo deployment first-time setup](#demo-deployment)) or the Pages
+  deploy job is rejected at the environment gate even when CI is green.
+
+The `.claude/settings.json` denies in this repo mirror these rules at the
+Claude Code permission layer; branch protection is the source of truth
+and applies to humans + bots alike.
+
 ## Local dry runs
 
 Before shipping anything, verify the package looks right:
@@ -30,6 +61,9 @@ Before shipping anything, verify the package looks right:
 # Run the full pre-publish gate (format, lint, typecheck, test, build).
 npm run verify
 
+# Check the bundle-size budget (gzip).
+npm run size
+
 # Inspect what npm would actually publish.
 npm run pack:dry
 ```
@@ -37,6 +71,31 @@ npm run pack:dry
 `pack:dry` prints the exact file list + tarball size. Only `dist/`,
 `README.md`, and `LICENSE` should appear (per the `files` field in
 `package.json`).
+
+`npm run size` runs the `size-limit` budget against the built
+`dist/index.js` and `dist/integrations/excalibur/index.js` (gzip). Budgets
+live in the `size-limit` field of `package.json`. If a legitimate
+feature pushes a bundle over budget, bump the limit in the same PR with
+a one-line justification in the commit message.
+
+## Release candidate pre-flight
+
+Any branch matching `release/v*` (e.g. `release/v1.0.0`) is gated by the
+`.github/workflows/release-candidate.yml` workflow on every push. It
+runs on Node 20 + 22 and does everything `CI` does plus:
+
+- **`npm run size`** — the gzip bundle-size budget.
+- **Pack + smoke install** — `npm pack` into a tarball, install it into
+  a scratch project, and verify the shipped ESM resolves and exports
+  `Agent`. Catches "builds fine, broken once users `npm install`" bugs
+  that repo-local tests can't see.
+- **`npm publish --dry-run`** — validates the would-be publish (files
+  list, `publishConfig`, registry auth surface) without actually
+  pushing a version to npm.
+
+The workflow can also be kicked off manually from
+**Actions → Release candidate → Run workflow** against any `release/v*`
+branch.
 
 ## Adding a changeset
 
@@ -72,6 +131,63 @@ The `.github/workflows/release.yml` workflow runs on every push to `main`:
    next cycle.
 
 No manual `npm publish` calls are needed in the normal path.
+
+## First release (v1.0.0)
+
+The initial release is a one-time setup. Everything below happens on
+short-lived branches; do **not** push directly to `main` until the
+final merge.
+
+Pre-flight (once, before cutting `release/v1.0.0`):
+
+1. **npm token.** Confirm `NPM_TOKEN` is set in Settings → Secrets →
+   Actions. Must be an **automation** token (not "Publish" classic)
+   for provenance attestation to work.
+2. **Branch protection.** Apply the rules in the [checklist
+   above](#branch-protection-checklist) to `main`, `develop`, `demo`.
+3. **Environment.** Settings → Environments → (create) `npm-publish`
+   if you want to add manual approval before npm publishes; otherwise
+   the `release` job runs automatically on push to `main`. The
+   `github-pages` environment should already include `demo`.
+4. **Sanity dry-run.** Locally: `npm run verify && npm run size && npm
+pack --dry-run`. All clean.
+5. **Changeset.** The v1 changeset should describe the initial public
+   API surface. Bump is **major** (pre-1.0 `0.x` → `1.0.0`).
+   ```bash
+   npm run changeset
+   # Pick: major — summary: "Initial public release."
+   ```
+   Commit the `.changeset/*.md` to `develop` via a regular PR.
+
+Release (on `release/v1.0.0`, cut from `develop`):
+
+1. `git switch develop && git pull origin develop`
+2. `git switch -c release/v1.0.0`
+3. `npx changeset version` — bumps `package.json` to `1.0.0`,
+   rewrites `CHANGELOG.md`, deletes consumed changesets.
+4. Commit: `chore(release): v1.0.0`. Push: `git push -u origin
+release/v1.0.0`.
+5. **`release-candidate.yml` runs.** Wait for all matrix rows green.
+   If the publish dry-run fails, fix and re-push before moving on.
+6. Open PR: base `main`, head `release/v1.0.0`. Title:
+   `release: v1.0.0`. Wait for CI + release-candidate green, at least
+   one approving review.
+7. **Squash-merge** via the GitHub UI.
+8. `release.yml` fires on the push to `main`, runs `npm run release`
+   (`changeset publish`), tags `v1.0.0`, publishes to npm with
+   provenance.
+
+Post-flight:
+
+1. Visit https://www.npmjs.com/package/agentonomous — v1.0.0 listed,
+   "Signed by GitHub Actions" provenance badge present.
+2. In a scratch project: `npm install agentonomous@1.0.0` and check
+   `import { Agent } from 'agentonomous'` resolves.
+3. Back-merge `main` → `develop` so the version bump + CHANGELOG
+   propagate: open a PR base `develop`, head `main`, merge-commit (no
+   squash — we want the tag reachable from `develop`).
+4. Delete the `release/v1.0.0` branch locally + remote.
+5. Announce, celebrate, nap.
 
 ## Manual / emergency publish
 
@@ -154,7 +270,12 @@ git push -u origin demo`) **before** enabling protection, so the
    initial push isn't blocked.
 3. Add branch protection for `demo`: require PR, require CI green, disallow
    force-push. From this point on, promotions use the PR path above.
-4. Open the first promotion PR (or dispatch the workflow) and watch the
+4. Repo → Settings → **Environments → `github-pages` → Deployment
+   branches and tags** → add `demo` to the allowed list (or switch to
+   "Protected branches only" now that `demo` is protected). GitHub
+   creates this environment with `main` pre-allowed; the deploy job
+   is rejected at the environment gate until `demo` is added.
+5. Open the first promotion PR (or dispatch the workflow) and watch the
    `Deploy demo to GitHub Pages` workflow.
 
 ## Rolling back

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@changesets/cli": "^2.31.0",
         "@eslint/js": "^10.0.1",
+        "@size-limit/file": "^12.1.0",
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.4",
         "eslint": "^10.2.1",
@@ -19,6 +20,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.3",
+        "size-limit": "^12.1.0",
         "typedoc": "^0.28.19",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.58.2",
@@ -438,6 +440,474 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1484,6 +1954,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2338,6 +2821,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2579,6 +3072,50 @@
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3715,6 +4252,19 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -4080,6 +4630,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/natural-compare": {
@@ -4655,6 +5215,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test && npm run build",
     "prepublishOnly": "npm run verify",
     "pack:dry": "npm pack --dry-run",
+    "size": "npm run build && size-limit",
+    "size:why": "npm run build && size-limit --why",
     "demo:install": "npm install && npm run build && cd examples/nurture-pet && npm install",
     "demo:dev": "cd examples/nurture-pet && npm run dev",
     "demo:build": "npm run build && cd examples/nurture-pet && npm run build"
@@ -76,6 +78,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@eslint/js": "^10.0.1",
+    "@size-limit/file": "^12.1.0",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.4",
     "eslint": "^10.2.1",
@@ -84,6 +87,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
+    "size-limit": "^12.1.0",
     "typedoc": "^0.28.19",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
@@ -123,6 +127,20 @@
       "optional": true
     }
   },
+  "size-limit": [
+    {
+      "name": "dist/index.js (gzip)",
+      "path": "dist/index.js",
+      "gzip": true,
+      "limit": "35 KB"
+    },
+    {
+      "name": "dist/integrations/excalibur/index.js (gzip)",
+      "path": "dist/integrations/excalibur/index.js",
+      "gzip": true,
+      "limit": "2 KB"
+    }
+  ],
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",


### PR DESCRIPTION
## Summary

Hardens the path to v1.0.0 so the first merge into `main` can be a
single automated release. No changes to `main` land in this PR —
everything is pipeline prep on `develop` and new tooling.

## What's in it

### Bundle-size budget

- `@size-limit/file` with per-entry gzip limits:
  - `dist/index.js` — **35 kB** (current: 30.16 kB).
  - `dist/integrations/excalibur/index.js` — **2 kB** (current: 1.43 kB).
- Budgets colocated in `package.json` under `"size-limit"`.
- `npm run size` / `npm run size:why` as local convenience scripts.
- Wired into `ci.yml` after the build step, so **every** PR to
  `main` / `develop` / `demo` is size-gated.

### `release-candidate.yml`

New workflow triggered on push to any `release/v*` branch (plus
manual `workflow_dispatch`). Runs on Node 20 + 22 and does everything
CI does, plus:

- `size-limit` budget check.
- **Pack + smoke install:** `npm pack` → install the resulting tarball
  into a scratch project → `import('agentonomous')` and assert
  `Agent` is exported. Catches tarball-shape regressions that
  repo-local tests miss.
- **`npm publish --dry-run`** to validate the publish surface without
  pushing a version.

### PUBLISHING.md runbook additions

- **Branch-protection checklist** for `main` / `develop` / `demo`
  with per-branch deltas. Source-of-truth complement to the
  `.claude/settings.json` denies.
- **Release candidate pre-flight** section documenting the new
  workflow's gates.
- **First release (v1.0.0)** — step-by-step pre-flight, release, and
  post-flight runbook for the inaugural cut.
- Pages first-time setup now includes the `github-pages` environment
  deployment-branch allow-list step (without it, pushes to `demo`
  trigger the workflow but the `deploy` job is rejected at the
  environment gate — observed on the last demo deploy attempt).

## Notable decisions

- **File-mode `size-limit`** (not preset-small-lib) so measurements
  match vite's reported gzip output and budgets are readable from the
  build log. Preset-small-lib bundles+brotlis which doesn't align
  with what vite reports.
- **CI gates size on every PR**, not only on release branches.
  Regressions that land on `develop` become v1 problems; catching
  them at PR time is cheaper.
- **No changeset.** Tooling-only; no library behavior change.

## Test plan

- [x] CI (`test (node 20)` / `test (node 22)`) green on this PR —
      includes the new bundle-size step.
- [x] `npm run size` locally reports both entries under budget.
- [ ] After merge, cut a throwaway `release/v0.0.0-preflight` branch
      from `develop` and push to it; confirm `release-candidate.yml`
      runs the full matrix and the pack/smoke-install/publish-dry-run
      steps all pass. Delete the branch afterwards.
- [ ] Apply the branch-protection rules from the checklist to
      `main` / `develop` / `demo` in Settings → Branches (one-time).

https://claude.ai/code/session_0184U834WsqhLeZBq7D675pJ