### PR TITLE
refactor(ci): split monolithic job into parallel stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,39 +11,80 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: test (node ${{ matrix.node }})
+  format-check:
+    name: Format check
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Prettier
+        run: npm run format:check
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: ESLint
+        run: npm run lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: tsc --noEmit
+        run: npm run typecheck
+
+  test:
+    name: Test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    needs: [format-check, lint, typecheck]
     strategy:
       fail-fast: false
       matrix:
         node: [20, 22]
     steps:
       - uses: actions/checkout@v4
-
-      - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: npm
-
       - name: Install dependencies
         run: npm ci
-
-      - name: Format check
-        run: npm run format:check
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Test with coverage
+      - name: Vitest with coverage
         run: npm run test:coverage
 
-      - name: Build
+  build:
+    name: Build & size budget
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build library
         run: npm run build
-
       - name: Bundle size budget
         run: npx size-limit


### PR DESCRIPTION
## Summary

Refactors `.github/workflows/ci.yml` per the review recommendations:

- Splits the single `test` job into dedicated `format-check`, `lint`, `typecheck`, `test`, and `build` jobs.
- Fast static checks (format/lint/typecheck) now run in **parallel** for quicker feedback.
- `test` (Node 20 + 22 matrix) depends on the fast checks; `build` + `size-limit` depends on `test`.
- Clearer job and step names (`Prettier`, `ESLint`, `tsc --noEmit`, `Vitest with coverage`, `Build library`).

No checks were added or removed — the gate remains `format:check → lint → typecheck → test:coverage → build → size-limit`, matching the `npm run verify` pre-PR gate in CLAUDE.md.

Out of scope (intentionally not included): CodeQL, automated releases. Those are separate concerns and warrant their own PRs.

## Test plan

- [ ] CI pipeline turns green on this PR
- [ ] Confirm `format-check`, `lint`, `typecheck` jobs run concurrently
- [ ] Confirm `test` waits on all three static checks
- [ ] Confirm `build` waits on `test` (both Node versions)
- [ ] Confirm `size-limit` still executes inside the `build` job