### PR TITLE
chore(demo): rename whiskers:speed → agentonomous/speed

### DIFF
--- a/examples/nurture-pet/README.md
+++ b/examples/nurture-pet/README.md
@@ -78,6 +78,6 @@ bindAgentToStore(pet, (state) => store.syncFromAgent(state));
 | ------------------------------------- | ---------------------------------------------- |
 | `agentonomous/whiskers`               | Agent snapshot (auto-save, every 5 s)          |
 | `agentonomous/__agentonomous/index__` | Snapshot store index                           |
-| `whiskers:speed`                      | Speed-picker preference (not part of snapshot) |
+| `agentonomous/speed`                  | Speed-picker preference (not part of snapshot) |
 
 Reset clears the first two and reloads. Speed preference survives.

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -14,7 +14,24 @@ import { catSpecies } from './species.js';
 import { mountExportImport, mountHud, mountResetButton, mountSpeedPicker } from './ui.js';
 
 const STORAGE_KEY = 'whiskers';
-const SPEED_STORAGE_KEY = 'whiskers:speed';
+const SPEED_STORAGE_KEY = 'agentonomous/speed';
+const LEGACY_SPEED_STORAGE_KEY = 'whiskers:speed';
+
+// D4: one-shot migration from the old `whiskers:speed` key to the
+// prefix-aligned `agentonomous/speed`. Runs once per browser on the
+// first load after this change ships; subsequent loads find no legacy
+// key and no-op.
+try {
+  const legacy = globalThis.localStorage?.getItem(LEGACY_SPEED_STORAGE_KEY);
+  if (legacy !== null && legacy !== undefined) {
+    if (globalThis.localStorage?.getItem(SPEED_STORAGE_KEY) === null) {
+      globalThis.localStorage?.setItem(SPEED_STORAGE_KEY, legacy);
+    }
+    globalThis.localStorage?.removeItem(LEGACY_SPEED_STORAGE_KEY);
+  }
+} catch {
+  // localStorage unavailable (private mode, quota) — skip migration.
+}
 // Base wall→virtual scale. The speed picker multiplies this; 1× == base.
 // Tuned alongside catSpecies decay rates so hunger reaches its critical
 // threshold in ~45 s of wall time at 1×, per the Phase A demo spec.


### PR DESCRIPTION
Closes D4 from [`.claude/plans/mvp-demo-roadmap.md`](../blob/develop/.claude/plans/mvp-demo-roadmap.md).

Every other `localStorage` key the demo writes lives under the `agentonomous/` prefix (`agentonomous/whiskers`, `agentonomous/__agentonomous/index__`). The speed-picker preference was the odd one out: `whiskers:speed`. This PR aligns it.

## What changed

- `SPEED_STORAGE_KEY` renamed `whiskers:speed` → `agentonomous/speed` in `main.ts`.
- One-shot startup migration: if `whiskers:speed` is present, its value is copied to the new key (unless the new key already exists) and the legacy entry is deleted. Wrapped in `try/catch` for private-mode / quota-denied browsers.
- README localStorage key table updated.

## Migration semantics

- First load after upgrade with a saved legacy speed → new key gets the value, old key removed, picker initializes normally.
- First load after upgrade without a legacy key → no-op.
- Subsequent loads → no legacy key exists, migration block no-ops.
- localStorage unavailable → caught, migration silently skipped (picker falls back to default `1×`).

Demo-only. No library impact. No changeset.

## Verification

- [x] `npm run verify` green
- [ ] Manual: set speed to `2×`, reload — preference survives with the new key written to `agentonomous/speed`
- [ ] Manual (legacy): seed `localStorage.setItem('whiskers:speed', '4')`, reload — `whiskers:speed` is gone, `agentonomous/speed` is `"4"`, picker shows `4×` active
