### PR TITLE
fix(demo): calibrate need decay + lifecycle for readable 1× pacing

### DIFF
--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -16,7 +16,9 @@ import { mountExportImport, mountHud, mountResetButton, mountSpeedPicker } from 
 const STORAGE_KEY = 'whiskers';
 const SPEED_STORAGE_KEY = 'whiskers:speed';
 // Base wall→virtual scale. The speed picker multiplies this; 1× == base.
-const BASE_TIME_SCALE = 60;
+// Tuned alongside catSpecies decay rates so hunger reaches its critical
+// threshold in ~45 s of wall time at 1×, per the Phase A demo spec.
+const BASE_TIME_SCALE = 10;
 
 // --- Random events ------------------------------------------------------------
 // R-11: cadence tuned so a player sees 2–3 events per virtual minute.

--- a/examples/nurture-pet/src/species.ts
+++ b/examples/nurture-pet/src/species.ts
@@ -2,27 +2,27 @@ import { defineSpecies, type SpeciesDescriptor } from 'agentonomous';
 
 /**
  * Canonical nurture-pet cat. Needs tuned so an unattended kitten grows
- * hungry in ~45 s of wall time at `timeScale: 60` (i.e., 45 virtual
- * minutes), and the full lifecycle completes in ~3 wall minutes for
- * quick demo play.
+ * hungry in ~45 s of wall time at the demo's base `timeScale` of 10 (so
+ * "1×" = 10 virtual sec per wall sec), and the full lifecycle completes
+ * in ~3 wall minutes for quick demo play.
  */
 export const catSpecies: SpeciesDescriptor = defineSpecies({
   id: 'cat',
   displayName: 'Cat',
   persona: { traits: { playfulness: 0.7, sociability: 0.5, curiosity: 0.6 } },
   needs: [
-    { id: 'hunger', level: 1, decayPerSec: 0.006, criticalThreshold: 0.3 },
-    { id: 'cleanliness', level: 1, decayPerSec: 0.003, criticalThreshold: 0.25 },
-    { id: 'happiness', level: 0.8, decayPerSec: 0.004, criticalThreshold: 0.25 },
-    { id: 'energy', level: 1, decayPerSec: 0.005, criticalThreshold: 0.2 },
-    { id: 'health', level: 1, decayPerSec: 0.001, criticalThreshold: 0.2 },
+    { id: 'hunger', level: 1, decayPerSec: 0.0015, criticalThreshold: 0.3 },
+    { id: 'cleanliness', level: 1, decayPerSec: 0.00075, criticalThreshold: 0.25 },
+    { id: 'happiness', level: 0.8, decayPerSec: 0.001, criticalThreshold: 0.25 },
+    { id: 'energy', level: 1, decayPerSec: 0.00125, criticalThreshold: 0.2 },
+    { id: 'health', level: 1, decayPerSec: 0.00025, criticalThreshold: 0.2 },
   ],
   lifecycle: {
     schedule: [
       { stage: 'egg', atSeconds: 0 },
-      { stage: 'kitten', atSeconds: 30 },
-      { stage: 'adult', atSeconds: 120 },
-      { stage: 'elder', atSeconds: 360 },
+      { stage: 'kitten', atSeconds: 150 },
+      { stage: 'adult', atSeconds: 600 },
+      { stage: 'elder', atSeconds: 1800 },
     ],
     capabilities: {
       egg: { allow: [] },

--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -159,7 +159,7 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
 
 /**
  * Discrete simulation-speed picker. The base scale is `baseScale` virtual
- * seconds per real second (60 in the nurture-pet demo). Multipliers map
+ * seconds per real second (10 in the nurture-pet demo). Multipliers map
  * to `baseScale * mult`; the Pause button maps to scale 0.
  *
  * Persists the last selection to `localStorage` under `<storageKey>` so


### PR DESCRIPTION
Closes the P0 item in [`.claude/plans/mvp-demo-roadmap.md`](../blob/develop/.claude/plans/mvp-demo-roadmap.md) — Chapter A of the Phase A demo spec was unreadable because the nurture-pet burned through hunger in ~2 wall seconds.

## What changed

Demo-only. No library API touched; no changeset.

| Knob                      | Before       | After         |
| ------------------------- | ------------ | ------------- |
| `BASE_TIME_SCALE` (1× )   | 60           | **10**        |
| hunger `decayPerSec`      | 0.006        | **0.0015**    |
| cleanliness `decayPerSec` | 0.003        | **0.00075**   |
| happiness `decayPerSec`   | 0.004        | **0.001**     |
| energy `decayPerSec`      | 0.005        | **0.00125**   |
| health `decayPerSec`      | 0.001        | **0.00025**   |
| lifecycle `atSeconds`     | 0/30/120/360 | 0/150/600/1800 |

Relative need ratios preserved. Species header comment updated; `ui.ts` speed-picker doc-comment's "60" also updated to "10".

## Resulting pacing at each speed-picker setting

| Button | timeScale | hunger → critical |
| ------ | --------- | ----------------- |
| ⏸      | 0         | never             |
| 0.5×   | 5         | ~93 s             |
| **1×** | **10**    | **~47 s** ✅      |
| 2×     | 20        | ~23 s             |
| 4×     | 40        | ~12 s             |
| 8×     | 80        | ~6 s              |

Lifecycle at 1×: egg → kitten 15 s → cat 60 s → elder 180 s (≈ 3 wall min), matching the species descriptor's aspirational header comment.

## Scope

- P0 only. The stretch "pace slider in HUD" is deferred into P3's JSON config panel per the roadmap discussion.
- No library change → no `.changeset/` entry.
- No tests touched: `Agent.test.ts` / `Agent-persistence.test.ts` construct their own `timeScale: 60` agents independent of the demo species.

## Verification

- [x] `npm run verify` — format:check, lint, typecheck, 304 tests, build all green
- [x] `npm run size` — `dist/index.js` 30.16 kB gzipped (budget 35 kB)
- [x] Manual: confirm 1× "feels calm" in the browser (`npm run demo:dev`)
