### PR TITLE
feat(demo): seed display + Copy / Replay / New-seed controls (P2)

### DIFF
--- a/examples/nurture-pet/index.html
+++ b/examples/nurture-pet/index.html
@@ -175,6 +175,49 @@
       .io-button:hover {
         background: #475569;
       }
+      .seed {
+        background: #fff;
+        border-radius: 12px;
+        padding: 12px 16px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+        font-size: 13px;
+      }
+      @media (prefers-color-scheme: dark) {
+        .seed {
+          background: #1b2140;
+        }
+      }
+      .seed-label {
+        font-size: 12px;
+        opacity: 0.7;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      .seed-value {
+        font-family: ui-monospace, SFMono-Regular, monospace;
+        padding: 4px 8px;
+        border-radius: 6px;
+        background: #e2e8f0;
+        color: #0f172a;
+        user-select: all;
+      }
+      @media (prefers-color-scheme: dark) {
+        .seed-value {
+          background: #26304d;
+          color: #e6e6f0;
+        }
+      }
+      .seed-button {
+        padding: 6px 10px;
+        font-size: 13px;
+        background: #64748b;
+      }
+      .seed-button:hover {
+        background: #475569;
+      }
       .modifiers li {
         display: inline-flex;
         align-items: center;
@@ -288,6 +331,31 @@
         <button id="import-button" class="io-button" type="button">📂 Import</button>
         <input id="import-file" type="file" accept="application/json,.json" hidden />
         <button id="reset-button" class="reset-button" type="button">🔄 Reset</button>
+      </div>
+      <div class="seed">
+        <span class="seed-label">Seed</span>
+        <code id="seed-display" class="seed-value" aria-label="Current RNG seed"></code>
+        <button id="seed-copy" class="seed-button" type="button" aria-label="Copy seed">
+          📋 Copy
+        </button>
+        <button
+          id="seed-replay"
+          class="seed-button"
+          type="button"
+          aria-label="Replay this seed"
+          title="Reset the pet, keep the seed — the RNG stream will be byte-identical"
+        >
+          🔁 Replay seed
+        </button>
+        <button
+          id="seed-new"
+          class="seed-button"
+          type="button"
+          aria-label="Reset with a new seed"
+          title="Generate a new seed and reset the pet"
+        >
+          🎲 New seed
+        </button>
       </div>
       <div class="bars" id="bars"></div>
       <div class="modifiers">

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -13,6 +13,7 @@ import {
 import { catSpecies } from './species.js';
 import { mountExportImport, mountHud, mountResetButton, mountSpeedPicker } from './ui.js';
 import { mountTraceView } from './traceView.js';
+import { loadSeed, mountSeedPanel } from './seed.js';
 
 const STORAGE_KEY = 'whiskers';
 const SPEED_STORAGE_KEY = 'agentonomous/speed';
@@ -72,12 +73,13 @@ skills.register(ExpressSadSkill);
 skills.register(ExpressSleepySkill);
 
 // --- Agent --------------------------------------------------------------------
+const seed = loadSeed();
 const pet = createAgent({
   id: STORAGE_KEY,
   name: 'Whiskers',
   species: catSpecies,
   timeScale: BASE_TIME_SCALE,
-  rng: STORAGE_KEY,
+  rng: seed,
   memory: new InMemoryMemoryAdapter(),
   modules: [defaultPetInteractionModule],
   skills,
@@ -88,6 +90,7 @@ const pet = createAgent({
 const hud = mountHud(pet);
 const traceView = mountTraceView(pet);
 mountSpeedPicker(pet, { baseScale: BASE_TIME_SCALE, storageKey: SPEED_STORAGE_KEY });
+mountSeedPanel(pet, seed);
 mountExportImport(pet);
 mountResetButton(pet);
 bindAgentToStore(pet, (state) => {

--- a/examples/nurture-pet/src/seed.ts
+++ b/examples/nurture-pet/src/seed.ts
@@ -1,0 +1,105 @@
+import type { Agent } from 'agentonomous';
+import { resetSimulation } from './ui.js';
+
+const SEED_STORAGE_KEY = 'agentonomous/seed';
+const LEGACY_DEFAULT_SEED = 'whiskers';
+
+/**
+ * Load the persisted seed or fall back to the legacy default. The
+ * default keeps byte-identity with existing saved pets on the first
+ * load after this feature ships — players who had a `whiskers` pet
+ * before P2 landed reload into the same RNG stream.
+ */
+export function loadSeed(): string {
+  try {
+    const stored = globalThis.localStorage?.getItem(SEED_STORAGE_KEY);
+    if (typeof stored === 'string' && stored.length > 0) return stored;
+  } catch {
+    // localStorage unavailable — fall through to default.
+  }
+  return LEGACY_DEFAULT_SEED;
+}
+
+function saveSeed(seed: string): void {
+  try {
+    globalThis.localStorage?.setItem(SEED_STORAGE_KEY, seed);
+  } catch {
+    // localStorage unavailable — silently skip. A fresh seed this
+    // session is better than nothing; the user can copy it.
+  }
+}
+
+/**
+ * Generate a fresh random seed string. Non-determinism is intentional
+ * here — this is the one place a user explicitly asks for a new RNG
+ * stream — so `Math.random` + `Date.now` are fair game. The result is
+ * short enough to read out loud and long enough to collision-resist.
+ */
+function generateSeed(): string {
+  const rnd = Math.random().toString(36).slice(2, 8);
+  const stamp = Date.now().toString(36).slice(-4);
+  return `${rnd}-${stamp}`;
+}
+
+/**
+ * Mount the seed controls panel: read-only seed display, Copy, "Reset
+ * with new seed", and "Replay this seed". Visibility in the DOM is
+ * persistent; the demo chooses whether to show the whole panel.
+ *
+ * - **Copy seed** writes the current seed to the clipboard (if the
+ *   browser supports it).
+ * - **Reset with new seed** generates a fresh seed, persists it, then
+ *   wipes the pet snapshot and reloads. New pet, new RNG stream.
+ * - **Replay this seed** keeps the seed and wipes the snapshot. New
+ *   pet, byte-identical RNG stream — a free determinism demo.
+ */
+export function mountSeedPanel(agent: Agent, currentSeed: string): void {
+  const display = document.getElementById('seed-display');
+  const copyBtn = document.getElementById('seed-copy');
+  const newBtn = document.getElementById('seed-new');
+  const replayBtn = document.getElementById('seed-replay');
+  if (!display || !copyBtn || !newBtn || !replayBtn) return;
+
+  display.textContent = currentSeed;
+  display.setAttribute('title', `Current RNG seed: ${currentSeed}`);
+
+  copyBtn.addEventListener('click', () => {
+    const copy = globalThis.navigator?.clipboard?.writeText?.bind(globalThis.navigator.clipboard);
+    if (!copy) {
+      flash(copyBtn, 'Unsupported');
+      return;
+    }
+    copy(currentSeed).then(
+      () => flash(copyBtn, 'Copied!'),
+      () => flash(copyBtn, 'Failed'),
+    );
+  });
+
+  newBtn.addEventListener('click', () => {
+    const name = agent.identity.name ?? agent.identity.id;
+    const ok = globalThis.confirm?.(
+      `Reset ${name} with a new seed? The current pet and its RNG stream will be lost.`,
+    );
+    if (!ok) return;
+    saveSeed(generateSeed());
+    resetSimulation(agent.identity.id);
+  });
+
+  replayBtn.addEventListener('click', () => {
+    const name = agent.identity.name ?? agent.identity.id;
+    const ok = globalThis.confirm?.(
+      `Replay this seed? ${name}'s current state will be lost, but the RNG stream will be byte-identical from the start.`,
+    );
+    if (!ok) return;
+    // Keep the seed key; resetSimulation only removes the snapshot.
+    resetSimulation(agent.identity.id);
+  });
+}
+
+function flash(btn: HTMLElement, text: string): void {
+  const prev = btn.textContent;
+  btn.textContent = text;
+  globalThis.setTimeout?.(() => {
+    btn.textContent = prev;
+  }, 1200);
+}


### PR DESCRIPTION
## Summary

P2 from the MVP demo roadmap. Adds seed controls to the nurture-pet
HUD, closing Chapter E of the demo spec:

- **Read-only seed display** (monospace, `user-select: all` so a quick
  double-click selects the whole string).
- **📋 Copy** — writes the current seed to the clipboard via the Async
  Clipboard API; falls back to a short "Unsupported" flash if the
  browser lacks support.
- **🔁 Replay seed** — resets the pet but keeps the seed. Byte-identical
  RNG stream from the start; a free determinism showcase.
- **🎲 New seed** — generates a fresh random seed, persists it to
  `agentonomous/seed`, then resets the pet.

Seed persistence lives in `examples/nurture-pet/src/seed.ts`.

## Compat note

The default seed on first load is `'whiskers'` — which matches the
legacy implicit seed (the old code passed `rng: STORAGE_KEY` where
`STORAGE_KEY = 'whiskers'`). Existing saved pets keep their RNG stream
byte-identical until the player clicks **New seed**.

## Roadmap gap discovered

The roadmap assumed the snapshot schema carried the seed
("Snapshot schema already carries RNG state via `seed`/`cursor`;
confirm and surface"). It doesn't — neither `AgentSnapshot` nor
`SeededRng` expose the constructor seed. Rather than widen the
library surface here, I kept "seed" as a demo-owned concept persisted
under `agentonomous/seed`. If we later want the library to carry the
seed through snapshots for determinism-across-restore, that's a
separate PR against `SeededRng` + `AgentSnapshot.schemaVersion` 3.

## Test plan

- [x] `npm run verify` — 310 tests, build clean, gzip `dist/index.js` = 30.58 kB
- [x] `cd examples/nurture-pet && npm run build` — demo bundles cleanly (17.03 kB gzip)
- [ ] Manual: **Copy** puts the seed on the clipboard; **Replay seed** produces a byte-identical stream (verify by noting the first random-event timing); **New seed** generates a distinct stream
- [ ] Manual: existing players with a saved `whiskers` pet keep their RNG stream on first load (seed defaults to `'whiskers'`)

Demo-only change — no changeset needed.

https://claude.ai/code/session_01GDTFnHb1GQbo86yRoFmtXo