### PR TITLE
refactor(ci): polish workflow UX and tighten release/RC gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,9 @@
+# CI — runs on every push and PR to main, develop, and demo.
+#
+# Static checks (format, lint, typecheck) run in parallel for fast
+# feedback. Tests depend on all three passing. Build + bundle-size
+# budget runs last. Mirrors the `npm run verify` pre-PR gate.
+
 name: CI
 
 on:
@@ -12,60 +18,68 @@ concurrency:
 
 jobs:
   format-check:
-    name: Format check
+    name: Format (Prettier)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-      - name: Install dependencies
+      - name: Install dependencies (npm ci)
         run: npm ci
-      - name: Prettier
+      - name: Check formatting
         run: npm run format:check
 
   lint:
-    name: Lint
+    name: Lint (ESLint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-      - name: Install dependencies
+      - name: Install dependencies (npm ci)
         run: npm ci
-      - name: ESLint
+      - name: Run ESLint
         run: npm run lint
 
   typecheck:
-    name: Typecheck
+    name: Typecheck (tsc --noEmit)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-      - name: Install dependencies
+      - name: Install dependencies (npm ci)
         run: npm ci
-      - name: tsc --noEmit
+      - name: Run TypeScript compiler
         run: npm run typecheck
 
   test:
-    name: Test
+    name: Test (Vitest + coverage)
     runs-on: ubuntu-latest
     needs: [format-check, lint, typecheck]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-      - name: Install dependencies
+      - name: Install dependencies (npm ci)
         run: npm ci
-      - name: Vitest with coverage
+      - name: Run Vitest with coverage
         run: npm run test:coverage
 
   build:
@@ -73,14 +87,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
-      - name: Install dependencies
+      - name: Install dependencies (npm ci)
         run: npm ci
-      - name: Build library
+      - name: Build library (vite build)
         run: npm run build
-      - name: Bundle size budget
+      - name: Enforce bundle-size budget
         run: npx size-limit

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,3 +1,10 @@
+# GitHub Pages — deploys the `examples/nurture-pet` demo.
+#
+# Triggered by pushes to the long-lived `demo` branch and via manual
+# dispatch. Builds the library first (the demo consumes `dist/`),
+# then builds the example with `PAGES_BASE` set so asset URLs work
+# under `/<repo>/`, and uploads the result as a Pages artifact.
+
 name: Deploy demo to GitHub Pages
 
 on:
@@ -16,27 +23,29 @@ permissions:
 
 jobs:
   build:
-    name: Build library + example
+    name: Build library + demo example
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
 
-      - name: Install library dependencies
+      - name: Install library dependencies (npm ci)
         run: npm ci
 
-      - name: Build library
+      - name: Build library (vite build)
         run: npm run build
 
-      - name: Install example dependencies
+      - name: Install demo dependencies
         working-directory: examples/nurture-pet
         run: npm install --no-audit --no-fund
 
-      - name: Build example
+      - name: Build demo (vite build, PAGES_BASE=/repo/)
         working-directory: examples/nurture-pet
         env:
           # GitHub Pages serves the repo from /<repo-name>/ by default.
@@ -44,19 +53,19 @@ jobs:
           PAGES_BASE: /${{ github.event.repository.name }}/
         run: npm run build
 
-      - name: Upload Pages artifact
+      - name: Upload Pages artifact (examples/nurture-pet/dist)
         uses: actions/upload-pages-artifact@v3
         with:
           path: examples/nurture-pet/dist
 
   deploy:
-    name: Deploy
+    name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy to Pages
+      - name: Deploy artifact
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,3 +1,11 @@
+# Release candidate — triggered by pushes to `release/v*` branches and
+# via manual dispatch.
+#
+# Runs the full pre-PR gate, enforces the bundle-size budget, packs a
+# tarball, smoke-installs it in a scratch project to verify the public
+# export shape, and performs a `npm publish --dry-run` as the last
+# check before cutting a real release.
+
 name: Release candidate
 
 on:
@@ -11,38 +19,35 @@ concurrency:
 
 jobs:
   preflight:
-    name: Preflight (node ${{ matrix.node }})
+    name: Preflight (verify, pack, smoke-install)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [20, 22]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Use Node ${{ matrix.node }}
+      - name: Setup Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 22
           cache: npm
 
-      - name: Install dependencies
+      - name: Install dependencies (npm ci)
         run: npm ci
 
       - name: Verify (format + lint + typecheck + test + build)
         run: npm run verify
 
-      - name: Bundle size budget
+      - name: Enforce bundle-size budget
         run: npx size-limit
 
-      - name: Pack tarball
+      - name: Pack tarball (npm pack)
         id: pack
         run: |
           npm pack --json > pack.json
           TARBALL="$(node -e "console.log(require('./pack.json')[0].filename)")"
           echo "tarball=$GITHUB_WORKSPACE/$TARBALL" >> "$GITHUB_OUTPUT"
 
-      - name: Smoke-install tarball in a scratch project
+      - name: Smoke-install tarball into scratch project
         run: |
           mkdir -p /tmp/smoke && cd /tmp/smoke
           npm init -y > /dev/null
@@ -57,5 +62,5 @@ jobs:
             console.log('Smoke import OK:', Object.keys(mod).length, 'named exports');
           "
 
-      - name: Publish dry-run
+      - name: Publish dry-run (npm publish --dry-run)
         run: npm publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,11 @@
+# Release — triggered by pushes to `main`.
+#
+# Runs the full pre-PR gate (format, lint, typecheck, test) as a
+# safety net before building, then hands off to `changesets/action`.
+# When unconsumed changesets are present the action opens/updates a
+# version PR; when the version bump has already landed it publishes
+# to npm with provenance.
+
 name: Release
 
 on:
@@ -15,26 +23,40 @@ permissions:
 
 jobs:
   release:
-    name: Release
+    name: Verify, build, and release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository (full history for changesets)
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js 22 (npm registry)
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install dependencies
+      - name: Install dependencies (npm ci)
         run: npm ci
 
-      - name: Build
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run TypeScript compiler
+        run: npm run typecheck
+
+      - name: Run Vitest
+        run: npm test
+
+      - name: Build library (vite build)
         run: npm run build
 
-      - name: Create release PR or publish
+      - name: Version PR or publish to npm (changesets)
         uses: changesets/action@v1
         with:
           publish: npm run release


### PR DESCRIPTION
## Summary

Follow-up to #26 / #27 / #29 addressing the remaining workflow hygiene items:

1. **`release.yml` — add a verify gate.** Previously a push to `main` went straight to `npm run build` → `changesets/action`. If branch protection ever missed a regression, a broken commit could publish. Now the workflow runs `format:check`, `lint`, `typecheck`, `npm test` explicitly before building.
2. **`release-candidate.yml` — drop Node 20 leg.** Aligns with the "latest only" policy set in #27. RC preflight now runs on Node 22 only (no matrix).
3. **Readability across all four workflows.** Each file now has a top-of-file comment stating its purpose + triggers, every step has an explicit `name:`, and job names use a consistent convention (`Format (Prettier)`, `Typecheck (tsc --noEmit)`, `Test (Vitest + coverage)`, `Build & size budget`, `Verify, build, and release`, `Preflight (verify, pack, smoke-install)`, `Build library + demo example`, `Deploy to GitHub Pages`) that reads well in the Actions sidebar and required-checks list.

No behavior change beyond the new verify gate; no changeset needed (workflow-only, no library behavior change).

## Test plan

- [ ] CI is green on this PR (all five CI jobs — format, lint, typecheck, test, build — still run and pass)
- [ ] Actions UI shows clearer job/step names for this workflow run
- [ ] Next push to a `release/v*` branch runs Preflight on Node 22 only (no matrix expansion)
- [ ] Next push to `main` runs the verify steps before the changesets action