### PR TITLE
feat(facade): expose getTimeScale() on AgentFacade

### DIFF
--- a/.changeset/facade-get-timescale.md
+++ b/.changeset/facade-get-timescale.md
@@ -1,0 +1,12 @@
+---
+'agentonomous': minor
+---
+
+Expose `getTimeScale(): number` on `AgentFacade`.
+
+Reactive handlers and modules can now read the current wall-to-virtual
+multiplier without reaching past the facade boundary — useful for
+deferring work during pause (`facade.getTimeScale() === 0`) or logging
+the scale alongside tick-time. The setter stays on `Agent` only;
+keeping pause a harness-level concern matches the
+`setTimeScale` contract (which is not exposed on the facade).

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -812,6 +812,7 @@ export class Agent {
           this.clock.now(),
         );
       },
+      getTimeScale: () => this.timeScale,
     };
   }
 

--- a/src/agent/AgentFacade.ts
+++ b/src/agent/AgentFacade.ts
@@ -33,4 +33,13 @@ export interface AgentFacade {
    * in-tick skill execution.
    */
   invokeSkill(skillId: string, params?: Record<string, unknown>): Promise<void>;
+
+  /**
+   * Current wall-to-virtual time multiplier. `0` means paused. Read-only
+   * on the facade; use `Agent.setTimeScale(scale)` at the harness layer to
+   * change it. A reactive handler that wants to defer work during pause
+   * can check `facade.getTimeScale() === 0` without reaching past the
+   * facade boundary.
+   */
+  getTimeScale(): number;
 }

--- a/tests/unit/agent/Agent.test.ts
+++ b/tests/unit/agent/Agent.test.ts
@@ -279,5 +279,30 @@ describe('Agent (M2 shell)', () => {
       expect(trace.virtualDtSeconds).toBeCloseTo(1e-9, 12);
       expect(trace.virtualDtSeconds).toBeGreaterThan(0);
     });
+
+    it('exposes getTimeScale() on the AgentFacade for reactive handlers', async () => {
+      const observed: number[] = [];
+      const probe: AgentModule = {
+        id: 'scale-probe',
+        reactiveHandlers: [
+          {
+            on: 'probe',
+            handle: (_event, facade) => {
+              observed.push(facade.getTimeScale());
+            },
+          },
+        ],
+      };
+      const bus = new InMemoryEventBus();
+      const agent = new Agent(baseDeps({ eventBus: bus, modules: [probe], timeScale: 3 }));
+
+      bus.publish({ type: 'probe', at: 0 });
+      await agent.tick(0.016);
+      agent.setTimeScale(0);
+      bus.publish({ type: 'probe', at: 0 });
+      await agent.tick(0.016);
+
+      expect(observed).toEqual([3, 0]);
+    });
   });
 });


### PR DESCRIPTION
Closes **D1** from [`.claude/plans/mvp-demo-roadmap.md`](../blob/develop/.claude/plans/mvp-demo-roadmap.md).

Reactive handlers and modules receive an `AgentFacade` — the safe-mutation surface that prevents consumers from poking at agent internals. Today they have no way to observe the wall-to-virtual time scale without reaching past the facade to the concrete `Agent`. This PR adds a read-only `getTimeScale(): number` to the facade so a handler can e.g. defer work while paused with `facade.getTimeScale() === 0`.

## Design choice — setter stays off the facade

`setTimeScale` remains on `Agent` only. Pausing the simulation is a harness-level concern (the demo's speed picker, test scaffolding) — not a skill / reactive-handler concern. Keeping the facade read-only for time scale matches the facade's existing stance that mutation verbs (`satisfyNeed`, `applyModifier`) flow through deliberate methods, not ambient controls.

## Files

- `src/agent/AgentFacade.ts` — new `getTimeScale(): number` method with JSDoc explaining the read-only stance.
- `src/agent/Agent.ts` — `facade()` wires the getter to `this.timeScale`.
- `tests/unit/agent/Agent.test.ts` — new test: a module's reactive handler observes the current scale before and after `setTimeScale(0)`, asserts `[3, 0]`.
- `.changeset/facade-get-timescale.md` — minor bump.

## Verification

- [x] `npm run verify` green — 306 tests
- [x] `npm run size` — within budget (30.58 kB gzipped)
