### PR TITLE
feat(demo): editable species config JSON panel (P3)

### DIFF
--- a/examples/nurture-pet/index.html
+++ b/examples/nurture-pet/index.html
@@ -310,6 +310,88 @@
         opacity: 0.75;
         font-style: italic;
       }
+      .species-config {
+        background: #fff;
+        border-radius: 12px;
+        padding: 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      @media (prefers-color-scheme: dark) {
+        .species-config {
+          background: #1b2140;
+        }
+      }
+      .species-config-toggle {
+        background: #64748b;
+        font-size: 13px;
+        padding: 6px 10px;
+        align-self: flex-start;
+      }
+      .species-config-toggle:hover {
+        background: #475569;
+      }
+      .species-config[data-visible='false'] #species-config-body {
+        display: none;
+      }
+      #species-config-body {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      #species-config-textarea {
+        width: 100%;
+        min-height: 180px;
+        font-family: ui-monospace, SFMono-Regular, monospace;
+        font-size: 12px;
+        padding: 8px;
+        border-radius: 8px;
+        border: 1px solid #cbd5e1;
+        background: #f8fafc;
+        color: #0f172a;
+        resize: vertical;
+        box-sizing: border-box;
+      }
+      @media (prefers-color-scheme: dark) {
+        #species-config-textarea {
+          background: #0f172a;
+          color: #e6e6f0;
+          border-color: #334155;
+        }
+      }
+      .species-config-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .species-config-actions button {
+        font-size: 13px;
+        padding: 6px 10px;
+      }
+      #species-config-apply {
+        background: #16a34a;
+      }
+      #species-config-apply:hover {
+        background: #15803d;
+      }
+      #species-config-reset {
+        background: #94a3b8;
+      }
+      #species-config-reset:hover {
+        background: #64748b;
+      }
+      #species-config-status {
+        font-size: 12px;
+        min-height: 16px;
+        font-variant-numeric: tabular-nums;
+      }
+      #species-config-status[data-kind='error'] {
+        color: #dc2626;
+      }
+      #species-config-status[data-kind='ok'] {
+        color: #16a34a;
+      }
     </style>
   </head>
   <body>
@@ -378,6 +460,29 @@
           Show decision trace
         </button>
         <div id="decision-trace-body"></div>
+      </div>
+      <div id="species-config" class="species-config" data-visible="false">
+        <button
+          id="species-config-toggle"
+          class="species-config-toggle"
+          type="button"
+          aria-controls="species-config-body"
+          aria-expanded="false"
+        >
+          Show species config
+        </button>
+        <div id="species-config-body">
+          <textarea
+            id="species-config-textarea"
+            spellcheck="false"
+            aria-label="Species configuration JSON"
+          ></textarea>
+          <div id="species-config-status" data-kind="ok"></div>
+          <div class="species-config-actions">
+            <button id="species-config-apply" type="button">Apply &amp; reset</button>
+            <button id="species-config-reset" type="button">Reset to defaults</button>
+          </div>
+        </div>
       </div>
     </section>
 

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -11,9 +11,21 @@ import {
   bindAgentToStore,
 } from 'agentonomous';
 import { catSpecies } from './species.js';
-import { mountExportImport, mountHud, mountResetButton, mountSpeedPicker } from './ui.js';
+import {
+  mountExportImport,
+  mountHud,
+  mountResetButton,
+  mountSpeedPicker,
+  resetSimulation,
+} from './ui.js';
 import { mountTraceView } from './traceView.js';
 import { loadSeed, mountSeedPanel } from './seed.js';
+import {
+  applyOverride,
+  currentEditableConfig,
+  loadConfigOverride,
+  mountConfigPanel,
+} from './speciesConfig.js';
 
 const STORAGE_KEY = 'whiskers';
 const SPEED_STORAGE_KEY = 'agentonomous/speed';
