### PR TITLE
feat(agent): live-swap cognition reasoner via setReasoner (P4 foundation)

### DIFF
--- a/.changeset/agent-set-reasoner.md
+++ b/.changeset/agent-set-reasoner.md
@@ -1,0 +1,15 @@
+---
+'agentonomous': minor
+---
+
+Add `Agent.setReasoner(reasoner)` and `Agent.getReasoner()` so consumers
+can live-swap the cognition reasoner on an already-constructed agent
+without rebuilding it.
+
+The tick pipeline reads the reasoner fresh each tick, so a swap takes
+effect on the next `selectIntention` call — use it to build UIs that
+toggle between heuristic / BT / BDI / learned reasoners at runtime.
+`setReasoner` throws `TypeError` on null, undefined, or objects without
+a `selectIntention` method; nothing is transferred from the outgoing
+reasoner, so adapters that want continuity should persist their own
+state.

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -170,7 +170,12 @@ export class Agent {
   readonly scripted: ScriptedController | undefined;
   readonly snapshotStore: SnapshotStorePort | undefined;
   readonly autoSaveKey: string;
-  readonly reasoner: Reasoner;
+  /**
+   * Current cognition reasoner. Mutable: consumers live-swap via
+   * `setReasoner(reasoner)`. The tick pipeline reads this field fresh
+   * each tick rather than capturing it at construction.
+   */
+  reasoner: Reasoner;
   readonly behavior: BehaviorRunner;
   readonly learner: Learner;
   readonly skills: SkillRegistry;
@@ -531,6 +536,36 @@ export class Agent {
   /** Current wall-to-virtual time multiplier. */
   getTimeScale(): number {
     return this.timeScale;
+  }
+
+  /**
+   * Replace the cognition reasoner used by the autonomous tick pipeline.
+   *
+   * The tick pipeline reads this field fresh at Stage 4/5, so the new
+   * reasoner takes effect on the next `selectIntention` call. Callers
+   * driving the tick loop from outside the agent (UI handler, framework
+   * `onPreUpdate`) see this as "applies from the next tick"; a swap
+   * issued from a Stage-1 reactive handler is used within the same
+   * tick. Nothing is transferred from the outgoing reasoner — adapters
+   * that want continuity should persist their own state.
+   *
+   * Throws `TypeError` if `reasoner` is null / undefined / lacks
+   * `selectIntention`.
+   */
+  setReasoner(reasoner: Reasoner): void {
+    if (
+      reasoner === null ||
+      reasoner === undefined ||
+      typeof reasoner.selectIntention !== 'function'
+    ) {
+      throw new TypeError('setReasoner: expected a Reasoner with a selectIntention method.');
+    }
+    this.reasoner = reasoner;
+  }
+
+  /** Current cognition reasoner. */
+  getReasoner(): Reasoner {
+    return this.reasoner;
   }
 
   // =========================================================================

--- a/tests/unit/agent/Agent-setReasoner.test.ts
+++ b/tests/unit/agent/Agent-setReasoner.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { createAgent } from '../../../src/agent/createAgent.js';
+import { UrgencyReasoner } from '../../../src/cognition/reasoning/UrgencyReasoner.js';
+import type { Reasoner, ReasonerContext } from '../../../src/cognition/reasoning/Reasoner.js';
+import type { Intention } from '../../../src/cognition/Intention.js';
+import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
+import { ManualClock } from '../../../src/ports/ManualClock.js';
+
+/** Stub reasoner that records invocations and returns a fixed intention. */
+function recordingReasoner(
+  id: string,
+  intention: Intention | null = null,
+): Reasoner & {
+  id: string;
+  calls: ReasonerContext[];
+} {
+  const calls: ReasonerContext[] = [];
+  return {
+    id,
+    calls,
+    selectIntention(ctx) {
+      calls.push(ctx);
+      return intention;
+    },
+  };
+}
+
+describe('Agent.setReasoner', () => {
+  it('defaults to UrgencyReasoner when none is passed', () => {
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      eventBus: new InMemoryEventBus(),
+    });
+    expect(agent.getReasoner()).toBeInstanceOf(UrgencyReasoner);
+  });
+
+  it('swaps the reasoner used on the next autonomous tick', async () => {
+    const first = recordingReasoner('first');
+    const second = recordingReasoner('second');
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      eventBus: new InMemoryEventBus(),
+      reasoner: first,
+    });
+
+    await agent.tick(0.016);
+    expect(first.calls).toHaveLength(1);
+    expect(second.calls).toHaveLength(0);
+
+    agent.setReasoner(second);
+    expect(agent.getReasoner()).toBe(second);
+
+    await agent.tick(0.016);
+    expect(first.calls).toHaveLength(1);
+    expect(second.calls).toHaveLength(1);
+  });
+
+  it('throws TypeError on null / undefined / malformed reasoner', () => {
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      eventBus: new InMemoryEventBus(),
+    });
+    expect(() => agent.setReasoner(null as unknown as Reasoner)).toThrow(TypeError);
+    expect(() => agent.setReasoner(undefined as unknown as Reasoner)).toThrow(TypeError);
+    expect(() => agent.setReasoner({} as unknown as Reasoner)).toThrow(TypeError);
+    expect(() =>
+      agent.setReasoner({ selectIntention: 'not a function' } as unknown as Reasoner),
+    ).toThrow(TypeError);
+  });
+
+  it('leaves the rest of the agent state intact across a swap', async () => {
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      eventBus: new InMemoryEventBus(),
+    });
+
+    await agent.tick(0.5);
+    const needsBefore = { ...agent.getState().needs };
+    const timeScaleBefore = agent.getTimeScale();
+
+    agent.setReasoner(recordingReasoner('stub'));
+
+    expect(agent.getState().needs).toEqual(needsBefore);
+    expect(agent.getTimeScale()).toBe(timeScaleBefore);
+  });
+});


