### PR TITLE
chore: enable superpowers plugin at project scope

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -126,5 +126,8 @@
       "Bash(rm -rf tests*)",
       "Bash(rm -rf .git*)"
     ]
+  },
+  "enabledPlugins": {
+    "superpowers@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary

- Enables `superpowers@claude-plugins-official` (v5.0.7) at project scope via `.claude/settings.json` so the `brainstorming`, `writing-plans`, `execute-plan`, and related skills travel with the repo.
- Every contributor gets the skills on first Claude Code session in this repo; no per-user install needed.

## Test plan

- [ ] After merge + fresh Claude Code session in this repo, `claude plugin list` shows `superpowers@claude-plugins-official` as enabled in project scope.
- [ ] The `brainstorming` and `writing-plans` skills appear in the available-skills list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)