@@ -72,12 +84,16 @@ skills.register(ExpressMeowSkill);
 skills.register(ExpressSadSkill);
 skills.register(ExpressSleepySkill);
 
+// --- Species (base + optional user JSON override) -----------------------------
+const speciesOverride = loadConfigOverride();
+const effectiveSpecies = speciesOverride ? applyOverride(catSpecies, speciesOverride) : catSpecies;
+
 // --- Agent --------------------------------------------------------------------
 const seed = loadSeed();
 const pet = createAgent({
   id: STORAGE_KEY,
   name: 'Whiskers',
-  species: catSpecies,
+  species: effectiveSpecies,
   timeScale: BASE_TIME_SCALE,
   rng: seed,
   memory: new InMemoryMemoryAdapter(),
@@ -93,6 +109,9 @@ mountSpeedPicker(pet, { baseScale: BASE_TIME_SCALE, storageKey: SPEED_STORAGE_KE
 mountSeedPanel(pet, seed);
 mountExportImport(pet);
 mountResetButton(pet);
+mountConfigPanel(catSpecies, currentEditableConfig(effectiveSpecies), () =>
+  resetSimulation(pet.identity.id),
+);
 bindAgentToStore(pet, (state) => {
   hud.update(state);
 });

--- a/examples/nurture-pet/src/speciesConfig.ts
+++ b/examples/nurture-pet/src/speciesConfig.ts
@@ -1,0 +1,299 @@
+import { defineSpecies, type SpeciesDescriptor } from 'agentonomous';
+
+const CONFIG_STORAGE_KEY = 'agentonomous/species-config';
+
+/**
+ * Flat, user-facing override shape. Mirrors the subset of
+ * `SpeciesDescriptor` the config panel exposes for editing. Kept
+ * separate from the library type so the v1 demo's editable surface can
+ * evolve without a library version bump.
+ */
+export interface EditableSpeciesConfig {
+  needs: Record<string, { decayPerSec: number }>;
+  persona: { traits: Record<string, number> };
+  lifecycle: { schedule: Record<string, number> };
+}
+
+/**
+ * Extract the editable subset from a `SpeciesDescriptor`. Used to seed
+ * the textarea contents both on first mount and after a "Reset to
+ * defaults" click.
+ */
+export function currentEditableConfig(descriptor: SpeciesDescriptor): EditableSpeciesConfig {
+  const needs: EditableSpeciesConfig['needs'] = {};
+  for (const n of descriptor.needs ?? []) {
+    needs[n.id] = { decayPerSec: n.decayPerSec };
+  }
+  const traits: Record<string, number> = {};
+  for (const [k, v] of Object.entries(descriptor.persona?.traits ?? {})) {
+    if (typeof v === 'number') traits[k] = v;
+  }
+  const schedule: Record<string, number> = {};
+  for (const entry of descriptor.lifecycle?.schedule ?? []) {
+    schedule[entry.stage] = entry.atSeconds;
+  }
+  return { needs, persona: { traits }, lifecycle: { schedule } };
+}
+
+type ValidationResult = { ok: true; config: EditableSpeciesConfig } | { ok: false; error: string };
+
+/**
+ * Validate a raw string from the textarea. Returns the parsed config on
+ * success, or a human-readable error string on failure. Shape is
+ * forgiving: unknown keys are tolerated (no-op at apply time); known
+ * keys must have the correct primitive type and stay within sensible
+ * bounds (non-negative finite decay / atSeconds, traits in [0, 1]).
+ */
+export function validateEditableConfig(raw: string, base: SpeciesDescriptor): ValidationResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { ok: false, error: `JSON parse error: ${(err as Error).message}` };
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    return { ok: false, error: 'Top-level value must be a JSON object.' };
+  }
+
+  const baseNeedIds = new Set((base.needs ?? []).map((n) => n.id));
+  const baseStageIds = new Set((base.lifecycle?.schedule ?? []).map((e) => e.stage));
+
+  const obj = parsed as Record<string, unknown>;
+  const needs: Record<string, { decayPerSec: number }> = {};
+  const traits: Record<string, number> = {};
+  const schedule: Record<string, number> = {};
+
+  if (obj['needs'] !== undefined) {
+    if (obj['needs'] === null || typeof obj['needs'] !== 'object') {
+      return { ok: false, error: '`needs` must be an object keyed by need id.' };
+    }
+    for (const [id, value] of Object.entries(obj['needs'] as Record<string, unknown>)) {
+      if (!baseNeedIds.has(id)) {
+        return {
+          ok: false,
+          error: `Unknown need id "${id}". Valid: ${[...baseNeedIds].join(', ')}.`,
+        };
+      }
+      if (value === null || typeof value !== 'object') {
+        return { ok: false, error: `needs.${id} must be an object.` };
+      }
+      const rate = (value as Record<string, unknown>)['decayPerSec'];
+      if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < 0) {
+        return {
+          ok: false,
+          error: `needs.${id}.decayPerSec must be a finite number ≥ 0 (got ${String(rate)}).`,
+        };
+      }
+      needs[id] = { decayPerSec: rate };
+    }
+  }
+
+  if (obj['persona'] !== undefined) {
+    const persona = obj['persona'];
+    if (persona === null || typeof persona !== 'object') {
+      return { ok: false, error: '`persona` must be an object.' };
+    }
+    const rawTraits = (persona as Record<string, unknown>)['traits'];
+    if (rawTraits !== undefined) {
+      if (rawTraits === null || typeof rawTraits !== 'object') {
+        return { ok: false, error: '`persona.traits` must be an object.' };
+      }
+      for (const [k, v] of Object.entries(rawTraits as Record<string, unknown>)) {
+        if (typeof v !== 'number' || !Number.isFinite(v) || v < 0 || v > 1) {
+          return {
+            ok: false,
+            error: `persona.traits.${k} must be a finite number in [0, 1] (got ${String(v)}).`,
+          };
+        }
+        traits[k] = v;
+      }
+    }
+  }
+
+  if (obj['lifecycle'] !== undefined) {
+    const lifecycle = obj['lifecycle'];
+    if (lifecycle === null || typeof lifecycle !== 'object') {
+      return { ok: false, error: '`lifecycle` must be an object.' };
+    }
+    const rawSchedule = (lifecycle as Record<string, unknown>)['schedule'];
+    if (rawSchedule !== undefined) {
+      if (rawSchedule === null || typeof rawSchedule !== 'object') {
+        return { ok: false, error: '`lifecycle.schedule` must be an object keyed by stage.' };
+      }
+      for (const [stage, at] of Object.entries(rawSchedule as Record<string, unknown>)) {
+        if (!baseStageIds.has(stage)) {
+          return {
+            ok: false,
+            error: `Unknown lifecycle stage "${stage}". Valid: ${[...baseStageIds].join(', ')}.`,
+          };
+        }
+        if (typeof at !== 'number' || !Number.isFinite(at) || at < 0) {
+          return {
+            ok: false,
+            error: `lifecycle.schedule.${stage} must be a finite number ≥ 0 (got ${String(at)}).`,
+          };
+        }
+        schedule[stage] = at;
+      }
+      // Ordering check: the merged schedule must stay monotonic non-decreasing.
+      const merged = (base.lifecycle?.schedule ?? []).map((e) => ({
+        stage: e.stage,
+        atSeconds: schedule[e.stage] ?? e.atSeconds,
+      }));
+      for (let i = 1; i < merged.length; i++) {
+        const prev = merged[i - 1]!;
+        const curr = merged[i]!;
+        if (curr.atSeconds < prev.atSeconds) {
+          return {
+            ok: false,
+            error: `lifecycle.schedule must be monotonic: "${curr.stage}" (${curr.atSeconds}) before "${prev.stage}" (${prev.atSeconds}).`,
+          };
+        }
+      }
+    }
+  }
+
+  return { ok: true, config: { needs, persona: { traits }, lifecycle: { schedule } } };
+}
+
+/**
+ * Merge an override onto a base `SpeciesDescriptor`, producing a new
+ * descriptor suitable for `createAgent({ species })`. Only fields named
+ * in the override are replaced; everything else (displayName, allowed
+ * skills, appearance, capabilities, etc.) flows through from the base.
+ */
+export function applyOverride(
+  base: SpeciesDescriptor,
+  override: EditableSpeciesConfig,
+): SpeciesDescriptor {
+  const nextNeeds = (base.needs ?? []).map((n) => {
+    const patch = override.needs[n.id];
+    if (!patch) return n;
+    return { ...n, decayPerSec: patch.decayPerSec };
+  });
+
+  const baseTraits = base.persona?.traits ?? {};
+  const nextTraits = { ...baseTraits, ...override.persona.traits };
+
+  const nextSchedule = (base.lifecycle?.schedule ?? []).map((e) => {
+    const at = override.lifecycle.schedule[e.stage];
+    if (at === undefined) return e;
+    return { ...e, atSeconds: at };
+  });
+
+  return defineSpecies({
+    ...base,
+    needs: nextNeeds,
+    persona: { ...base.persona, traits: nextTraits },
+    lifecycle: {
+      ...base.lifecycle,
+      schedule: nextSchedule,
+    },
+  });
+}
+
+export function loadConfigOverride(): EditableSpeciesConfig | null {
+  try {
+    const raw = globalThis.localStorage?.getItem(CONFIG_STORAGE_KEY);
+    if (typeof raw !== 'string' || raw.length === 0) return null;
+    return JSON.parse(raw) as EditableSpeciesConfig;
+  } catch {
+    return null;
+  }
+}
+
+function saveConfigOverride(cfg: EditableSpeciesConfig): void {
+  try {
+    globalThis.localStorage?.setItem(CONFIG_STORAGE_KEY, JSON.stringify(cfg));
+  } catch {
+    // localStorage full / unavailable — surface via alert at call site.
+  }
+}
+
+function clearConfigOverride(): void {
+  try {
+    globalThis.localStorage?.removeItem(CONFIG_STORAGE_KEY);
+  } catch {
+    // nothing to clean up if storage is unavailable
+  }
+}
+
+const PANEL_VISIBLE_KEY = 'agentonomous/species-config-visible';
+
+/**
+ * Mount the species-config panel: a collapsible textarea pre-populated
+ * with the effective editable subset of the current species, plus Apply
+ * and Reset-to-defaults buttons. Apply validates the JSON, persists the
+ * override, and triggers a full-page reset via the `onApply` callback so
+ * the agent is rebuilt with the new descriptor from a clean slate.
+ *
+ * Validation errors surface inline in the status line; on success, the
+ * panel calls `onApply()` — callers typically pipe this into
+ * `resetSimulation(id)` so the reload picks up the stored override.
+ */
+export function mountConfigPanel(
+  base: SpeciesDescriptor,
+  effective: EditableSpeciesConfig,
+  onApply: () => void,
+): void {
+  const root = document.getElementById('species-config');
+  const toggle = document.getElementById('species-config-toggle');
+  const textarea = document.getElementById('species-config-textarea');
+  const status = document.getElementById('species-config-status');
+  const applyBtn = document.getElementById('species-config-apply');
+  const resetBtn = document.getElementById('species-config-reset');
+  if (
+    !root ||
+    !toggle ||
+    !(textarea instanceof HTMLTextAreaElement) ||
+    !status ||
+    !applyBtn ||
+    !resetBtn
+  )
+    return;
+
+  const defaults = currentEditableConfig(base);
+  textarea.value = JSON.stringify(effective, null, 2);
+
+  const initialVisible = globalThis.localStorage?.getItem(PANEL_VISIBLE_KEY) === 'true';
+  setVisible(root, toggle, initialVisible);
+
+  toggle.addEventListener('click', () => {
+    const next = root.getAttribute('data-visible') !== 'true';
+    setVisible(root, toggle, next);
+    try {
+      globalThis.localStorage?.setItem(PANEL_VISIBLE_KEY, next ? 'true' : 'false');
+    } catch {
+      // non-fatal — toggle still works for this session.
+    }
+  });
+
+  applyBtn.addEventListener('click', () => {
+    const result = validateEditableConfig(textarea.value, base);
+    if (!result.ok) {
+      setStatus(status, result.error, 'error');
+      return;
+    }
+    saveConfigOverride(result.config);
+    setStatus(status, 'Saved — reloading…', 'ok');
+    onApply();
+  });
+
+  resetBtn.addEventListener('click', () => {
+    textarea.value = JSON.stringify(defaults, null, 2);
+    clearConfigOverride();
+    setStatus(status, 'Reset to defaults — reloading…', 'ok');
+    onApply();
+  });
+}
+
+function setVisible(root: HTMLElement, toggle: HTMLElement, visible: boolean): void {
+  root.setAttribute('data-visible', visible ? 'true' : 'false');
+  toggle.textContent = visible ? 'Hide species config' : 'Show species config';
+  toggle.setAttribute('aria-expanded', visible ? 'true' : 'false');
+}
+
+function setStatus(el: HTMLElement, text: string, kind: 'ok' | 'error'): void {
+  el.textContent = text;
+  el.setAttribute('data-kind', kind);
+}


### PR DESCRIPTION
## Summary

Roadmap item **P3** (Week 4) — ship a JSON-based species config panel in
the demo so players can tweak `needs[].decayPerSec`, `persona.traits.*`,
and `lifecycle.schedule[].atSeconds` without rebuilding.

- New `examples/nurture-pet/src/speciesConfig.ts` with a flat editable
  shape (`EditableSpeciesConfig`), an extractor, a validator, and a
  merger that re-runs `defineSpecies` on the override. Persistence is
  demo-owned under `agentonomous/species-config`.
- `mountConfigPanel(base, effective, onApply)` renders a collapsible
  textarea + Apply + Reset-to-defaults buttons and writes a visibility
  flag under `agentonomous/species-config-visible`.
- `main.ts` loads the override at startup, merges it onto `catSpecies`,
  and passes the resulting descriptor to `createAgent`. Apply / Reset
  trigger `resetSimulation(pet.identity.id)` — the usual deliberate
  full-page reload so the agent rebuilds from a clean slate.
- `index.html` gets a `#species-config` section with styles for the
  toggle, textarea, status line, and Apply / Reset buttons. The status
  line flips between neutral / `ok` / `error` via `data-kind`.

Validation surfaces human-readable errors inline:

- Unknown need / stage ids listed against the base descriptor's set.
- `decayPerSec` and `atSeconds` must be finite numbers ≥ 0.
- Trait values must be finite numbers in `[0, 1]`.
- The merged lifecycle schedule must stay monotonic non-decreasing.

Editable-subset design: flat objects keyed by id / stage
(`needs.hunger.decayPerSec`) rather than arrays — partial edits are
forgiving and unknown keys simply fail validation instead of silently
replacing the array. Everything outside the editable subset (display
name, allowed skills, appearance, capabilities) flows through from the
base unchanged.

No library changes → no changeset.

## Test plan

- [x] `npm run verify` (format:check + lint + typecheck + 310 tests + build) green.
- [x] Demo builds clean (`npx vite build` in `examples/nurture-pet/`).
- [ ] Manual: toggle panel → edit `needs.hunger.decayPerSec` → Apply → reload shows faster/slower hunger decay.
- [ ] Manual: invalid JSON / out-of-range values show inline error; panel stays open.
- [ ] Manual: "Reset to defaults" clears override key and reloads with the base descriptor.

https://claude.ai/code/session_01GDTFnHb1GQbo86yRoFmtXo