### PR TITLE
refactor(ci): drop Node version matrix, target latest only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,18 +54,14 @@ jobs:
         run: npm run typecheck
 
   test:
-    name: Test (Node ${{ matrix.node }})
+    name: Test
     runs-on: ubuntu-latest
     needs: [format-check, lint, typecheck]
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 22
           cache: npm
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Removes the `node: [20, 22]` matrix from the `test` job. CI now runs on Node 22 only (matching `.nvmrc`).

Rationale: we develop and verify locally on Node 22, and a second leg on 20 doubles the test job cost without catching meaningful breakage for a library whose `engines.node` range is advisory.

## Test plan

- [x] CI is green on this PR
- [x] Only a single `Test` job appears (no matrix expansion)
- [x] `build` still runs after `test`