### PR TITLE
chore(demo): remove dead #pet-age div

### DIFF
--- a/examples/nurture-pet/index.html
+++ b/examples/nurture-pet/index.html
@@ -215,7 +215,6 @@
       <div class="pet-meta">
         <div><strong id="pet-name">whiskers</strong></div>
         <div id="pet-stage">stage: egg</div>
-        <div id="pet-age">age: 0s</div>
         <div id="pet-mood">mood: —</div>
         <div id="pet-animation">anim: idle</div>
       </div>

--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -43,7 +43,6 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
   const petEl = document.getElementById('pet') as HTMLElement;
   const nameEl = document.getElementById('pet-name') as HTMLElement;
   const stageEl = document.getElementById('pet-stage') as HTMLElement;
-  const ageEl = document.getElementById('pet-age') as HTMLElement;
   const moodEl = document.getElementById('pet-mood') as HTMLElement;
   const animEl = document.getElementById('pet-animation') as HTMLElement;
 
@@ -110,7 +109,6 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
     update(state: AgentState): void {
       const stageLabel = STAGE_LABELS[state.stage] ?? state.stage;
       stageEl.textContent = `${stageLabel} — ${formatAge(state.ageSeconds)} old`;
-      ageEl.textContent = '';
       moodEl.textContent = `mood: ${state.mood?.category ?? '—'}`;
       animEl.textContent = `anim: ${state.animation}`;
 


### PR DESCRIPTION
Closes D6 from [`.claude/plans/mvp-demo-roadmap.md`](../blob/develop/.claude/plans/mvp-demo-roadmap.md).

The `#pet-age` div in `index.html` stopped being written to when age was folded into the stage label ("Kitten — 23s old"). `ui.ts` kept looking up `ageEl` and setting its `textContent` to the empty string every tick — a no-op. This PR deletes the div, the `getElementById` lookup, and the blanking write.

Demo-only. No library impact. No changeset.

## Verification

- [x] `npm run verify` green
- [ ] Manual: stage label still reads "Kitten — 23s old" in the browser (`npm run demo:dev`)
