### PR TITLE
fix(demo): tone down speed picker + pulse critical bars (D5)

### DIFF
--- a/examples/nurture-pet/index.html
+++ b/examples/nurture-pet/index.html
@@ -100,6 +100,23 @@
       }
       .bar-fill.critical {
         background: #f43f5e;
+        animation: critical-pulse 1.1s ease-in-out infinite;
+      }
+      @keyframes critical-pulse {
+        0%,
+        100% {
+          opacity: 1;
+          filter: brightness(1);
+        }
+        50% {
+          opacity: 0.75;
+          filter: brightness(1.15);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .bar-fill.critical {
+          animation: none;
+        }
       }
       .modifiers ul {
         list-style: none;
@@ -147,16 +164,36 @@
         flex-wrap: wrap;
       }
       .speed-buttons button {
-        padding: 6px 10px;
-        font-size: 13px;
-        background: #475569;
+        padding: 4px 8px;
+        font-size: 12px;
+        font-weight: 500;
+        background: transparent;
+        color: inherit;
+        border: 1px solid #cbd5e1;
+        opacity: 0.75;
       }
       .speed-buttons button:hover {
-        background: #334155;
+        background: #e2e8f0;
+        opacity: 1;
       }
       .speed-buttons button.active {
-        background: #16a34a;
-        box-shadow: 0 0 0 2px rgba(22, 163, 74, 0.35);
+        background: #475569;
+        color: #fff;
+        border-color: #475569;
+        opacity: 1;
+      }
+      @media (prefers-color-scheme: dark) {
+        .speed-buttons button {
+          border-color: #334155;
+        }
+        .speed-buttons button:hover {
+          background: #26304d;
+        }
+        .speed-buttons button.active {
+          background: #cbd5e1;
+          color: #0f172a;
+          border-color: #cbd5e1;
+        }
       }
       .reset-button {
         margin-left: auto;


### PR DESCRIPTION
## Summary

Closes roadmap item **D5** (speed-picker visual hierarchy vs
critical-need flash) from `.claude/plans/mvp-demo-roadmap.md`.

**Problem.** The speed picker's active state was a bright green pill
with a soft outer glow (`box-shadow: 0 0 0 2px rgba(22, 163, 74, 0.35)`)
— the most attention-grabbing element on the HUD. Meanwhile a
critical-need bar just flipped to solid red with no motion cue, so
"hungry" lost the visual contest to "you picked 2×".

**Fix.**

- Speed buttons now use a transparent inactive state with a slate
  border, and an active state that's a solid muted slate pill — no
  glow, lighter typography. Still clearly selectable; no longer the
  brightest thing on screen.
- `.bar-fill.critical` gets a gentle opacity + brightness pulse
  (`critical-pulse` @ 1.1 s, ease-in-out, infinite). Disabled under
  `prefers-reduced-motion`.

Demo-only diff; no library changes, no changeset.

## Test plan

- [x] `npm run verify` (format:check + lint + typecheck + 310 tests + build) green.
- [ ] Manual: critical bar visibly pulses; speed buttons are legible but recede behind the bars.
- [ ] Manual: dark mode still reads cleanly (active button flips to light-slate pill so it stays visible on navy).
- [ ] Manual: `prefers-reduced-motion` suppresses the pulse.

https://claude.ai/code/session_01GDTFnHb1GQbo86yRoFmtXo