### PR TITLE
feat(trace): expose reasoner candidates on DecisionTrace.deltas

### DIFF
--- a/.changeset/trace-deltas-candidates.md
+++ b/.changeset/trace-deltas-candidates.md
@@ -1,0 +1,17 @@
+---
+'agentonomous': minor
+---
+
+Surface the reasoner's candidate list on `DecisionTrace.deltas.candidates`
+when autonomous cognition runs.
+
+Each entry is an `IntentionCandidate` — `{ intention, score, source }` —
+in the order the needs policy produced it. The field is omitted on ticks
+where the reasoner didn't run (remote / scripted control modes) or where
+no candidates were produced (e.g. no needs + no needs policy). Ordering
+is stable under a fixed seed, preserving the determinism contract.
+
+Presentation layers (including the Phase A nurture-pet demo's upcoming
+Decision Trace panel) can read this directly to render Chapter B's
+"candidate intentions + scores" explainability view without reaching into
+internal cognition classes.

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -57,7 +57,6 @@ import { NullLogger } from '../ports/Logger.js';
 import type { Validator } from '../ports/Validator.js';
 import type { AgentState } from '../persistence/AgentState.js';
 import { INTERACTION_REQUESTED } from '../interaction/InteractionRequestedEvent.js';
-import type { AgentAction } from './AgentAction.js';
 import type { AgentFacade } from './AgentFacade.js';
 import type { AgentIdentity } from './AgentIdentity.js';
 import type { AgentModule, ReactiveHandler } from './AgentModule.js';
