### PR TITLE
feat(cognition): js-son BDI reasoner adapter (P4)

### DIFF
--- a/.changeset/cognition-adapter-js-son.md
+++ b/.changeset/cognition-adapter-js-son.md
@@ -1,0 +1,43 @@
+---
+'agentonomous': minor
+---
+
+Add a BDI cognition adapter at
+`agentonomous/cognition/adapters/js-son`. Wraps the
+[`js-son-agent`](https://github.com/TimKam/js-son) optional peer into a
+`Reasoner` so consumers can drive intention selection from
+beliefs / desires / plans instead of the default heuristic
+`UrgencyReasoner`.
+
+```ts
+import { Belief, Desire, JsSonReasoner, Plan } from 'agentonomous/cognition/adapters/js-son';
+
+agent.setReasoner(
+  new JsSonReasoner({
+    beliefs: { ...Belief('alive', true) },
+    desires: {
+      ...Desire('hungerCritical', (b) => (b.needs?.hunger ?? 1) < 0.3),
+    },
+    plans: [
+      Plan(
+        (intentions) => intentions.hungerCritical === true,
+        () => [{ intention: { kind: 'satisfy', type: 'satisfy-need:hunger' } }],
+      ),
+    ],
+  }),
+);
+```
+
+Bodies return action arrays; any action carrying an `intention` field
+is treated as the committed intention for that tick (last wins). The
+default `toBeliefs` mapper exposes `needs` (flat `{id: level}`),
+`candidates`, and a `topCandidate(filter?)` helper as beliefs so plans
+can pick from the structured `ReasonerContext` without reaching past
+the adapter. Consumers can override `toBeliefs` for custom mappings.
+
+`reset()` rebuilds the underlying agent from the original options —
+useful after major state shifts (e.g. lifecycle stage transitions).
+
+Ships as a separate bundle entry — pulling `js-son-agent` into the
+consumer's bundle is opt-in and only happens when this module is
+imported.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-config-prettier": "^10.1.8",
         "excalibur": "^0.32.0",
         "husky": "^9.1.7",
+        "js-son-agent": "^0.0.17",
         "lint-staged": "^16.4.0",
         "mistreevous": "^4.3.1",
         "prettier": "^3.8.3",
@@ -3397,6 +3398,13 @@
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-son-agent": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/js-son-agent/-/js-son-agent-0.0.17.tgz",
+      "integrity": "sha512-RnpHDIH9p8W2mxVStk7M8JB0mNc579o0NilOlo5rOGoCix/TT/B6iCbX6sjtXLvlyEnVCrMgc/AHOKL6bN/3jA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/js-tokens": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
       "import": "./dist/cognition/adapters/mistreevous/index.js",
       "types": "./dist/cognition/adapters/mistreevous/index.d.ts"
     },
