### PR TITLE
polish(demo): smooth HUD + richer event log + shared constants

### DIFF
--- a/.changeset/store-binding-event-only-caveat.md
+++ b/.changeset/store-binding-event-only-caveat.md
@@ -1,0 +1,9 @@
+---
+'agentonomous': patch
+---
+
+Document that `bindAgentToStore` is event-driven only — its listener does
+not fire on silent per-tick state changes (needs decay, age advance,
+modifier countdown). JSDoc now explicitly steers consumers toward
+combining the subscription with a `requestAnimationFrame` loop that
+reads `agent.getState()` every frame for a smoothly-animated HUD.

--- a/examples/nurture-pet/src/constants.ts
+++ b/examples/nurture-pet/src/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared demo-level constants. Extracted so the HUD (`ui.ts`) and the
+ * decision-trace inspector (`traceView.ts`) show the same needs in the
+ * same order without drift.
+ */
+export const NEEDS: readonly { id: string; label: string }[] = [
+  { id: 'hunger', label: 'Hunger' },
+  { id: 'cleanliness', label: 'Cleanliness' },
+  { id: 'happiness', label: 'Happiness' },
+  { id: 'energy', label: 'Energy' },
+  { id: 'health', label: 'Health' },
+];

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -117,6 +117,10 @@ bindAgentToStore(pet, (state) => {
 });
 
 // Additional listener to decorate mildIllness / surpriseTreat side-effects.