@@ -378,7 +377,7 @@ export class Agent {
     // remote/scripted). `executeActions` then runs invoke-skill /
     // emit-event / noop actions through the registry, emits
     // SkillCompleted | SkillFailed, and lets the learner score outcomes.
-    const actions: AgentAction[] = await this.cognitionPipeline.collectActions(
+    const { actions, candidates } = await this.cognitionPipeline.collectActions(
       tickStartedAt,
       perceived,
     );
@@ -400,6 +399,7 @@ export class Agent {
     }
     if (moodChange) deltasRecord.mood = moodChange;
     if (animationTransition) deltasRecord.animation = animationTransition;
+    if (candidates.length > 0) deltasRecord.candidates = candidates;
     const deltas = Object.keys(deltasRecord).length > 0 ? deltasRecord : undefined;
 
     const stage: LifeStage = this.ageModel?.stage ?? 'alive';

--- a/src/agent/DecisionTrace.ts
+++ b/src/agent/DecisionTrace.ts
@@ -10,7 +10,9 @@ import type { ControlMode } from './ControlMode.js';
  *   - M3 adds `needs`.
  *   - M4 adds `modifiers` (applied / expired).
  *   - M5 adds `stageTransitions` and `moodChanges`.
- *   - M7 adds `intentionCandidates` and `selectedIntention`.
+ *   - M7 adds `candidates` — the `IntentionCandidate[]` considered this
+ *     tick when the control mode is autonomous (empty / omitted for
+ *     remote / scripted modes). Ordering is stable under a fixed seed.
  *   - M8 adds `animationTransitions`.
  */
 export interface DecisionTrace {

--- a/src/agent/internal/CognitionPipeline.ts
+++ b/src/agent/internal/CognitionPipeline.ts
@@ -14,6 +14,18 @@ import { isInvokeSkillAction, type AgentAction } from '../AgentAction.js';
 import type { Agent } from '../Agent.js';
 
 /**
+ * Result of `collectActions` — the action list plus the candidate
+ * intentions the reasoner considered this tick. `candidates` is empty for
+ * non-autonomous control modes.
+ *
+ * @internal
+ */
+export type CollectActionsResult = {
+  actions: AgentAction[];
+  candidates: readonly IntentionCandidate[];
+};
+
+/**
  * Stages 3–7 of the tick pipeline: collect actions (control-mode-dispatched),
  * run autonomous cognition, execute resulting actions through the skill
  * registry, and build the `SkillContext` passed to each skill invocation.
@@ -23,22 +35,27 @@ import type { Agent } from '../Agent.js';
 export class CognitionPipeline {
   constructor(private readonly agent: Agent) {}
 
-  /** Collect actions for this tick based on the agent's current `controlMode`. */
+  /**
+   * Collect actions for this tick based on the agent's current `controlMode`,
+   * returning both the resolved action list and — for autonomous cognition —
+   * the candidate intentions considered. Remote and scripted modes report
+   * an empty candidate list (they bypass the reasoner entirely).
+   */
   async collectActions(
     wallNowMs: number,
     perceived: readonly DomainEvent[],
-  ): Promise<AgentAction[]> {
+  ): Promise<CollectActionsResult> {
     const agent = this.agent;
     switch (agent.controlMode) {
       case 'remote': {
-        if (!agent.remote) return [];
+        if (!agent.remote) return { actions: [], candidates: [] };
         const pulled = await agent.remote.pull(agent.identity.id, wallNowMs);
-        return [...pulled];
+        return { actions: [...pulled], candidates: [] };
       }
       case 'scripted': {
-        if (!agent.scripted) return [];
+        if (!agent.scripted) return { actions: [], candidates: [] };
         const next = agent.scripted.next(agent.identity.id, wallNowMs);
-        return next ? [...next] : [];
+        return { actions: next ? [...next] : [], candidates: [] };
       }
       case 'autonomous':
       default:
@@ -47,7 +64,7 @@ export class CognitionPipeline {
   }
 
   /** Autonomous cognition — Stage 4 (candidates) + 5 (select) + 6 (behavior). */
-  runAutonomousCognition(perceived: readonly DomainEvent[]): AgentAction[] {
+  runAutonomousCognition(perceived: readonly DomainEvent[]): CollectActionsResult {
     const agent = this.agent;
     const candidates: IntentionCandidate[] = [];
     if (agent.needs && agent.needsPolicy) {
@@ -62,8 +79,8 @@ export class CognitionPipeline {
       ...(agent.identity.persona !== undefined ? { persona: agent.identity.persona } : {}),
       candidates,
     });
-    if (!intention) return [];
-    return [...agent.behavior.run(intention)];
+    if (!intention) return { actions: [], candidates };
+    return { actions: [...agent.behavior.run(intention)], candidates };
   }
 
   /** Stage 7: dispatch actions — invoke-skill goes through the registry. */

--- a/tests/unit/agent/createAgent.test.ts
+++ b/tests/unit/agent/createAgent.test.ts
@@ -4,6 +4,7 @@ import { ManualClock } from '../../../src/ports/ManualClock.js';
 import { SeededRng } from '../../../src/ports/SeededRng.js';
 import { Needs } from '../../../src/needs/Needs.js';
 import { DEFAULT_URGENCY_CURVE } from '../../../src/needs/Need.js';
+import type { IntentionCandidate } from '../../../src/cognition/IntentionCandidate.js';
 
 describe('createAgent (M2 builder)', () => {
   it('builds a running agent with only id + species', async () => {
@@ -63,6 +64,28 @@ describe('createAgent (M2 builder)', () => {
     const trace = await agent.tick(1);
 
     expect(trace.actions.length + trace.emitted.length).toBeGreaterThan(0);
+  });
+
+  it('surfaces intention candidates on trace.deltas.candidates for autonomous ticks', async () => {
+    const needs = new Needs([
+      {
+        id: 'hunger',
+        level: 0.05,
+        decayPerSec: 0,
+        urgencyCurve: DEFAULT_URGENCY_CURVE,
+        criticalThreshold: 0.2,
+      },
+    ]);
+
+    const agent = createAgent({ id: 'hungry', species: 'cat', needs });
+    const trace = await agent.tick(1);
+    const candidates = trace.deltas?.candidates as readonly IntentionCandidate[] | undefined;
+    expect(candidates).toBeDefined();
+    expect(candidates!.length).toBeGreaterThan(0);
+    for (const c of candidates!) {
+      expect(typeof c.score).toBe('number');
+      expect(typeof c.intention.type).toBe('string');
+    }
   });
 
   it('honors role, persona, name, version overrides', () => {


### PR DESCRIPTION
Prep work for **P1 — Decision Trace panel** ([`.claude/plans/mvp-demo-roadmap.md`](../blob/develop/.claude/plans/mvp-demo-roadmap.md)). The roadmap's scope notes assume `DecisionTrace` already carries the candidate intentions + scores needed for Chapter B's "candidate intentions with scores" explainability view — but the current trace only exposes `actions` / `emitted` / `perceived` / opaque `deltas`. This PR fills that gap so the follow-up demo PR can stay presentation-only.

## Change

`CognitionPipeline.collectActions` now returns `{ actions, candidates }` instead of a bare `AgentAction[]`. `Agent.tick()` destructures both, and stage 10 attaches `candidates` to `trace.deltas.candidates` when the array is non-empty — mirroring how `needs`, `modifiers`, `mood`, and `animation` are already attached.

- Autonomous control mode → `candidates` populated with everything `needsPolicy.suggest()` produced, in the policy's iteration order (already deterministic under a fixed seed).
- Remote / scripted control modes → empty `candidates`, field omitted from the trace.
- No needs or no needs policy → empty `candidates`, field omitted.

`CognitionPipeline` is `@internal` and not re-exported, so the method-signature widening is not a public break.

## Files

- `src/agent/internal/CognitionPipeline.ts` — return shape + new `CollectActionsResult` type.
- `src/agent/Agent.ts` — destructure the result, append to `deltasRecord` when non-empty, drop the now-unused `AgentAction` type import.
- `src/agent/DecisionTrace.ts` — JSDoc updated (the M7 bullet now names the real key).
- `tests/unit/agent/createAgent.test.ts` — new test pins the contract under the auto-wired `ExpressiveNeedsPolicy`.
- `.changeset/trace-deltas-candidates.md` — minor bump.

## Verification

- [x] `npm run verify` green — 305 tests pass (new one included)
- [x] `npm run size` — `dist/index.js` 30.31 kB gzipped (budget 35 kB; +0.15 kB from the extra wiring)

## Follow-up

Once this lands, the demo PR (coming next) renders `trace.deltas.candidates` as a right-hand "Decision Trace" panel per the P1 spec — no further library work needed there.