+    "./cognition/adapters/js-son": {
+      "import": "./dist/cognition/adapters/js-son/index.js",
+      "types": "./dist/cognition/adapters/js-son/index.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -89,6 +93,7 @@
     "eslint-config-prettier": "^10.1.8",
     "excalibur": "^0.32.0",
     "husky": "^9.1.7",
+    "js-son-agent": "^0.0.17",
     "lint-staged": "^16.4.0",
     "mistreevous": "^4.3.1",
     "prettier": "^3.8.3",
@@ -148,6 +153,12 @@
     {
       "name": "dist/cognition/adapters/mistreevous/index.js (gzip)",
       "path": "dist/cognition/adapters/mistreevous/index.js",
+      "gzip": true,
+      "limit": "2 KB"
+    },
+    {
+      "name": "dist/cognition/adapters/js-son/index.js (gzip)",
+      "path": "dist/cognition/adapters/js-son/index.js",
       "gzip": true,
       "limit": "2 KB"
     }

--- a/src/cognition/adapters/js-son/JsSonReasoner.ts
+++ b/src/cognition/adapters/js-son/JsSonReasoner.ts
@@ -1,0 +1,208 @@
+import {
+  Agent as JsSonAgent,
+  type JsSonAgentOptions,
+  type JsSonBeliefs,
+  type JsSonDesires,
+  type JsSonPlan,
+} from 'js-son-agent';
+import type { Intention } from '../../Intention.js';
+import type { IntentionCandidate } from '../../IntentionCandidate.js';
+import type { Reasoner, ReasonerContext } from '../../reasoning/Reasoner.js';
+
+/**
+ * Helpers passed to the default / consumer-provided `toBeliefs` mapper.
+ * Used to derive belief updates from the structured `ReasonerContext`
+ * without each plan having to rewrite scoring logic.
+ */
+export interface JsSonBeliefHelpers {
+  /**
+   * Highest-scoring candidate matching `filter` (or any candidate when
+   * `filter` is omitted). Mirrors the mistreevous adapter's helper for
+   * symmetry. Typed as a property (not a method) so consumers can pass
+   * it through into beliefs without losing `this` binding.
+   */
+  topCandidate: (filter?: (c: IntentionCandidate) => boolean) => IntentionCandidate | null;
+  /** Flat `{id: level}` snapshot of the agent's needs, or `{}` if unset. */
+  needsLevels: () => Record<string, number>;
+}
+
+/**
+ * Maps the per-tick `ReasonerContext` to a js-son belief update object.
+ * The return value is merged into the underlying agent's beliefs via its
+ * configured `reviseBeliefs` function (defaults to non-monotonic merge).
+ */
+export type JsSonBeliefMapper = (ctx: ReasonerContext, helpers: JsSonBeliefHelpers) => JsSonBeliefs;
+
+/**
+ * Constructor options for `JsSonReasoner`.
+ *
+ * The three BDI ingredients (`beliefs`, `desires`, `plans`) are forwarded
+ * straight through to the underlying js-son `Agent`. The adapter only
+ * layers the per-tick context mapping and intention extraction on top.
+ */
+export interface JsSonReasonerOptions {
+  /**
+   * Initial beliefs — the object that `new Agent({ beliefs })` is seeded
+   * with. Typically assembled via the `Belief()` helper from
+   * `js-son-agent`. Consumer-owned; the adapter does not add to it.
+   */
+  beliefs: JsSonBeliefs;
+  /**
+   * Map of desire id → belief predicate. Defaults to `{}` (no desires).
+   * When empty js-son short-circuits `intentions = beliefs`.
+   */
+  desires?: JsSonDesires;
+  /**
+   * BDI plans. Each plan body returns an array of action objects; the
+   * adapter treats any action containing an `intention` field as the
+   * committed intention for that tick. Later wins if multiple plans
+   * commit, matching the mistreevous adapter's "last commit wins" rule.
+   *
+   * Note on `intentions` vs `beliefs` inside a plan body: when `desires`
+   * is non-empty, the body receives only the filtered desire results
+   * (not the full belief object). To still reach `topCandidate` /
+   * `needs` / `candidates` in that case, either define a no-desire
+   * reasoner (then `intentions === beliefs`) or read from `this.beliefs`
+   * inside a `function() { ... }` body — js-son binds the agent as
+   * `this` when `selfUpdatesPossible` is true (default).
+   */
+  plans: readonly JsSonPlan[];
+  /**
+   * Optional preference function forwarded as js-son's
+   * `determinePreferences`. See
+   * [`js-son-agent` README](https://github.com/TimKam/js-son#agent).
+   */
+  preferenceFunction?: JsSonAgentOptions['determinePreferences'];
+  /** Optional belief-revision function forwarded to the underlying Agent. */
+  reviseBeliefs?: JsSonAgentOptions['reviseBeliefs'];
+  /**
+   * Maps `ReasonerContext` → belief updates. Runs every `selectIntention`
+   * call. Defaults to a mapper that exposes `needs` (flat
+   * `{id: level}`), `candidates` (the raw array), and `topCandidate` (a
+   * helper function) as beliefs of those names.
+   */
+  toBeliefs?: JsSonBeliefMapper;
+  /**
+   * Optional agent id. Defaults to `'agentonomous'`. Only surfaces in
+   * js-son's multi-agent `Environment` flows, which this adapter does
+   * not use.
+   */
+  id?: string;
+}
+
+const INTENTION_KEY = 'intention' as const;
+
+function defaultToBeliefs(_ctx: ReasonerContext, helpers: JsSonBeliefHelpers): JsSonBeliefs {
+  return {
+    needs: helpers.needsLevels(),
+    candidates: [..._ctx.candidates],
+    topCandidate: helpers.topCandidate,
+  };
+}
+
+function isIntentionAction(action: unknown): action is { [INTENTION_KEY]: Intention } {
+  return (
+    typeof action === 'object' &&
+    action !== null &&
+    INTENTION_KEY in action &&
+    typeof (action as Record<string, unknown>)[INTENTION_KEY] === 'object' &&
+    (action as Record<string, unknown>)[INTENTION_KEY] !== null
+  );
+}
+
+/**
+ * Reasoner adapter that delegates intention selection to a
+ * [`js-son-agent`](https://github.com/TimKam/js-son) BDI agent. Each
+ * call to `selectIntention(ctx)`:
+ *
+ * 1. Builds belief updates from `ctx` via `toBeliefs` (defaults exposed
+ *    are `needs`, `candidates`, `topCandidate`).
+ * 2. Calls `agent.next(beliefUpdates)` — js-son computes intentions from
+ *    desires, then runs each plan's head+body.
+ * 3. Scans the returned actions for one with an `intention` field and
+ *    returns it (last wins). Returns `null` if no plan committed.
+ *
+ * Determinism: js-son itself doesn't consult `Math.random` or
+ * `Date.now`; plan evaluation follows array order. Keep plan bodies
+ * pure w.r.t. the inputs and determinism is preserved.
+ */
+export class JsSonReasoner implements Reasoner {
+  private agent: JsSonAgent;
+  private readonly init: Required<Pick<JsSonReasonerOptions, 'beliefs' | 'plans' | 'id'>> &
+    JsSonReasonerOptions;
+  private readonly toBeliefs: JsSonBeliefMapper;
+
+  constructor(opts: JsSonReasonerOptions) {
+    this.init = {
+      ...opts,
+      id: opts.id ?? 'agentonomous',
+      beliefs: opts.beliefs,
+      plans: opts.plans,
+    };
+    this.toBeliefs = opts.toBeliefs ?? defaultToBeliefs;
+    this.agent = this.buildAgent();
+  }
+
+  selectIntention(ctx: ReasonerContext): Intention | null {
+    const helpers: JsSonBeliefHelpers = {
+      topCandidate: (filter) => {
+        let best: IntentionCandidate | null = null;
+        for (const c of ctx.candidates) {
+          if (filter && !filter(c)) continue;
+          if (!best || c.score > best.score) best = c;
+        }
+        return best;
+      },
+      needsLevels: () => {
+        const needs = ctx.needs;
+        if (!needs) return {};
+        const out: Record<string, number> = {};
+        for (const n of needs.list()) out[n.id] = n.level;
+        return out;
+      },
+    };
+
+    const beliefUpdates = this.toBeliefs(ctx, helpers);
+    const planResults = this.agent.next(beliefUpdates);
+
+    let selected: Intention | null = null;
+    for (const actions of planResults) {
+      for (const action of actions) {
+        if (isIntentionAction(action)) selected = action.intention;
+      }
+    }
+    return selected;
+  }
+
+  /**
+   * Rebuild the underlying js-son `Agent` from the original options.
+   * Use after major state shifts — js-son agents are stateful (beliefs
+   * accumulate across `next()` calls) so there's no built-in "rewind".
+   */
+  reset(): void {
+    this.agent = this.buildAgent();
+  }
+
+  /** Read-only snapshot of the agent's current beliefs. */
+  getBeliefs(): JsSonBeliefs {
+    return { ...this.agent.beliefs };
+  }
+
+  private buildAgent(): JsSonAgent {
+    const agentOpts: JsSonAgentOptions = {
+      id: this.init.id,
+      beliefs: { ...this.init.beliefs },
+      desires: this.init.desires ?? {},
+      plans: this.init.plans,
+    };
+    if (this.init.preferenceFunction) {
+      agentOpts.determinePreferences = this.init.preferenceFunction;
+    }
+    if (this.init.reviseBeliefs) {
+      agentOpts.reviseBeliefs = this.init.reviseBeliefs;
+    }
+    return new JsSonAgent(agentOpts);
+  }
+}
+
+export type { JsSonAction, JsSonBeliefs, JsSonDesires, JsSonPlan } from 'js-son-agent';

--- a/src/cognition/adapters/js-son/index.ts
+++ b/src/cognition/adapters/js-son/index.ts
@@ -1,0 +1,15 @@
+// js-son BDI adapter — import from `agentonomous/cognition/adapters/js-son`
+// so consumers only pull the `js-son-agent` peer dep into their bundle
+// when they actually use this reasoner.
+
+export {
+  JsSonReasoner,
+  type JsSonBeliefHelpers,
+  type JsSonBeliefMapper,
+  type JsSonReasonerOptions,
+} from './JsSonReasoner.js';
+
+// Re-export the three BDI building blocks from the upstream library so
+// consumers can author beliefs / desires / plans without adding a direct
+// `js-son-agent` import of their own.
+export { Belief, Desire, Plan } from 'js-son-agent';

--- a/src/cognition/adapters/js-son/index.ts
+++ b/src/cognition/adapters/js-son/index.ts
@@ -1,6 +1,12 @@
 // js-son BDI adapter — import from `agentonomous/cognition/adapters/js-son`
 // so consumers only pull the `js-son-agent` peer dep into their bundle
 // when they actually use this reasoner.
+//
+// `js-son-agent` ships no TypeScript types. The ambient module shim in
+// `./js-son-agent.d.ts` types the slice we rely on; the build step
+// copies it into `dist/` and prepends a triple-slash reference to the
+// emitted `index.d.ts` and `JsSonReasoner.d.ts` so consumers pick it up
+// automatically. See `vite.config.ts → prependAmbientDtsReferences`.
 
 export {
   JsSonReasoner,

--- a/src/cognition/adapters/js-son/js-son-agent.d.ts
+++ b/src/cognition/adapters/js-son/js-son-agent.d.ts
@@ -1,0 +1,45 @@
+// Ambient type declarations for the optional `js-son-agent` peer dep.
+// The upstream package ships pure JavaScript with no `.d.ts`; this file
+// covers only the slice our adapter relies on (Agent constructor in
+// object form + `next()` + the `Belief` / `Desire` / `Plan` helpers).
+declare module 'js-son-agent' {
+  export type JsSonBeliefs = Record<string, unknown>;
+  export type JsSonDesires = Record<string, (beliefs: JsSonBeliefs) => boolean>;
+  export type JsSonIntentions = Record<string, unknown>;
+  export type JsSonAction = Record<string, unknown>;
+
+  export interface JsSonPlan {
+    head: ((intentions: JsSonIntentions) => boolean) | { isActive: boolean; value?: unknown };
+    body: (intentions: JsSonIntentions, ...rest: unknown[]) => readonly JsSonAction[];
+    run: (intentions: JsSonIntentions) => readonly JsSonAction[] | null;
+  }
+
+  export interface JsSonAgentOptions {
+    id: string;
+    beliefs: JsSonBeliefs;
+    desires?: JsSonDesires;
+    plans: readonly JsSonPlan[];
+    determinePreferences?: (
+      beliefs: JsSonBeliefs,
+      desires: JsSonDesires,
+    ) => (key: string) => boolean;
+    reviseBeliefs?: (current: JsSonBeliefs, updates: JsSonBeliefs) => JsSonBeliefs;
+    selfUpdatesPossible?: boolean;
+  }
+
+  export class Agent {
+    constructor(options: JsSonAgentOptions);
+    beliefs: JsSonBeliefs;
+    next(beliefUpdates: JsSonBeliefs): readonly (readonly JsSonAction[])[];
+  }
+
+  export function Belief(id: string, value: unknown): Record<string, unknown>;
+  export function Desire(
+    id: string,
+    body: (beliefs: JsSonBeliefs) => boolean,
+  ): Record<string, (beliefs: JsSonBeliefs) => boolean>;
+  export function Plan(
+    head: (intentions: JsSonIntentions) => boolean,
+    body: (intentions: JsSonIntentions) => readonly JsSonAction[],
+  ): JsSonPlan;
+}

--- a/tests/unit/cognition/adapters/JsSonReasoner.test.ts
+++ b/tests/unit/cognition/adapters/JsSonReasoner.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import {
+  Belief,
+  Desire,
+  JsSonReasoner,
+  Plan,
+} from '../../../../src/cognition/adapters/js-son/index.js';
+import type { IntentionCandidate } from '../../../../src/cognition/IntentionCandidate.js';
+import type { ReasonerContext } from '../../../../src/cognition/reasoning/Reasoner.js';
+import { Modifiers } from '../../../../src/modifiers/Modifiers.js';
+
+type NeedsLike = { list(): readonly { id: string; level: number }[] };
+
+function ctx(
+  candidates: readonly IntentionCandidate[],
+  needs?: Record<string, number>,
+): ReasonerContext {
+  const needsLike: NeedsLike | undefined = needs
+    ? {
+        list: () => Object.entries(needs).map(([id, level]) => ({ id, level })),
+      }
+    : undefined;
+  return {
+    perceived: [],
+    needs: needsLike as unknown as ReasonerContext['needs'],
+    modifiers: new Modifiers(),
+    candidates,
+  };
+}
+
+describe('JsSonReasoner', () => {
+  it('returns null when no plan commits an intention', () => {
+    const reasoner = new JsSonReasoner({
+      beliefs: { ...Belief('alive', true) },
+      plans: [
+        Plan(
+          () => true,
+          () => [{ log: 'noop' }],
+        ),
+      ],
+    });
+    expect(reasoner.selectIntention(ctx([]))).toBeNull();
+  });
+
+  it('commits the intention returned by a plan body', () => {
+    const reasoner = new JsSonReasoner({
+      beliefs: { ...Belief('alive', true) },
+      plans: [
+        Plan(
+          () => true,
+          () => [{ intention: { kind: 'satisfy', type: 'eat' } }],
+        ),
+      ],
+    });
+    expect(reasoner.selectIntention(ctx([]))).toEqual({ kind: 'satisfy', type: 'eat' });
+  });
+
+  it('routes on beliefs derived from ctx.needs via the default mapper', () => {
+    type NeedsBeliefs = { needs?: Record<string, number> };
+    const reasoner = new JsSonReasoner({
+      beliefs: { ...Belief('needs', {}) },
+      plans: [
+        Plan(
+          (intentions) => ((intentions as NeedsBeliefs).needs?.['hunger'] ?? 1) >= 0.3,
+          () => [{ intention: { kind: 'idle', type: 'idle' } }],
+        ),
+        Plan(
+          (intentions) => ((intentions as NeedsBeliefs).needs?.['hunger'] ?? 1) < 0.3,
+          () => [{ intention: { kind: 'satisfy', type: 'satisfy-need:hunger' } }],
+        ),
+      ],
+    });
+
+    expect(reasoner.selectIntention(ctx([], { hunger: 0.1 }))).toEqual({
+      kind: 'satisfy',
+      type: 'satisfy-need:hunger',
+    });
+
+    expect(reasoner.selectIntention(ctx([], { hunger: 0.9 }))).toEqual({
+      kind: 'idle',
+      type: 'idle',
+    });
+  });
+
+  it('routes desires → intentions: only fires the plan when the desire holds', () => {
+    type UrgentIntentions = { urgent?: boolean };
+    const reasoner = new JsSonReasoner({
+      beliefs: { ...Belief('alive', true) },
+      desires: {
+        ...Desire(
+          'urgent',
+          (beliefs) =>
+            ((beliefs as { needs?: Record<string, number> }).needs?.['hunger'] ?? 1) < 0.5,
+        ),
+      },
+      plans: [
+        Plan(
+          (intentions) => (intentions as UrgentIntentions).urgent === true,
+          () => [{ intention: { kind: 'satisfy', type: 'satisfy-need:hunger' } }],
+        ),
+      ],
+    });
+
+    expect(reasoner.selectIntention(ctx([], { hunger: 0.1 }))).toEqual({
+      kind: 'satisfy',
+      type: 'satisfy-need:hunger',
+    });
+
+    expect(reasoner.selectIntention(ctx([], { hunger: 0.9 }))).toBeNull();
+  });
+
+  it('exposes topCandidate as a belief so no-desire plans can pick from candidates', () => {
+    type TopCandidateFn = (
+      filter?: (c: IntentionCandidate) => boolean,
+    ) => IntentionCandidate | null;
+    type PlanBeliefs = {
+      topCandidate: TopCandidateFn;
+      needs?: Record<string, number>;
+    };
+
+    const candidates: IntentionCandidate[] = [
+      { intention: { kind: 'satisfy', type: 'satisfy-need:hunger' }, score: 0.8, source: 'needs' },
+      { intention: { kind: 'satisfy', type: 'satisfy-need:energy' }, score: 0.4, source: 'needs' },
+    ];
+
+    const reasoner = new JsSonReasoner({
+      beliefs: { ...Belief('candidates', []) },
+      plans: [
+        Plan(
+          (intentions) => ((intentions as PlanBeliefs).needs?.['hunger'] ?? 1) < 0.5,
+          (intentions) => {
+            const top = (intentions as PlanBeliefs).topCandidate(
+              (c) => c.intention.type === 'satisfy-need:hunger',
+            );
+            return top ? [{ intention: top.intention }] : [];
+          },
+        ),
+      ],
+    });
+
+    expect(reasoner.selectIntention(ctx(candidates, { hunger: 0.1 }))).toEqual({
+      kind: 'satisfy',
+      type: 'satisfy-need:hunger',
+    });
+
+    expect(reasoner.selectIntention(ctx(candidates, { hunger: 0.9 }))).toBeNull();
+  });
+
+  it('honours a custom toBeliefs mapper', () => {
+    type PerceivedCountBeliefs = { perceivedCount: number };
+    const reasoner = new JsSonReasoner({
+      beliefs: { perceivedCount: 0 },
+      toBeliefs: (c) => ({ perceivedCount: c.perceived.length + c.candidates.length }),
+      plans: [
+        Plan(
+          (intentions) => (intentions as PerceivedCountBeliefs).perceivedCount > 0,
+          (intentions) => [
+            { intention: { kind: 'react', type: 'observe', params: { seen: intentions } } },
+          ],
+        ),
+      ],
+    });
+
+    expect(reasoner.selectIntention(ctx([]))).toBeNull();
+    const observed = reasoner.selectIntention(
+      ctx([{ intention: { kind: 'satisfy', type: 'eat' }, score: 0.5, source: 'needs' }]),
+    );
+    expect(observed?.kind).toBe('react');
+    expect(observed?.type).toBe('observe');
+  });
+
+  it('uses the last committed intention when multiple plans fire', () => {
+    const reasoner = new JsSonReasoner({
+      beliefs: { ...Belief('alive', true) },
+      plans: [
+        Plan(
+          () => true,
+          () => [{ intention: { kind: 'express', type: 'first' } }],
+        ),
+        Plan(
+          () => true,
+          () => [{ intention: { kind: 'express', type: 'second' } }],
+        ),
+      ],
+    });
+    expect(reasoner.selectIntention(ctx([]))).toEqual({ kind: 'express', type: 'second' });
+  });
+
+  it('reset() rebuilds the agent so beliefs do not accumulate across ticks', () => {
+    const reasoner = new JsSonReasoner({
+      beliefs: { counter: 0 },
+      plans: [
+        Plan(
+          () => true,
+          () => [{ log: 'seen' }],
+        ),
+      ],
+    });
+    reasoner.selectIntention(ctx([], { hunger: 0.5 }));
+    const dirty = reasoner.getBeliefs();
+    expect(dirty['needs']).toBeDefined();
+    reasoner.reset();
+    const fresh = reasoner.getBeliefs();
+    expect(fresh['needs']).toBeUndefined();
+    expect(fresh['counter']).toBe(0);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ import { resolve } from 'node:path';
 // - excalibur:   src/integrations/excalibur/index.ts → dist/integrations/excalibur/index.js
 // - mistreevous: src/cognition/adapters/mistreevous/index.ts
 //                                                    → dist/cognition/adapters/mistreevous/index.js
+// - js-son:      src/cognition/adapters/js-son/index.ts
+//                                                    → dist/cognition/adapters/js-son/index.js
 //
 // All peer dependencies are marked external so consumers provide them.
 
@@ -34,6 +36,10 @@ export default defineConfig({
         'cognition/adapters/mistreevous/index': resolve(
           __dirname,
           'src/cognition/adapters/mistreevous/index.ts',
+        ),
+        'cognition/adapters/js-son/index': resolve(
+          __dirname,
+          'src/cognition/adapters/js-son/index.ts',
         ),
       },
       formats: ['es'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from 'vite';
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { defineConfig, type Plugin } from 'vite';
 import dts from 'vite-plugin-dts';
-import { resolve } from 'node:path';
 
 // Library mode build. Entries:
 // - main:        src/index.ts                        → dist/index.js
@@ -11,6 +12,59 @@ import { resolve } from 'node:path';
 //                                                    → dist/cognition/adapters/js-son/index.js
 //
 // All peer dependencies are marked external so consumers provide them.
+
+// Loose ambient `.d.ts` shims that vite-plugin-dts does not process
+// (it only emits declarations for `.ts` sources it compiles). For each
+// entry: copy the shim into `dist/` and prepend a `/// <reference>`
+// line to the listed emitted `.d.ts` files so consumers pick up the
+// ambient module declaration automatically when importing the subpath.
+type AmbientDtsEntry = {
+  /** Shim source path, relative to project root. */
+  from: string;
+  /** Shim destination path, relative to project root. */
+  to: string;
+  /**
+   * Emitted `.d.ts` files (relative to project root) that need a
+   * triple-slash reference to the shim prepended so TS resolves the
+   * ambient declaration when consuming the subpath.
+   */
+  referencedBy: string[];
+};
+
+const ambientDtsEntries: AmbientDtsEntry[] = [
+  {
+    from: 'src/cognition/adapters/js-son/js-son-agent.d.ts',
+    to: 'dist/cognition/adapters/js-son/js-son-agent.d.ts',
+    referencedBy: [
+      'dist/cognition/adapters/js-son/index.d.ts',
+      'dist/cognition/adapters/js-son/JsSonReasoner.d.ts',
+    ],
+  },
+];
+
+function copyAmbientDts(): Plugin {
+  return {
+    name: 'agentonomous:copy-ambient-dts',
+    apply: 'build',
+    closeBundle() {
+      for (const entry of ambientDtsEntries) {
+        const src = resolve(__dirname, entry.from);
+        const dest = resolve(__dirname, entry.to);
+        mkdirSync(resolve(dest, '..'), { recursive: true });
+        copyFileSync(src, dest);
+        for (const ref of entry.referencedBy) {
+          const refAbs = resolve(__dirname, ref);
+          const relPath = relative(resolve(refAbs, '..'), dest).replace(/\\/g, '/');
+          const prefixedPath = relPath.startsWith('.') ? relPath : `./${relPath}`;
+          const directive = `/// <reference path="${prefixedPath}" />\n`;
+          const current = readFileSync(refAbs, 'utf8');
+          if (current.startsWith(directive)) continue;
+          writeFileSync(refAbs, directive + current);
+        }
+      }
+    },
+  };
+}
 
 const externalPackages = [
   '@anthropic-ai/sdk',
@@ -62,6 +116,7 @@ export default defineConfig({
       rollupTypes: false,
       insertTypesEntry: true,
     }),
+    copyAmbientDts(),
   ],
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

Third PR of roadmap item **P4** (cognition switcher). Adds the BDI reasoner — wraps the optional [`js-son-agent`](https://github.com/TimKam/js-son) peer behind the now-shared adapter pattern (separate vite entry + opt-in subpath export + size-limit budget). Sits alongside the heuristic `UrgencyReasoner` (default) and the mistreevous BT adapter from PR #34.

- `src/cognition/adapters/js-son/JsSonReasoner.ts` builds a js-son `Agent` from consumer-provided beliefs/desires/plans, then per `selectIntention(ctx)` maps the `ReasonerContext` into belief updates via a `toBeliefs` mapper (default exposes `needs`, `candidates`, and a `topCandidate` helper) and scans the resulting plan-body actions for one carrying an `intention` field. Last commit wins, mirroring the mistreevous adapter.
- `reset()` rebuilds the underlying agent from the stored options so consumers can rewind after major state shifts (lifecycle stage transitions, etc.).
- Re-exports `Belief`, `Desire`, `Plan` from js-son so consumers don't need a direct `js-son-agent` import to author plans.
- Local ambient `js-son-agent.d.ts` covers the slice of the untyped js-son API the adapter touches (Agent constructor object form, `next`, helpers).

## Why no `random` / `getDeltaTime` injection (vs. mistreevous)

js-son evaluates desires and plans deterministically — it doesn't consult `Math.random` or `Date.now` anywhere in its hot path. Plans run in array order, desires run in `Object.keys` order. So as long as plan bodies are pure w.r.t. inputs, the reasoner is byte-deterministic on its own without forwarding the agent's seeded `Rng`. (Documented in the class docstring.)

## Bundle / packaging

Ships from a separate entry point `agentonomous/cognition/adapters/js-son` — pulling `js-son-agent` into the consumer's bundle is opt-in and only happens when this module is imported. Wired via:

- `vite.config.ts` — new entry point.
- `package.json` `exports` — new subpath.
- `package.json` `size-limit` — 2 KB gzip budget; current 1.37 KB.

`js-son-agent` was already declared as an optional peer dep (and `external` in vite); this PR adds it to `devDependencies` so we can typecheck and run the unit tests.

## Tests (8 new in `tests/unit/cognition/adapters/JsSonReasoner.test.ts`)

- Empty intent → `null` when no plan commits.
- A plan body can commit an intention via `{ intention: ... }` action.
- Default `toBeliefs` exposes `needs` (flat `{id: level}`) — plans route on `needs.hunger`.
- Desires drive plan firing: `urgent` desire only fires plan when hunger is critical.
- `topCandidate` helper is exposed as a belief — no-desire plans can pick from `ctx.candidates`.
- Last-wins tie-break when multiple plans commit different intentions.
- Custom `toBeliefs` mapper is honoured.
- `reset()` rebuilds the agent so accumulated beliefs don't leak across ticks.

## Why this PR is small

Each adapter (BT, BDI, learning bias) is independently shippable. The demo's Chapter C dropdown will land as a single demo PR after all four adapters are in. This keeps each adapter PR reviewable in isolation and the per-adapter optional-peer surface gated behind its own bundle entry.

## Changeset

Minor bump — additive subpath export.

## Test plan

- [x] `npm run verify` (format:check + lint + typecheck + 328 tests + build) green.
- [x] Main `dist/index.js` unchanged at 30.94 kB gzip; new js-son entry at 1.37 kB gzip.
- [x] No new `Date.now` / `Math.random` / `setTimeout` in `src/`.

https://claude.ai/code/session_01GDTFnHb1GQbo86yRoFmtXo