### PR TITLE
feat(modifiers): add Modifier.visual.label for human-readable names (D3)

### DIFF
--- a/.changeset/modifier-visual-label.md
+++ b/.changeset/modifier-visual-label.md
@@ -1,0 +1,10 @@
+---
+'agentonomous': minor
+---
+
+Add `Modifier.visual.label?: string` for human-readable display names.
+
+Renderers should prefer `label` over the raw `id` when present. The
+field is optional and additive — existing modifiers and consumers are
+unaffected. Demo consumers like the nurture-pet HUD can now show
+"Happy glow" instead of `happy-glow` in the buffs/debuffs tray.

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -108,7 +108,7 @@ pet.subscribe((event) => {
       effects: [
         { target: { type: 'skill-effectiveness', skillId: 'feed' }, kind: 'multiply', value: 0.5 },
       ],
-      visual: { hudIcon: '🤒', fxHint: 'sick-swirl' },
+      visual: { label: 'Sick', hudIcon: '🤒', fxHint: 'sick-swirl' },
     });
   } else if (re.subtype === 'surpriseTreat') {
     pet.applyModifier({
@@ -118,7 +118,7 @@ pet.subscribe((event) => {
       expiresAt: pet.clock.now() + 20_000,
       stack: 'refresh',
       effects: [{ target: { type: 'mood-bias', category: 'playful' }, kind: 'add', value: 0.5 }],
-      visual: { hudIcon: '🎁', fxHint: 'sparkle-gold' },
+      visual: { label: 'Happy glow', hudIcon: '🎁', fxHint: 'sparkle-gold' },
     });
   } else if (re.subtype === 'messyPlay') {
     // R-10: a mess to clean up + R-12: a reason to scold.
@@ -129,7 +129,7 @@ pet.subscribe((event) => {
       expiresAt: pet.clock.now() + 120_000,
       stack: 'refresh',
       effects: [{ target: { type: 'mood-bias', category: 'sad' }, kind: 'add', value: 0.2 }],
-      visual: { hudIcon: '🧹', fxHint: 'dust-cloud' },
+      visual: { label: 'Dirty', hudIcon: '🧹', fxHint: 'dust-cloud' },
     });
     pet.applyModifier({
       id: 'disobedient',
@@ -138,7 +138,7 @@ pet.subscribe((event) => {
       expiresAt: pet.clock.now() + 60_000,
       stack: 'replace',
       effects: [],
-      visual: { hudIcon: '😼', fxHint: 'mischief' },
+      visual: { label: 'Disobedient', hudIcon: '😼', fxHint: 'mischief' },
     });
   }
 });

--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -373,7 +373,8 @@ function renderModifierTray(host: HTMLElement, agent: Agent, paused: boolean): v
   for (const mod of agent.modifiers.list()) {
     const li = document.createElement('li');
     const icon = mod.visual?.hudIcon;
-    const label = icon ? `${icon} ${mod.id}` : mod.id;
+    const name = mod.visual?.label ?? mod.id;
+    const label = icon ? `${icon} ${name}` : name;
     li.textContent = label;
     if (typeof mod.expiresAt === 'number') {
       const time = document.createElement('span');

--- a/src/modifiers/Modifier.ts
+++ b/src/modifiers/Modifier.ts
@@ -38,8 +38,14 @@ export interface Modifier {
   stack: ModifierStackPolicy;
   /** The numerical effects this modifier contributes. */
   effects: readonly ModifierEffect[];
-  /** Optional visual hints for renderers. */
+  /**
+   * Optional visual hints for renderers. `label` is a human-readable
+   * display name — renderers should prefer it over the raw `id` when
+   * present. The other fields are opaque hints consumed by whichever
+   * rendering layer the host app wires up.
+   */
   visual?: {
+    label?: string;
     hudIcon?: string;
     overlay?: string;
     fxHint?: string;

--- a/tests/unit/modifiers/defineModifier.test.ts
+++ b/tests/unit/modifiers/defineModifier.test.ts
@@ -32,6 +32,19 @@ describe('defineModifier', () => {
     expect(mod.expiresAt).toBeUndefined();
   });
 
+  it('preserves the visual.label field through instantiate()', () => {
+    const blueprint = defineModifier({
+      id: 'sick',
+      source: 'event:illness',
+      stack: 'refresh',
+      effects: [],
+      visual: { label: 'Sick', hudIcon: '🤒' },
+    });
+    const mod = blueprint.instantiate(0);
+    expect(mod.visual?.label).toBe('Sick');
+    expect(mod.visual?.hudIcon).toBe('🤒');
+  });
+
   it('accepts per-instance overrides', () => {
     const blueprint = defineModifier({
       id: 'rng',


### PR DESCRIPTION
## Summary

D3 from the MVP demo roadmap. Adds an optional `label` field to
`Modifier.visual` so renderers can display friendly names like "Happy
glow" instead of `happy-glow`.

- `src/modifiers/Modifier.ts` — new optional field, JSDoc updated.
- `examples/nurture-pet/src/ui.ts` — HUD's buffs/debuffs tray prefers
  `mod.visual?.label ?? mod.id`.
- `examples/nurture-pet/src/main.ts` — the four demo modifiers
  (`sick`, `happy-glow`, `dirty`, `disobedient`) now carry labels.
- `tests/unit/modifiers/defineModifier.test.ts` — asserts the new
  field round-trips through `instantiate()`.

## Compatibility

Additive + optional — consumers that don't set or read `label` are
unaffected. Minor bump via `.changeset/modifier-visual-label.md`.

## Test plan

- [x] `npm run verify` — 310 tests, build clean, gzip `dist/index.js` = 30.58 kB (unchanged)
- [ ] Manual: trigger `messyPlay` in the demo, confirm the tray shows "🧹 Dirty" rather than "🧹 dirty"

https://claude.ai/code/session_01GDTFnHb1GQbo86yRoFmtXo