### PR TITLE
feat(cognition): mistreevous behaviour-tree reasoner adapter (P4)

### DIFF
--- a/.changeset/cognition-adapter-mistreevous.md
+++ b/.changeset/cognition-adapter-mistreevous.md
@@ -1,0 +1,34 @@
+---
+'agentonomous': minor
+---
+
+Add a behaviour-tree cognition adapter at
+`agentonomous/cognition/adapters/mistreevous`. Wraps the
+[`mistreevous`](https://www.npmjs.com/package/mistreevous) optional
+peer into a `Reasoner` so consumers can drive intention selection from
+an MDSL behaviour tree instead of the default heuristic
+`UrgencyReasoner`.
+
+```ts
+import { MistreevousReasoner } from 'agentonomous/cognition/adapters/mistreevous';
+
+agent.setReasoner(
+  new MistreevousReasoner({
+    definition: `root { selector { ... } }`,
+    handlers: {
+      hungerCritical: (ctx) => /* read needs, return boolean */ ,
+      pickHunger: (_ctx, helpers) => {
+        const top = helpers.topCandidate(c => c.intention.type === 'satisfy-need:hunger');
+        if (top) helpers.commit(top.intention);
+      },
+    },
+    // Optional: forward the agent's seeded RNG so `lotto` / `wait` /
+    // `repeat` / `retry` nodes stay deterministic.
+    random: () => agentRng.next(),
+  }),
+);
+```
+
+Ships as a separate bundle entry — pulling `mistreevous` into the
+consumer's bundle is opt-in and only happens when this module is
+imported.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "excalibur": "^0.32.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
+        "mistreevous": "^4.3.1",
         "prettier": "^3.8.3",
         "size-limit": "^12.1.0",
         "typedoc": "^0.28.19",
@@ -29,7 +30,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=20.18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "*",
@@ -3922,6 +3923,13 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/lotto-draw": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lotto-draw/-/lotto-draw-1.0.2.tgz",
+      "integrity": "sha512-1ih414A35BWpApfNlWAHBKOBLSxTj45crAJ+CMWF/kVY5nx6N22DA1OVF/FWW5WM5CGJbIMRh1O+xe8ukyoQ8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -4043,6 +4051,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mistreevous": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/mistreevous/-/mistreevous-4.3.1.tgz",
+      "integrity": "sha512-AnDNOd8qGcBbz1fDRGYh5Kf+FodR4KcZyc+H4rPpFL7kdOAmGSwnpW57HwX9h0J8pDrj6FJRSAXdfqI6/N1UTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lotto-draw": "^1.0.2"
       }
     },
     "node_modules/mlly": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
       "import": "./dist/integrations/excalibur/index.js",
       "types": "./dist/integrations/excalibur/index.d.ts"
     },
