### PR TITLE
chore(demo): align formatRemaining spacing with formatAge

### DIFF
--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -409,7 +409,7 @@ function formatRemaining(ms: number): string {
   if (s < 60) return `${s}s`;
   const m = Math.floor(s / 60);
   const rem = s % 60;
-  return rem === 0 ? `${m}m` : `${m}m${rem}s`;
+  return rem === 0 ? `${m}m` : `${m}m ${rem}s`;
 }
 
 /**


### PR DESCRIPTION
Closes D7 from [`.claude/plans/mvp-demo-roadmap.md`](../blob/develop/.claude/plans/mvp-demo-roadmap.md).

`formatAge` renders durations as `"5m 23s"` (space between unit pairs); `formatRemaining` used the compact `"5m23s"`. This PR aligns `formatRemaining` to the spaced form so every duration the HUD shows has the same shape.

Single-line change in `examples/nurture-pet/src/ui.ts`.

Demo-only. No library impact. No changeset.

## Verification

- [x] `npm run verify` green
- [ ] Manual: modifier chip countdown reads like `"1m 30s"` (`npm run demo:dev`)

## Post-merge D6 cleanup

D6 (#17) just merged. I'll sync my local `develop` and prune after this PR lands — no conflict risk since D6 removed the `#pet-age` div + `ageEl` lookup (different lines from this one-line formatter tweak).