+// Note: `Modifier.expiresAt` is wall-clock ms — it does not scale with
+// `setTimeScale`. At 8× the pet ages eight times faster but a 45 000 ms
+// `sick` modifier still expires after 45 s of real time. See
+// `CLAUDE.md → setTimeScale(0) pause semantics` for the full quirk.
 pet.subscribe((event) => {
   if (event.type !== 'RandomEvent') return;
   const re = event as { subtype?: string };
@@ -166,12 +170,18 @@ pet.subscribe((event) => {
 });
 
 // --- Game loop ----------------------------------------------------------------
+// `bindAgentToStore` fires the HUD updater only when the agent publishes an
+// event. Between events (most ticks) needs decay, age advances, and modifier
+// timers count down silently — without this per-frame repaint the HUD would
+// appear frozen until the next critical-threshold crossing or skill result.
 let last = performance.now();
 async function loop(now: number): Promise<void> {
   const dt = Math.min((now - last) / 1000, 0.25);
   last = now;
   const trace = await pet.tick(dt);
-  traceView.render(trace, pet.getState());
+  const state = pet.getState();
+  hud.update(state);
+  traceView.render(trace, state);
   requestAnimationFrame((t) => {
     void loop(t);
   });

--- a/examples/nurture-pet/src/traceView.ts
+++ b/examples/nurture-pet/src/traceView.ts
@@ -1,12 +1,6 @@
+import { isEmitEventAction, isInvokeSkillAction } from 'agentonomous';
 import type { Agent, AgentState, DecisionTrace, IntentionCandidate } from 'agentonomous';
-
-const NEEDS: { id: string; label: string }[] = [
-  { id: 'hunger', label: 'Hunger' },
-  { id: 'cleanliness', label: 'Cleanliness' },
-  { id: 'happiness', label: 'Happiness' },
-  { id: 'energy', label: 'Energy' },
-  { id: 'health', label: 'Health' },
-];
+import { NEEDS } from './constants.js';
 
 const VISIBILITY_STORAGE_KEY = 'agentonomous/trace-visible';
 const TOP_CANDIDATES = 5;
@@ -136,11 +130,11 @@ function renderSelection(trace: DecisionTrace): HTMLElement {
   }
   const rows = trace.actions
     .map((a) => {
-      if (a.type === 'invoke-skill') {
+      if (isInvokeSkillAction(a)) {
         const params = a.params ? ` · ${escapeHtml(JSON.stringify(a.params))}` : '';
         return `<div class="trace-row"><span class="trace-k">invoke-skill</span><span class="trace-v">${escapeHtml(a.skillId)}${params}</span></div>`;
       }
-      if (a.type === 'emit-event') {
+      if (isEmitEventAction(a)) {
         return `<div class="trace-row"><span class="trace-k">emit-event</span><span class="trace-v">${escapeHtml(a.event.type)}</span></div>`;
       }
       return `<div class="trace-row"><span class="trace-k">${escapeHtml(a.type)}</span><span class="trace-v">—</span></div>`;

--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -1,12 +1,5 @@
 import type { Agent, AgentState } from 'agentonomous';
-
-const NEEDS: { id: string; label: string }[] = [
-  { id: 'hunger', label: 'Hunger' },
-  { id: 'cleanliness', label: 'Cleanliness' },
-  { id: 'happiness', label: 'Happiness' },
-  { id: 'energy', label: 'Energy' },
-  { id: 'health', label: 'Health' },
-];
+import { NEEDS } from './constants.js';
 
 const INTERACTION_BUTTONS: { verb: string; label: string }[] = [
   { verb: 'feed', label: '🍖 Feed' },
@@ -68,7 +61,7 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
     buttonsEl.appendChild(btn);
   }
 
-  // Recent-event log (trimmed tail) + R-26 lifetime counters.
+  // Recent-event log (newest on top, trimmed tail) + R-26 lifetime counters.
   const traceLines: string[] = [];
   const counters: LifetimeCounters = {
     ateCount: 0,
@@ -77,13 +70,12 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
     petCount: 0,
   };
   agent.subscribe((event) => {
-    traceLines.push(
-      `${new Date(event.at).toISOString().slice(11, 19)}  ${event.type}${
-        typeof event.agentId === 'string' ? ` (${event.agentId})` : ''
-      }`,
-    );
-    if (traceLines.length > 40) traceLines.shift();
-    trace.textContent = traceLines.join('\n');
+    const line = formatEventLine(event);
+    if (line) {
+      traceLines.unshift(line);
+      if (traceLines.length > 40) traceLines.pop();
+      trace.textContent = traceLines.join('\n');
+    }
 
     // Tally the events we care about for the life-summary modal.
     if (event.type === 'SkillCompleted') {
@@ -483,4 +475,141 @@ function escapeHtml(s: string): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+const INTERACTION_VERB_LABELS: Record<string, string> = {
+  feed: '🍖 Feed',
+  clean: '🫧 Clean',
+  play: '🎾 Play',
+  rest: '💤 Rest',
+  pet: '❤️ Pet',
+  medicate: '💊 Medicate',
+  scold: '😠 Scold',
+};
+
+const SKILL_LABELS: Record<string, string> = {
+  feed: '🍖 Fed',
+  clean: '🫧 Cleaned',
+  play: '🎾 Played',
+  rest: '💤 Rested',
+  pet: '❤️ Petted',
+  medicate: '💊 Medicated',
+  scold: '😠 Scolded',
+  'express-meow': '😺 Meowed',
+  'express-sad': '😢 Cried',
+  'express-sleepy': '😴 Yawned',
+};
+
+const RANDOM_EVENT_LABELS: Record<string, string> = {
+  mildIllness: '🤒 Fell ill',
+  surpriseTreat: '🎁 Surprise treat',
+  messyPlay: '🧹 Made a mess',
+};
+
+const NEED_LABELS: Record<string, string> = {
+  hunger: 'hunger',
+  cleanliness: 'cleanliness',
+  happiness: 'happiness',
+  energy: 'energy',
+  health: 'health',
+};
+
+function formatTimestamp(at: number): string {
+  return new Date(at).toISOString().slice(11, 19);
+}
+
+function needLabel(id: string): string {
+  return NEED_LABELS[id] ?? id;
+}
+
+/**
+ * Turn a domain event into a single-line, human-friendly log entry. Returns
+ * `null` for events we intentionally skip (e.g. the synthetic `__init__`
+ * emitted by `bindAgentToStore`) so the log stays focused on simulation
+ * activity.
+ */
+function formatEventLine(
+  event: { type: string; at: number } & Record<string, unknown>,
+): string | null {
+  const ts = formatTimestamp(event.at);
+  const t = event.type;
+
+  if (t === '__init__') return null;
+
+  if (t === 'InteractionRequested') {
+    const verb = typeof event['verb'] === 'string' ? (event['verb'] as string) : 'unknown';
+    const label = INTERACTION_VERB_LABELS[verb] ?? verb;
+    return `${ts}  → ${label} requested`;
+  }
+  if (t === 'SkillCompleted') {
+    const skillId = typeof event['skillId'] === 'string' ? (event['skillId'] as string) : 'skill';
+    const eff = typeof event['effectiveness'] === 'number' ? (event['effectiveness'] as number) : 1;
+    const label = SKILL_LABELS[skillId] ?? skillId;
+    const pct = Math.round(eff * 100);
+    return `${ts}  ✓ ${label}${pct === 100 ? '' : ` (${pct}% effective)`}`;
+  }
+  if (t === 'SkillFailed') {
+    const skillId = typeof event['skillId'] === 'string' ? (event['skillId'] as string) : 'skill';
+    const code = typeof event['code'] === 'string' ? (event['code'] as string) : 'failed';
+    const msg = typeof event['message'] === 'string' ? (event['message'] as string) : '';
+    const label = SKILL_LABELS[skillId] ?? skillId;
+    return `${ts}  ✗ ${label} failed — ${code}${msg ? `: ${msg}` : ''}`;
+  }
+  if (t === 'RandomEvent') {
+    const subtype = typeof event['subtype'] === 'string' ? (event['subtype'] as string) : '';
+    const label = RANDOM_EVENT_LABELS[subtype] ?? `random: ${subtype || 'unknown'}`;
+    return `${ts}  ⚡ ${label}`;
+  }
+  if (t === 'NeedCritical') {
+    const needId = typeof event['needId'] === 'string' ? (event['needId'] as string) : '?';
+    const level = typeof event['level'] === 'number' ? (event['level'] as number) : NaN;
+    return `${ts}  ⚠ ${needLabel(needId)} critical (${level.toFixed(2)})`;
+  }
+  if (t === 'NeedSafe') {
+    const needId = typeof event['needId'] === 'string' ? (event['needId'] as string) : '?';
+    const level = typeof event['level'] === 'number' ? (event['level'] as number) : NaN;
+    return `${ts}  ✓ ${needLabel(needId)} recovered (${level.toFixed(2)})`;
+  }
+  if (t === 'NeedSatisfied') {
+    const needId = typeof event['needId'] === 'string' ? (event['needId'] as string) : '?';
+    const before = typeof event['before'] === 'number' ? (event['before'] as number) : NaN;
+    const after = typeof event['after'] === 'number' ? (event['after'] as number) : NaN;
+    return `${ts}  + ${needLabel(needId)} ${before.toFixed(2)} → ${after.toFixed(2)}`;
+  }
+  if (t === 'ModifierApplied') {
+    const mod = event['modifier'] as
+      | { id?: string; visual?: { label?: string }; source?: string }
+      | undefined;
+    const id = mod?.visual?.label ?? mod?.id ?? 'modifier';
+    const source = mod?.source ? ` (${mod.source})` : '';
+    return `${ts}  + ${id}${source}`;
+  }
+  if (t === 'ModifierExpired') {
+    const id =
+      typeof event['modifierId'] === 'string' ? (event['modifierId'] as string) : 'modifier';
+    return `${ts}  − ${id} expired`;
+  }
+  if (t === 'ModifierRemoved') {
+    const id =
+      typeof event['modifierId'] === 'string' ? (event['modifierId'] as string) : 'modifier';
+    const reason = typeof event['reason'] === 'string' ? (event['reason'] as string) : 'removed';
+    return `${ts}  − ${id} ${reason}`;
+  }
+  if (t === 'MoodChanged') {
+    const from = typeof event['from'] === 'string' ? (event['from'] as string) : '—';
+    const to = typeof event['to'] === 'string' ? (event['to'] as string) : '?';
+    return `${ts}  mood ${from} → ${to}`;
+  }
+  if (t === 'LifeStageChanged') {
+    const from = typeof event['from'] === 'string' ? (event['from'] as string) : '?';
+    const to = typeof event['to'] === 'string' ? (event['to'] as string) : '?';
+    return `${ts}  🎂 ${from} → ${to}`;
+  }
+  if (t === 'AgentDied') {
+    const cause = typeof event['cause'] === 'string' ? (event['cause'] as string) : 'unknown';
+    const reason = typeof event['reason'] === 'string' ? ` — ${event['reason'] as string}` : '';
+    return `${ts}  🪦 died: ${cause}${reason}`;
+  }
+
+  return `${ts}  ${t}`;
 }

--- a/src/persistence/StoreBinding.ts
+++ b/src/persistence/StoreBinding.ts
@@ -16,6 +16,15 @@ import type { AgentState } from './AgentState.js';
  * fresh `getState()` projection into the consumer's store. It's
  * intentionally minimal — any reactive framework (Pinia, Zustand, Redux,
  * Svelte stores, signals, React atoms) can plug in via the callback.
+ *
+ * **Event-driven only.** The listener fires on bus events — not on silent
+ * per-tick state changes. Needs decay, age advances, and time-bound
+ * modifier countdowns all happen between events, so a UI driven purely
+ * by this helper will appear frozen until the next `NeedCritical`,
+ * `SkillCompleted`, `ModifierApplied`, lifecycle transition, etc. For a
+ * smoothly-animated HUD, combine this subscription with a
+ * `requestAnimationFrame` loop (or equivalent host tick) that reads
+ * `agent.getState()` every frame.
  */
 export type AgentStateListener = (state: AgentState, event: DomainEvent) => void;
 


### PR DESCRIPTION
## Summary

Follow-up polish PR consolidating the review findings against the post-P4 demo + library. Two user-visible bugs + four small hygiene items.

### Demo bugs (user-reported)

1. **"Time is not running constantly" — HUD freezes between events.**
   Root cause: `bindAgentToStore` is event-driven and the demo only painted the HUD inside that callback. Needs decay, age advances, and modifier countdowns happen silently between bus events, so the HUD only refreshed on `NeedCritical` / `SkillCompleted` / `ModifierApplied` / lifecycle transitions.
   Fix: `examples/nurture-pet/src/main.ts` now calls `hud.update(state)` every rAF frame alongside the existing `traceView.render(...)`.

2. **Event log was chronological + cryptic.**
   Fix: `examples/nurture-pet/src/ui.ts` pushes newest entries to the top and formats each event through label dictionaries — interaction verbs, skill IDs, random-event subtypes, need IDs, modifier ids, mood, life stages, death cause. A glance now explains *what* happened and (for failures) *why*.

### Hygiene

3. **`AgentAction` narrowing in `traceView.ts`** — switched to the exported `isInvokeSkillAction` / `isEmitEventAction` type guards. Fixes pre-existing TS2339 errors caused by the `type: string & {}` escape hatch.
4. **`NEEDS` dedup** — `examples/nurture-pet/src/constants.ts` is the single source used by both `ui.ts` and `traceView.ts`.
5. **Modifier wall-clock caveat** — JSDoc note in `main.ts` explains why `Modifier.expiresAt` at 8× still expires after 45 s of real time (see `CLAUDE.md → setTimeScale(0) pause semantics`).
6. **`StoreBinding` JSDoc** — `src/persistence/StoreBinding.ts` now explicitly states the listener is event-driven only and points consumers at the rAF companion loop.

### Changeset

Patch bump for the StoreBinding JSDoc clarification (`.changeset/store-binding-event-only-caveat.md`). No runtime behavior changes in the library.

## Deferred (flagged during review, not in this PR)

Each would need its own scoped branch:

- `_internalPublish` / `_internalDie` rename on `Agent` (breaking surface change).
- New `AgentTicked` event so consumers can drive per-frame UI without the rAF companion.
- `Reasoner.reset()` harmonization across the three cognition adapters (BT / BDI / brain.js).

## Test plan

- [x] `npm run verify` — format, lint, typecheck, 336 tests, build all green.
- [ ] Manual demo smoke test: HUD meters tick continuously between interactions; event log reads newest-on-top with human-readable entries for Feed / Play / Clean / Scold / Pet + random events + modifier expiry + stage transitions.

https://claude.ai/code/session_01GDTFnHb1GQbo86yRoFmtXo