+    "./cognition/adapters/mistreevous": {
+      "import": "./dist/cognition/adapters/mistreevous/index.js",
+      "types": "./dist/cognition/adapters/mistreevous/index.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -86,6 +90,7 @@
     "excalibur": "^0.32.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
+    "mistreevous": "^4.3.1",
     "prettier": "^3.8.3",
     "size-limit": "^12.1.0",
     "typedoc": "^0.28.19",
@@ -137,6 +142,12 @@
     {
       "name": "dist/integrations/excalibur/index.js (gzip)",
       "path": "dist/integrations/excalibur/index.js",
+      "gzip": true,
+      "limit": "2 KB"
+    },
+    {
+      "name": "dist/cognition/adapters/mistreevous/index.js (gzip)",
+      "path": "dist/cognition/adapters/mistreevous/index.js",
       "gzip": true,
       "limit": "2 KB"
     }

--- a/src/cognition/adapters/mistreevous/MistreevousReasoner.ts
+++ b/src/cognition/adapters/mistreevous/MistreevousReasoner.ts
@@ -1,0 +1,156 @@
+import { BehaviourTree, type BehaviourTreeOptions, type State } from 'mistreevous';
+import type { Intention } from '../../Intention.js';
+import type { IntentionCandidate } from '../../IntentionCandidate.js';
+import type { Reasoner, ReasonerContext } from '../../reasoning/Reasoner.js';
+
+/**
+ * Helpers exposed to behaviour-tree handler functions. Closes over the
+ * adapter's per-tick state so handlers can read the current
+ * `ReasonerContext` and commit to an `Intention` without owning a
+ * reference to the agent itself.
+ */
+export interface MistreevousHelpers {
+  /**
+   * Commit to an intention. The most recent commit wins per
+   * `selectIntention` call; uncommitted ticks return `null`.
+   */
+  commit(intention: Intention): void;
+  /**
+   * Highest-scoring candidate matching `filter` (or any candidate when
+   * `filter` is omitted). Returns `null` when no candidate matches.
+   */
+  topCandidate(filter?: (c: IntentionCandidate) => boolean): IntentionCandidate | null;
+}
+
+/**
+ * Handler signature for action / condition nodes in the behaviour tree.
+ * Mistreevous calls these with a `this` bound to its internal agent
+ * object; the adapter wraps them so handlers receive the structured
+ * `ReasonerContext` + `MistreevousHelpers` instead.
+ *
+ * Return-value rules follow mistreevous semantics — these are checked
+ * at runtime by the underlying tree:
+ *
+ * - **Action** nodes must return `State.SUCCEEDED`, `State.FAILED`,
+ *   `State.RUNNING`, or `void` (treated as SUCCEEDED).
+ * - **Condition** nodes must return `boolean`.
+ *
+ * The adapter doesn't enforce which kind a given handler is bound to
+ * (that's encoded in the BT definition), so the type is the union of
+ * both.
+ */
+export type MistreevousHandler = (
+  ctx: ReasonerContext,
+  helpers: MistreevousHelpers,
+  ...args: unknown[]
+) => boolean | State | void;
+
+/**
+ * Constructor options for `MistreevousReasoner`. `definition` is passed
+ * straight through to the underlying `BehaviourTree`; `handlers` maps
+ * BT action / condition node names to functions the adapter will route
+ * mistreevous calls to.
+ */
+export interface MistreevousReasonerOptions {
+  /**
+   * Behaviour-tree definition, in mistreevous' MDSL string form or its
+   * structured `RootNodeDefinition` form. Passed straight to
+   * `new BehaviourTree(definition, agent, options)`.
+   */
+  definition: ConstructorParameters<typeof BehaviourTree>[0];
+  /**
+   * Map of BT handler names → handler functions. The adapter exposes
+   * each entry as `agent[name]` to the underlying tree.
+   */
+  handlers: Record<string, MistreevousHandler>;
+  /**
+   * Optional deterministic RNG. Forwarded to mistreevous as its
+   * `options.random` so `lotto` / `wait` / `repeat` / `retry` nodes
+   * stay byte-identical under a fixed seed. Defaults to the
+   * mistreevous default (`Math.random`).
+   */
+  random?: () => number;
+  /**
+   * Optional deterministic delta-time source for `wait` nodes.
+   * Forwarded to mistreevous as `options.getDeltaTime`.
+   */
+  getDeltaTime?: () => number;
+}
+
+/**
+ * Reasoner adapter that delegates intention selection to a
+ * [`mistreevous`](https://www.npmjs.com/package/mistreevous) behaviour
+ * tree. Each call to `selectIntention(ctx)` steps the tree once; action
+ * handlers commit the chosen intention via `helpers.commit(intention)`.
+ *
+ * The tree is **stateful across ticks** by design — `RUNNING` leaves
+ * resume on the next step, mirroring how BTs are normally driven. Use
+ * `reset()` to manually rewind, e.g. after a major state shift like a
+ * lifecycle stage transition.
+ *
+ * Determinism: pass `random` (and optionally `getDeltaTime`) sourced
+ * from the agent's `Rng` / virtual clock to keep `lotto` / `wait` /
+ * `repeat` / `retry` nodes seeded. The adapter never reaches for
+ * `Math.random` or `Date.now` itself.
+ */
+export class MistreevousReasoner implements Reasoner {
+  private readonly tree: BehaviourTree;
+  private currentCtx: ReasonerContext | null = null;
+  private selected: Intention | null = null;
+
+  constructor(opts: MistreevousReasonerOptions) {
+    const helpers: MistreevousHelpers = {
+      commit: (intention) => {
+        this.selected = intention;
+      },
+      topCandidate: (filter) => {
+        const ctx = this.currentCtx;
+        if (!ctx) return null;
+        let best: IntentionCandidate | null = null;
+        for (const c of ctx.candidates) {
+          if (filter && !filter(c)) continue;
+          if (!best || c.score > best.score) best = c;
+        }
+        return best;
+      },
+    };
+
+    const agent: Record<string, (...args: unknown[]) => boolean | State | void> = {};
+    for (const [name, fn] of Object.entries(opts.handlers)) {
+      agent[name] = (...args: unknown[]) => {
+        const ctx = this.currentCtx;
+        if (!ctx) {
+          // BT was stepped outside selectIntention — treat as no-op.
+          return false;
+        }
+        return fn(ctx, helpers, ...args);
+      };
+    }
+
+    const treeOptions: BehaviourTreeOptions = {};
+    if (opts.random) treeOptions.random = opts.random;
+    if (opts.getDeltaTime) treeOptions.getDeltaTime = opts.getDeltaTime;
+    this.tree = new BehaviourTree(opts.definition, agent, treeOptions);
+  }
+
+  selectIntention(ctx: ReasonerContext): Intention | null {
+    this.currentCtx = ctx;
+    this.selected = null;
+    try {
+      this.tree.step();
+    } finally {
+      this.currentCtx = null;
+    }
+    return this.selected;
+  }
+
+  /** Reset the underlying tree to READY. Use after major state shifts. */
+  reset(): void {
+    this.tree.reset();
+  }
+
+  /** Underlying tree state — useful for inspectors / debug overlays. */
+  getTreeState(): State {
+    return this.tree.getState();
+  }
+}

--- a/src/cognition/adapters/mistreevous/index.ts
+++ b/src/cognition/adapters/mistreevous/index.ts
@@ -1,0 +1,15 @@
+// Mistreevous behaviour-tree adapter — import from
+// `agentonomous/cognition/adapters/mistreevous` so consumers only pull
+// the `mistreevous` peer dep into their bundle when they actually use
+// this reasoner.
+
+export {
+  MistreevousReasoner,
+  type MistreevousHandler,
+  type MistreevousHelpers,
+  type MistreevousReasonerOptions,
+} from './MistreevousReasoner.js';
+
+// Re-export `State` so consumers can return `State.RUNNING` from
+// handlers without adding `mistreevous` to their own imports.
+export { State as MistreevousState } from 'mistreevous';

--- a/tests/unit/cognition/adapters/MistreevousReasoner.test.ts
+++ b/tests/unit/cognition/adapters/MistreevousReasoner.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MistreevousReasoner,
+  MistreevousState,
+} from '../../../../src/cognition/adapters/mistreevous/index.js';
+import type { IntentionCandidate } from '../../../../src/cognition/IntentionCandidate.js';
+import type { ReasonerContext } from '../../../../src/cognition/reasoning/Reasoner.js';
+import { Modifiers } from '../../../../src/modifiers/Modifiers.js';
+import { SeededRng } from '../../../../src/ports/SeededRng.js';
+
+type NeedsLike = { getLevel(id: string): number };
+
+function ctx(
+  candidates: readonly IntentionCandidate[],
+  needs?: Record<string, number>,
+): ReasonerContext {
+  const needsLike: NeedsLike | undefined = needs
+    ? { getLevel: (id: string) => needs[id] ?? 1 }
+    : undefined;
+  return {
+    perceived: [],
+    needs: needsLike as unknown as ReasonerContext['needs'],
+    modifiers: new Modifiers(),
+    candidates,
+  };
+}
+
+function readNeed(c: ReasonerContext, id: string): number {
+  const needs = c.needs as unknown as NeedsLike | undefined;
+  return needs?.getLevel(id) ?? 1;
+}
+
+describe('MistreevousReasoner', () => {
+  it('returns null when no handler commits an intention', () => {
+    const reasoner = new MistreevousReasoner({
+      definition: 'root { action [doNothing] }',
+      handlers: {
+        // Action handler returning void → SUCCEEDED.
+        doNothing: () => {},
+      },
+    });
+    expect(reasoner.selectIntention(ctx([]))).toBeNull();
+  });
+
+  it('commits the intention chosen by an action handler', () => {
+    const reasoner = new MistreevousReasoner({
+      definition: 'root { action [pickEat] }',
+      handlers: {
+        pickEat: (_ctx, helpers) => {
+          helpers.commit({ kind: 'satisfy', type: 'eat' });
+        },
+      },
+    });
+    const pick = reasoner.selectIntention(
+      ctx([{ intention: { kind: 'satisfy', type: 'eat' }, score: 0.9, source: 'needs' }]),
+    );
+    expect(pick).toEqual({ kind: 'satisfy', type: 'eat' });
+  });
+
+  it('routes a sequence of condition + action handlers and reads ctx.candidates', () => {
+    const reasoner = new MistreevousReasoner({
+      definition: `
+        root {
+          selector {
+            sequence {
+              condition [hungerCritical]
+              action [commitTopHungerCandidate]
+            }
+            action [commitIdle]
+          }
+        }
+      `,
+      handlers: {
+        // Condition: returns boolean.
+        hungerCritical: (c) => readNeed(c, 'hunger') < 0.3,
+        commitTopHungerCandidate: (_c, helpers) => {
+          const top = helpers.topCandidate((cand) => cand.intention.type === 'satisfy-need:hunger');
+          if (!top) return MistreevousState.FAILED;
+          helpers.commit(top.intention);
+          return MistreevousState.SUCCEEDED;
+        },
+        commitIdle: (_c, helpers) => {
+          helpers.commit({ kind: 'idle', type: 'idle' });
+        },
+      },
+    });
+
+    const candidates: IntentionCandidate[] = [
+      {
+        intention: { kind: 'satisfy', type: 'satisfy-need:hunger' },
+        score: 0.8,
+        source: 'needs',
+      },
+      {
+        intention: { kind: 'satisfy', type: 'satisfy-need:energy' },
+        score: 0.4,
+        source: 'needs',
+      },
+    ];
+
+    // hunger=0.1 is critical → BT picks the hunger candidate.
+    expect(reasoner.selectIntention(ctx(candidates, { hunger: 0.1 }))).toEqual({
+      kind: 'satisfy',
+      type: 'satisfy-need:hunger',
+    });
+
+    // hunger=0.9 is fine → BT falls through to the idle action.
+    expect(reasoner.selectIntention(ctx(candidates, { hunger: 0.9 }))).toEqual({
+      kind: 'idle',
+      type: 'idle',
+    });
+  });
+
+  it('respects RUNNING return values across ticks (BT state continuity)', () => {
+    let stepsRemaining = 2;
+    const reasoner = new MistreevousReasoner({
+      definition: 'root { action [longRunning] }',
+      handlers: {
+        longRunning: (_c, helpers) => {
+          if (stepsRemaining > 0) {
+            stepsRemaining -= 1;
+            return MistreevousState.RUNNING;
+          }
+          helpers.commit({ kind: 'satisfy', type: 'finally-done' });
+          return MistreevousState.SUCCEEDED;
+        },
+      },
+    });
+
+    expect(reasoner.selectIntention(ctx([]))).toBeNull();
+    expect(reasoner.selectIntention(ctx([]))).toBeNull();
+    expect(reasoner.selectIntention(ctx([]))).toEqual({
+      kind: 'satisfy',
+      type: 'finally-done',
+    });
+  });
+
+  it('routes a seeded random source through to mistreevous lotto nodes deterministically', () => {
+    function makeReasoner(seed: string): MistreevousReasoner {
+      const rng = new SeededRng(seed);
+      return new MistreevousReasoner({
+        definition: `
+          root {
+            lotto {
+              action [commitA]
+              action [commitB]
+              action [commitC]
+            }
+          }
+        `,
+        random: () => rng.next(),
+        handlers: {
+          commitA: (_c, h) => {
+            h.commit({ kind: 'express', type: 'A' });
+          },
+          commitB: (_c, h) => {
+            h.commit({ kind: 'express', type: 'B' });
+          },
+          commitC: (_c, h) => {
+            h.commit({ kind: 'express', type: 'C' });
+          },
+        },
+      });
+    }
+
+    const a = makeReasoner('lotto-seed');
+    const b = makeReasoner('lotto-seed');
+
+    const aPicks: string[] = [];
+    const bPicks: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      aPicks.push(a.selectIntention(ctx([]))?.type ?? '?');
+      bPicks.push(b.selectIntention(ctx([]))?.type ?? '?');
+    }
+
+    expect(aPicks).toEqual(bPicks);
+  });
+
+  it('reset() returns the tree to READY', () => {
+    const reasoner = new MistreevousReasoner({
+      definition: 'root { action [commitOnce] }',
+      handlers: {
+        commitOnce: (_c, h) => {
+          h.commit({ kind: 'satisfy', type: 'committed' });
+        },
+      },
+    });
+    reasoner.selectIntention(ctx([]));
+    reasoner.reset();
+    expect(reasoner.getTreeState()).toBe(MistreevousState.READY);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,10 @@ import dts from 'vite-plugin-dts';
 import { resolve } from 'node:path';
 
 // Library mode build. Entries:
-// - main:      src/index.ts                        → dist/index.js
-// - excalibur: src/integrations/excalibur/index.ts → dist/integrations/excalibur/index.js
+// - main:        src/index.ts                        → dist/index.js
+// - excalibur:   src/integrations/excalibur/index.ts → dist/integrations/excalibur/index.js
+// - mistreevous: src/cognition/adapters/mistreevous/index.ts
+//                                                    → dist/cognition/adapters/mistreevous/index.js
 //
 // All peer dependencies are marked external so consumers provide them.
 
@@ -29,6 +31,10 @@ export default defineConfig({
       entry: {
         index: resolve(__dirname, 'src/index.ts'),
         'integrations/excalibur/index': resolve(__dirname, 'src/integrations/excalibur/index.ts'),
+        'cognition/adapters/mistreevous/index': resolve(
+          __dirname,
+          'src/cognition/adapters/mistreevous/index.ts',
+        ),
       },
       formats: ['es'],
     },


### PR DESCRIPTION
## Summary

Second PR of roadmap item **P4** (cognition switcher). Builds on
`Agent.setReasoner` from PR #32 by shipping the first concrete
alternative reasoner — a behaviour-tree adapter wrapping the optional
`mistreevous` peer.

- `src/cognition/adapters/mistreevous/MistreevousReasoner.ts` — wraps a
  `BehaviourTree` instance. Each `selectIntention(ctx)` call steps the
  tree once; action handlers commit the chosen `Intention` via a
  `helpers.commit(...)` callback. The tree is stateful across ticks by
  design — `RUNNING` leaves resume on the next step. `reset()` is
  exposed for major state shifts.
- `helpers.topCandidate(filter?)` lets handlers cherry-pick from
  `ctx.candidates` without re-implementing scoring.
- Determinism: the constructor accepts optional `random` and
  `getDeltaTime` callbacks that are forwarded to mistreevous'
  `BehaviourTreeOptions`. Wire the agent's seeded `Rng` and virtual
  clock through to keep `lotto` / `wait` / `repeat` / `retry` nodes
  byte-identical under a fixed seed.
- Re-exports `MistreevousState` so consumers can return
  `MistreevousState.RUNNING` from handlers without taking a direct
  `mistreevous` import.

## Bundle / packaging

Ships from a separate entry point `agentonomous/cognition/adapters/mistreevous`
— pulling `mistreevous` into the consumer's bundle is opt-in and only
happens when this module is imported. Wired via:

- `vite.config.ts` — new entry point.
- `package.json` `exports` — new subpath.
- `package.json` `size-limit` — 2 KB gzip budget; current 1.09 KB.

`mistreevous` was already declared as an optional peer dep (and as
`external` in vite); this PR adds it to `devDependencies` so we can
typecheck and run the unit tests.

## Tests (6 new in `tests/unit/cognition/adapters/MistreevousReasoner.test.ts`)

- Empty intent → `null` when no handler commits.
- An action handler can commit an intention via `helpers.commit`.
- A real BT with a condition + selector + sequence routes intentions
  based on a stub `needs.getLevel('hunger')`.
- `MistreevousState.RUNNING` returns from action handlers persist
  across ticks (continuity).
- A seeded `random` callback produces byte-identical `lotto` picks
  across two reasoners with the same seed.
- `reset()` returns the tree to `READY`.

## Why this PR is small

Each adapter (BT, BDI, learning bias) is independently shippable. The
demo's Chapter C dropdown will land as a single demo PR after all four
adapters are in. This keeps each adapter PR reviewable in isolation
and the per-adapter optional-peer surface gated behind its own bundle
entry.

## Changeset

Minor bump — additive subpath export.

## Test plan

- [x] `npm run verify` (format:check + lint + typecheck + 320 tests + build) green.
- [x] Main `dist/index.js` unchanged at 30.94 kB gzip; new mistreevous entry at 1.09 kB gzip.
- [x] No new `Date.now` / `Math.random` / `setTimeout` in `src/`.

https://claude.ai/code/session_01GDTFnHb1GQbo86yRoFmtXo