### PR DESCRIPTION
## Summary

First PR of roadmap item **P4** (cognition switcher, Week 5+). Exposes
the foundation the four adapter PRs will plug into.

- Drops `readonly` from `Agent.reasoner` and adds `setReasoner(reasoner)`
  / `getReasoner()` methods.
- Validates the new reasoner is non-null and carries a `selectIntention`
  function; otherwise throws `TypeError`.
- No pipeline rebuild needed: `CognitionPipeline` already reads
  `agent.reasoner` fresh every tick at Stage 4/5 (see
  `src/agent/internal/CognitionPipeline.ts:75`), so the swap is just a
  guarded field write.

Four new unit tests in `tests/unit/agent/Agent-setReasoner.test.ts`:

- Defaults to `UrgencyReasoner` when none is passed.
- A swap takes effect on the next autonomous tick — the old reasoner
  receives one `selectIntention` call, the new one receives the next.
- `setReasoner(null | undefined | malformed)` throws `TypeError`.
- A swap leaves needs + `timeScale` untouched (continuity smoke test).

## Why this is the first of the four P4 PRs

Each of the three planned adapters (`mistreevous` BT, `js-son` BDI,
`brain.js` learning bias) is independently shippable, but the demo's
Chapter C dropdown — the whole point of the roadmap item — doesn't
work without a way to swap reasoners at runtime. Landing `setReasoner`
first means each adapter PR can focus on its own `Reasoner`
implementation and optional-peer wiring without reopening `Agent.ts`.

Docstring calls out that:

- The swap applies from the next tick when driven from outside the
  agent (UI handler, framework `onPreUpdate`).
- A swap from inside a Stage-1 reactive handler lands within the same
  tick — we don't snapshot the reasoner at tick entry the way we do
  for `timeScale`, because the reasoner value has no role in the
  virtual-time / pause contract.
- Nothing is transferred from the outgoing reasoner; adapters that
  want continuity (e.g. a BT's running-node cursor) should persist
  their own state.

## Changeset

Minor bump (additive method pair on the public `Agent` surface).

## Test plan

- [x] `npm run verify` (format:check + lint + typecheck + 314 tests + build) green.
- [x] Gzipped `dist/index.js` at 30.94 kB, comfortably under the 35 kB budget.
- [x] Determinism invariant preserved: no new `Date.now` / `Math.random` / `setTimeout`.

https://claude.ai/code/session_01GDTFnHb1GQbo86yRoFmtXo