### PR TITLE
fix: unaddressed PR review follow-ups + modernize Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -54,9 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -71,9 +71,9 @@ jobs:
     needs: [format-check, lint, typecheck]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -88,9 +88,9 @@ jobs:
     needs: test
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -54,7 +54,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact (examples/nurture-pet/dist)
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: examples/nurture-pet/dist
 
@@ -68,4 +68,4 @@ jobs:
     steps:
       - name: Deploy artifact
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -23,13 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies (npm ci)
         run: npm ci
@@ -64,3 +65,5 @@ jobs:
 
       - name: Publish dry-run (npm publish --dry-run)
         run: npm publish --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (full history for changesets)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js 22 (npm registry)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -32,17 +32,24 @@ Baseline (all three):
 
 - Require a pull request before merging; require at least 1 approving
   review.
-- Require status checks to pass before merging; include the `CI` workflow
-  (both `test (node 20)` and `test (node 22)` matrix rows).
+- Require status checks to pass before merging; include every job in the
+  `CI` workflow (`Format (Prettier)`, `Lint (ESLint)`,
+  `Typecheck (tsc --noEmit)`, `Test (Vitest + coverage)`,
+  `Build & size budget`).
 - Require branches to be up to date before merging.
 - Disallow force pushes. Disallow deletions.
 - Do **not** allow bypass for administrators (hold yourself to the same bar).
 
 Per-branch additions:
 
-- **`main`** — also require the `Release candidate` workflow (both matrix
-  rows) when the incoming branch matches `release/v*`. Optional: require
-  signed commits.
+- **`main`** — do **not** add the `Release candidate` workflow as a
+  required status check. Required checks in GitHub branch protection are
+  enforced for every incoming PR, but `release-candidate.yml` only runs
+  on pushes to `release/v*` branches (or manual dispatch), so marking it
+  required would wedge every non-release PR into `main` on a check that
+  never reports. Instead, reviewers verify the latest
+  `Release candidate` run is green on the source `release/v*` branch
+  before approving the release PR. Optional: require signed commits.
 - **`develop`** — baseline is sufficient.
 - **`demo`** — baseline is sufficient. Remember to add `demo` to the
   `github-pages` environment's deployment branch allow-list (see
@@ -82,7 +89,7 @@ a one-line justification in the commit message.
 
 Any branch matching `release/v*` (e.g. `release/v1.0.0`) is gated by the
 `.github/workflows/release-candidate.yml` workflow on every push. It
-runs on Node 20 + 22 and does everything `CI` does plus:
+runs on Node 22 and does everything `CI` does plus:
 
 - **`npm run size`** — the gzip bundle-size budget.
 - **Pack + smoke install** — `npm pack` into a tarball, install it into
@@ -167,8 +174,8 @@ Release (on `release/v1.0.0`, cut from `develop`):
    rewrites `CHANGELOG.md`, deletes consumed changesets.
 4. Commit: `chore(release): v1.0.0`. Push: `git push -u origin
 release/v1.0.0`.
-5. **`release-candidate.yml` runs.** Wait for all matrix rows green.
-   If the publish dry-run fails, fix and re-push before moving on.
+5. **`release-candidate.yml` runs.** Wait for the `Preflight` job to go
+   green. If the publish dry-run fails, fix and re-push before moving on.
 6. Open PR: base `main`, head `release/v1.0.0`. Title:
    `release: v1.0.0`. Wait for CI + release-candidate green, at least
    one approving review.

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -85,7 +85,7 @@ skills.register(ExpressSadSkill);
 skills.register(ExpressSleepySkill);
 
 // --- Species (base + optional user JSON override) -----------------------------
-const speciesOverride = loadConfigOverride();
+const speciesOverride = loadConfigOverride(catSpecies);
 const effectiveSpecies = speciesOverride ? applyOverride(catSpecies, speciesOverride) : catSpecies;
 
 // --- Agent --------------------------------------------------------------------

--- a/examples/nurture-pet/src/speciesConfig.ts
+++ b/examples/nurture-pet/src/speciesConfig.ts
@@ -192,11 +192,18 @@ export function applyOverride(
   });
 }
 
-export function loadConfigOverride(): EditableSpeciesConfig | null {
+/**
+ * Read a persisted override from localStorage and validate its shape
+ * against `base` before returning it. Malformed, stale, or
+ * schema-incompatible stored values fall back to `null` (defaults) so a
+ * bad blob can't crash `applyOverride` at startup.
+ */
+export function loadConfigOverride(base: SpeciesDescriptor): EditableSpeciesConfig | null {
   try {
     const raw = globalThis.localStorage?.getItem(CONFIG_STORAGE_KEY);
     if (typeof raw !== 'string' || raw.length === 0) return null;
-    return JSON.parse(raw) as EditableSpeciesConfig;
+    const result = validateEditableConfig(raw, base);
+    return result.ok ? result.config : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Resolves review threads left open after merge on three earlier PRs and clears the Node.js 20 action-runner deprecation warnings across every workflow.

### Demo config loader — follow-up on [#28](https://github.com/Luis85/agentonomous/pull/28#discussion_r3107113523)

`loadConfigOverride` now runs `validateEditableConfig` against the base `SpeciesDescriptor` before returning a non-null override, so a malformed-but-parseable blob in `localStorage` (e.g. `{"needs":null}` or `1`) falls back to defaults instead of crashing `applyOverride` at startup. The call site in `main.ts` passes `catSpecies` as the base.

### Release-candidate `publish --dry-run` auth — follow-up on [#13](https://github.com/Luis85/agentonomous/pull/13#discussion_r3106913672)

- Added `registry-url: https://registry.npmjs.org` to the `setup-node` step.
- Wired `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` into the `npm publish --dry-run` step so missing/expired credentials are caught on the release-candidate branch instead of surprising the real publish in `release.yml`.

### `PUBLISHING.md` branch-protection guidance — follow-up on [#13](https://github.com/Luis85/agentonomous/pull/13#discussion_r3106913669)

- Dropped the impossible "require `Release candidate` only when source matches `release/v*`" instruction. Required status checks in GitHub branch protection apply to *every* incoming PR, so keeping that required would wedge non-release PRs into `main` on a check that never reports. Replaced with reviewer-verifies-latest-run guidance.
- Refreshed stale matrix references: the `CI` workflow now lists its five parallel jobs explicitly, and `release-candidate.yml` is described as single-Node-22 (matrix was dropped in PRs #26 / #27).

### Action-runner modernization — new

CI was emitting 5 deprecation warnings per run because actions were running on Node 20. Bumped to Node 24-compatible majors across all four workflows:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

`changesets/action@v1` is already on Node 24 via v1.6.0+ (auto-resolves current v1.x).

## Test plan

- [x] `npm run verify` green — format, lint, typecheck, 310 tests, build.
- [x] CI green on this PR (the workflow bumps are exercised by this PR's own run).
- [ ] Reviewer sanity-check that `pages.yml` still deploys cleanly after the v3→v5 / v4→v5 Pages-action bumps — worth a `workflow_dispatch` run on `demo` once merged if cautious.

## Notes

Stale review threads on PR #27 (superseded by #29) and PR #10 (outdated intra-PR comment) are being marked resolved separately; no code change needed for those.

https://claude.ai/code/session_01CK1QYCcpETmNp1XY83s1sE