### PR TITLE
chore: raise engines.node to &gt;=22 to match CI

### DIFF
--- a/.changeset/raise-engines-node-22.md
+++ b/.changeset/raise-engines-node-22.md
@@ -1,0 +1,10 @@
+---
+'agentonomous': minor
+---
+
+Raise `engines.node` to `>=22`.
+
+CI now validates on Node 22 only; previously `engines` advertised `>=20.18`
+while CI stopped covering Node 20 on the preceding PR. Aligning the two
+closes the gap where a Node 22-only API could slip through without CI
+catching it. Consumers on Node 20 should upgrade to Node 22 (active LTS).

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/luis85/agentonomous#readme",
   "sideEffects": false,
   "engines": {
-    "node": ">=20.18"
+    "node": ">=22"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

Follow-up to #27 (which dropped Node 20 from the CI matrix). Raises `engines.node` from `>=20.18` to `>=22` so the declared support range matches what CI actually validates.

Closes the P1 concern raised by Codex on #27: without this alignment, a Node 22-only API could ship unnoticed while `engines` still advertised Node 20 support.

Includes a `minor` changeset (pre-1.0, so minor is permitted to carry breaking changes per semver).

## Test plan

- [ ] CI green
- [ ] `package.json` engines.node reads `>=22`
- [ ] Changeset file present under `.changeset/`