### PR TITLE
perf(demo): cut per-frame DOM churn and add teardown plumbing

### DIFF
--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -8,7 +8,6 @@ import {
   InMemoryMemoryAdapter,
   RandomEventTicker,
   SkillRegistry,
-  bindAgentToStore,
 } from 'agentonomous';
 import { catSpecies } from './species.js';
 import {
@@ -112,16 +111,18 @@ mountResetButton(pet);
 mountConfigPanel(catSpecies, currentEditableConfig(effectiveSpecies), () =>
   resetSimulation(pet.identity.id),
 );
-bindAgentToStore(pet, (state) => {
-  hud.update(state);
-});
+
+// HUD updates run from the per-frame RAF loop below — a prior
+// `bindAgentToStore` hook also called `hud.update` on every agent event,
+// causing two renders on event ticks. The RAF loop already covers
+// steady-state repaints.
 
 // Additional listener to decorate mildIllness / surpriseTreat side-effects.
 // Note: `Modifier.expiresAt` is wall-clock ms — it does not scale with
 // `setTimeScale`. At 8× the pet ages eight times faster but a 45 000 ms
 // `sick` modifier still expires after 45 s of real time. See
 // `CLAUDE.md → setTimeScale(0) pause semantics` for the full quirk.
-pet.subscribe((event) => {
+const unsubscribeModifierDecorator = pet.subscribe((event) => {
   if (event.type !== 'RandomEvent') return;
   const re = event as { subtype?: string };
   if (re.subtype === 'mildIllness') {
@@ -170,23 +171,47 @@ pet.subscribe((event) => {
 });
 
 // --- Game loop ----------------------------------------------------------------
-// `bindAgentToStore` fires the HUD updater only when the agent publishes an
-// event. Between events (most ticks) needs decay, age advances, and modifier
-// timers count down silently — without this per-frame repaint the HUD would
-// appear frozen until the next critical-threshold crossing or skill result.
+// Needs decay, age advances, and modifier timers count down silently
+// between agent events — without this per-frame repaint the HUD would
+// appear frozen until the next critical-threshold crossing or skill
+// result.
 let last = performance.now();
+let rafHandle = 0;
+let stopped = false;
 async function loop(now: number): Promise<void> {
   const dt = Math.min((now - last) / 1000, 0.25);
   last = now;
   const trace = await pet.tick(dt);
+  if (stopped) return;
   const state = pet.getState();
   hud.update(state);
   traceView.render(trace, state);
-  requestAnimationFrame((t) => {
+  rafHandle = requestAnimationFrame((t) => {
     void loop(t);
   });
 }
-requestAnimationFrame((t) => {
+rafHandle = requestAnimationFrame((t) => {
   last = t;
   void loop(t);
 });
+
+/**
+ * Tear down the demo cleanly: stop the RAF loop, drop the modifier-decorator
+ * subscription, and dispose the HUD's event subscription. Safe to call
+ * multiple times. The production flow resets via `location.reload()` so
+ * this path is mostly a safety net for future in-place reset flows and for
+ * HMR correctness (it prevents listener stacks across hot reloads).
+ */
+function disposeDemo(): void {
+  if (stopped) return;
+  stopped = true;
+  if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
+  unsubscribeModifierDecorator();
+  hud.dispose();
+}
+
+// Wire Vite HMR teardown so an edit-triggered reload doesn't stack a second
+// RAF loop / subscription on top of the old one. Typed inline to avoid
+// depending on `vite/client` ambient types from the demo tsconfig.
+const meta = import.meta as unknown as { hot?: { dispose: (cb: () => void) => void } };
+if (meta.hot) meta.hot.dispose(disposeDemo);

--- a/examples/nurture-pet/src/traceView.ts
+++ b/examples/nurture-pet/src/traceView.ts
@@ -32,44 +32,68 @@ export function mountTraceView(agent: Agent): {
     writeVisible(next);
   });
 
+  // Build the four section hosts once. The per-frame `render` only rewrites
+  // a section's `innerHTML` when its serialized signature actually changed —
+  // steady-state ticks are near-zero DOM work.
+  const summaryEl = document.createElement('div');
+  summaryEl.className = 'trace-summary';
+  const needsEl = document.createElement('section');
+  needsEl.className = 'trace-section';
+  const candidatesEl = document.createElement('section');
+  candidatesEl.className = 'trace-section';
+  const selectionEl = document.createElement('section');
+  selectionEl.className = 'trace-section';
+  body.appendChild(summaryEl);
+  body.appendChild(needsEl);
+  body.appendChild(candidatesEl);
+  body.appendChild(selectionEl);
+
+  const prev = { summary: '', needs: '', candidates: '', selection: '' };
+
   return {
     render(trace, state) {
       if (panel.dataset.visible !== 'true') return;
-      renderBody(body, trace, state, agent.getTimeScale());
+      const timeScale = agent.getTimeScale();
+
+      const summary = buildSummary(trace, state, timeScale);
+      if (summary !== prev.summary) {
+        summaryEl.innerHTML = summary;
+        prev.summary = summary;
+      }
+
+      const needs = buildNeeds(state, trace);
+      if (needs !== prev.needs) {
+        needsEl.innerHTML = needs;
+        prev.needs = needs;
+      }
+
+      const candidates = buildCandidates(trace);
+      if (candidates !== prev.candidates) {
+        candidatesEl.innerHTML = candidates;
+        prev.candidates = candidates;
+      }
+
+      const selection = buildSelection(trace);
+      if (selection !== prev.selection) {
+        selectionEl.innerHTML = selection;
+        prev.selection = selection;
+      }
     },
   };
 }
 
-function renderBody(
-  host: HTMLElement,
-  trace: DecisionTrace,
-  state: AgentState,
-  timeScale: number,
-): void {
-  host.innerHTML = '';
-  host.appendChild(renderSummary(trace, state, timeScale));
-  host.appendChild(renderNeeds(state, trace));
-  host.appendChild(renderCandidates(trace));
-  host.appendChild(renderSelection(trace));
-}
-
-function renderSummary(trace: DecisionTrace, state: AgentState, timeScale: number): HTMLElement {
-  const wrap = document.createElement('div');
-  wrap.className = 'trace-summary';
+function buildSummary(trace: DecisionTrace, state: AgentState, timeScale: number): string {
   const paused = timeScale === 0;
   const mode = paused ? 'paused' : trace.controlMode;
   const dt = trace.virtualDtSeconds.toFixed(3);
-  wrap.innerHTML = `
-    <div class="trace-row"><span class="trace-k">mode</span><span class="trace-v">${escapeHtml(mode)}</span></div>
-    <div class="trace-row"><span class="trace-k">stage</span><span class="trace-v">${escapeHtml(state.stage)}</span></div>
-    <div class="trace-row"><span class="trace-k">virtual dt</span><span class="trace-v">${escapeHtml(dt)}s</span></div>
-  `;
-  return wrap;
+  return (
+    `<div class="trace-row"><span class="trace-k">mode</span><span class="trace-v">${escapeHtml(mode)}</span></div>` +
+    `<div class="trace-row"><span class="trace-k">stage</span><span class="trace-v">${escapeHtml(state.stage)}</span></div>` +
+    `<div class="trace-row"><span class="trace-k">virtual dt</span><span class="trace-v">${escapeHtml(dt)}s</span></div>`
+  );
 }
 
-function renderNeeds(state: AgentState, trace: DecisionTrace): HTMLElement {
-  const wrap = document.createElement('section');
-  wrap.className = 'trace-section';
+function buildNeeds(state: AgentState, trace: DecisionTrace): string {
   const candidates = getCandidates(trace);
   const urgencyByNeed = new Map<string, number>();
   for (const c of candidates) {
@@ -85,48 +109,39 @@ function renderNeeds(state: AgentState, trace: DecisionTrace): HTMLElement {
     const level = state.needs[need.id] ?? 0;
     const urgency = urgencyByNeed.get(need.id);
     const urgencyStr = urgency === undefined ? '—' : urgency.toFixed(2);
-    return `
-      <div class="trace-row">
-        <span class="trace-k">${escapeHtml(need.label)}</span>
-        <span class="trace-v">${level.toFixed(2)} · urgency ${escapeHtml(urgencyStr)}</span>
-      </div>`;
+    return (
+      `<div class="trace-row">` +
+      `<span class="trace-k">${escapeHtml(need.label)}</span>` +
+      `<span class="trace-v">${level.toFixed(2)} · urgency ${escapeHtml(urgencyStr)}</span>` +
+      `</div>`
+    );
   }).join('');
-
-  wrap.innerHTML = `<h4>Needs</h4>${rows}`;
-  return wrap;
+  return `<h4>Needs</h4>${rows}`;
 }
 
-function renderCandidates(trace: DecisionTrace): HTMLElement {
-  const wrap = document.createElement('section');
-  wrap.className = 'trace-section';
+function buildCandidates(trace: DecisionTrace): string {
   const candidates = getCandidates(trace);
   if (candidates.length === 0) {
-    wrap.innerHTML = `<h4>Candidates</h4><div class="trace-empty">none</div>`;
-    return wrap;
+    return `<h4>Candidates</h4><div class="trace-empty">none</div>`;
   }
   // Candidates arrive pre-sorted by the reasoner; copy then sort defensively
   // so the panel never misleads if a future change drops the invariant.
   const sorted = [...candidates].sort((a, b) => b.score - a.score).slice(0, TOP_CANDIDATES);
   const rows = sorted
     .map(
-      (c) => `
-      <div class="trace-row">
-        <span class="trace-k">${escapeHtml(c.intention.type)}</span>
-        <span class="trace-v">${c.score.toFixed(2)} · ${escapeHtml(c.source)}</span>
-      </div>`,
+      (c) =>
+        `<div class="trace-row">` +
+        `<span class="trace-k">${escapeHtml(c.intention.type)}</span>` +
+        `<span class="trace-v">${c.score.toFixed(2)} · ${escapeHtml(c.source)}</span>` +
+        `</div>`,
     )
     .join('');
-  wrap.innerHTML = `<h4>Candidates (${candidates.length})</h4>${rows}`;
-  return wrap;
+  return `<h4>Candidates (${candidates.length})</h4>${rows}`;
 }
 
-function renderSelection(trace: DecisionTrace): HTMLElement {
-  const wrap = document.createElement('section');
-  wrap.className = 'trace-section';
+function buildSelection(trace: DecisionTrace): string {
   if (trace.actions.length === 0) {
-    const why = whyNoAction(trace);
-    wrap.innerHTML = `<h4>Selected</h4><div class="trace-empty">${escapeHtml(why)}</div>`;
-    return wrap;
+    return `<h4>Selected</h4><div class="trace-empty">${escapeHtml(whyNoAction(trace))}</div>`;
   }
   const rows = trace.actions
     .map((a) => {
@@ -141,8 +156,7 @@ function renderSelection(trace: DecisionTrace): HTMLElement {
     })
     .join('');
   const why = whyForSelection(trace);
-  wrap.innerHTML = `<h4>Selected</h4>${rows}<div class="trace-why">${escapeHtml(why)}</div>`;
-  return wrap;
+  return `<h4>Selected</h4>${rows}<div class="trace-why">${escapeHtml(why)}</div>`;
 }
 
 function whyForSelection(trace: DecisionTrace): string {

--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -363,12 +363,16 @@ function writeSavedMult(key: string, mult: number | 'pause'): void {
 }
 
 /**
- * Diffing renderer for the active-modifier chip list. Keeps per-id `<li>`
- * nodes alive across frames so the per-frame HUD update only touches the
+ * Diffing renderer for the active-modifier chip list. Keeps `<li>` nodes
+ * alive across frames so the per-frame HUD update only touches the
  * countdown text (the only thing that actually changes most ticks).
- * Chips are added when a modifier appears, removed when it expires, and
- * re-ordered via `appendChild` (which moves an existing node) to match
- * `agent.modifiers.list()`.
+ *
+ * Chips are keyed by `id` + occurrence index within the current
+ * `agent.modifiers.list()` so `stack: 'stack'` entries (which share an
+ * `id`) each get their own row. Reusing positional keys across frames
+ * preserves diffing in the common case; when a middle entry expires the
+ * remaining chips shift up, which rewrites their text but not the DOM
+ * node count.
  *
  * When `paused` is true the countdown reads `paused` rather than a wall
  * clock figure. Modifier expiry is itself wall-clock-bound (see
@@ -387,31 +391,52 @@ function createModifierTrayRenderer(host: HTMLElement): {
       const now = agent.clock.now();
       const list = agent.modifiers.list();
       const seen = new Set<string>();
+      const nthById = new Map<string, number>();
 
       for (const mod of list) {
-        seen.add(mod.id);
+        const nth = nthById.get(mod.id) ?? 0;
+        nthById.set(mod.id, nth + 1);
+        const key = `${mod.id}#${nth}`;
+        seen.add(key);
+
         const icon = mod.visual?.hudIcon;
         const name = mod.visual?.label ?? mod.id;
         const label = icon ? `${icon} ${name}` : name;
+        const hasTime = typeof mod.expiresAt === 'number';
 
-        let chip = chips.get(mod.id);
+        let chip = chips.get(key);
         if (!chip) {
           const li = document.createElement('li');
           li.textContent = label;
           let time: HTMLSpanElement | null = null;
-          if (typeof mod.expiresAt === 'number') {
+          if (hasTime) {
             time = document.createElement('span');
             time.className = 'mod-time';
             li.appendChild(time);
           }
           chip = { li, time, label };
-          chips.set(mod.id, chip);
+          chips.set(key, chip);
           host.appendChild(li);
-        } else if (chip.label !== label) {
-          // Label changed (e.g. visual swap) — rewrite text, preserve time span.
-          chip.li.textContent = label;
-          if (chip.time) chip.li.appendChild(chip.time);
-          chip.label = label;
+        } else {
+          if (chip.label !== label) {
+            // Positional slot now holds a different modifier (middle entry
+            // expired and later ones shifted up) or the visual changed —
+            // rewrite the label text while preserving the time span.
+            chip.li.textContent = label;
+            if (chip.time) chip.li.appendChild(chip.time);
+            chip.label = label;
+          }
+          // Time span presence can flip if a chip slot is reused for a
+          // modifier with/without `expiresAt`. Reconcile both directions.
+          if (hasTime && !chip.time) {
+            const time = document.createElement('span');
+            time.className = 'mod-time';
+            chip.li.appendChild(time);
+            chip.time = time;
+          } else if (!hasTime && chip.time) {
+            chip.time.remove();
+            chip.time = null;
+          }
         }
 
         if (chip.time) {
@@ -422,10 +447,10 @@ function createModifierTrayRenderer(host: HTMLElement): {
         }
       }
 
-      for (const [id, chip] of chips) {
-        if (!seen.has(id)) {
+      for (const [key, chip] of chips) {
+        if (!seen.has(key)) {
           chip.li.remove();
-          chips.delete(id);
+          chips.delete(key);
         }
       }
     },

--- a/examples/nurture-pet/src/ui.ts
+++ b/examples/nurture-pet/src/ui.ts
@@ -28,7 +28,10 @@ type LifetimeCounters = {
   petCount: number;
 };
 
-export function mountHud(agent: Agent): { update: (state: AgentState) => void } {
+export function mountHud(agent: Agent): {
+  update: (state: AgentState) => void;
+  dispose: () => void;
+} {
   const bars = document.getElementById('bars') as HTMLElement;
   const modifiersEl = document.getElementById('modifier-list') as HTMLElement;
   const buttonsEl = document.getElementById('buttons') as HTMLElement;
@@ -39,7 +42,9 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
   const moodEl = document.getElementById('pet-mood') as HTMLElement;
   const animEl = document.getElementById('pet-animation') as HTMLElement;
 
-  // Build need bars
+  // Build need bars and cache refs so the per-frame `update` loop never hits
+  // `document.querySelector` — which was ~10 DOM traversals per RAF.
+  const needRefs = new Map<string, { fill: HTMLElement; value: HTMLElement }>();
   for (const need of NEEDS) {
     const row = document.createElement('div');
     row.className = 'bar';
@@ -49,6 +54,9 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
       <span class="bar-value" data-need-value="${need.id}">1.00</span>
     `;
     bars.appendChild(row);
+    const fill = row.querySelector<HTMLElement>(`[data-need="${need.id}"]`);
+    const value = row.querySelector<HTMLElement>(`[data-need-value="${need.id}"]`);
+    if (fill && value) needRefs.set(need.id, { fill, value });
   }
 
   // Build interaction buttons
@@ -69,7 +77,7 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
     illnessCount: 0,
     petCount: 0,
   };
-  agent.subscribe((event) => {
+  const unsubscribe = agent.subscribe((event) => {
     const line = formatEventLine(event);
     if (line) {
       traceLines.unshift(line);
@@ -97,6 +105,8 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
 
   nameEl.textContent = agent.identity.name;
 
+  const modifierTray = createModifierTrayRenderer(modifiersEl);
+
   return {
     update(state: AgentState): void {
       const stageLabel = STAGE_LABELS[state.stage] ?? state.stage;
@@ -106,16 +116,15 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
 
       for (const need of NEEDS) {
         const level = state.needs[need.id] ?? 0;
-        const fill = document.querySelector<HTMLElement>(`[data-need="${need.id}"]`);
-        const value = document.querySelector<HTMLElement>(`[data-need-value="${need.id}"]`);
-        if (fill) {
-          fill.style.width = `${Math.max(0, Math.min(100, level * 100))}%`;
-          fill.classList.toggle('critical', level < 0.25);
+        const refs = needRefs.get(need.id);
+        if (refs) {
+          refs.fill.style.width = `${Math.max(0, Math.min(100, level * 100))}%`;
+          refs.fill.classList.toggle('critical', level < 0.25);
+          refs.value.textContent = level.toFixed(2);
         }
-        if (value) value.textContent = level.toFixed(2);
       }
 
-      renderModifierTray(modifiersEl, agent, agent.getTimeScale() === 0);
+      modifierTray.update(agent, agent.getTimeScale() === 0);
 
       // Halt / animation visual cue.
       if (state.halted) {
@@ -143,6 +152,9 @@ export function mountHud(agent: Agent): { update: (state: AgentState) => void } 
         petEl.textContent = '🐱';
         petEl.style.background = '#fde68a';
       }
+    },
+    dispose(): void {
+      unsubscribe();
     },
   };
 }
@@ -260,19 +272,21 @@ export function mountExportImport(agent: Agent): void {
   );
 
   exportBtn.addEventListener('click', () => {
+    let url: string | null = null;
     try {
       const snap = agent.snapshot();
       const blob = new Blob([JSON.stringify(snap, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
+      url = URL.createObjectURL(blob);
       const anchor = document.createElement('a');
       anchor.href = url;
       anchor.download = `${agent.identity.id}.json`;
       document.body.appendChild(anchor);
       anchor.click();
       anchor.remove();
-      URL.revokeObjectURL(url);
     } catch (err) {
       globalThis.alert?.(`Export failed: ${(err as Error).message}`);
+    } finally {
+      if (url !== null) URL.revokeObjectURL(url);
     }
   });
 
@@ -349,38 +363,73 @@ function writeSavedMult(key: string, mult: number | 'pause'): void {
 }
 
 /**
- * Render active modifiers as a chip list with the modifier's HUD icon (if
- * declared on `Modifier.visual.hudIcon`) and a live remaining-time
- * countdown for time-bound modifiers.
+ * Diffing renderer for the active-modifier chip list. Keeps per-id `<li>`
+ * nodes alive across frames so the per-frame HUD update only touches the
+ * countdown text (the only thing that actually changes most ticks).
+ * Chips are added when a modifier appears, removed when it expires, and
+ * re-ordered via `appendChild` (which moves an existing node) to match
+ * `agent.modifiers.list()`.
  *
- * When `paused` is true, the countdown is rendered as `paused` instead of
- * a wall-clock-derived figure. Modifier expiry is itself wall-clock-bound
- * (a documented quirk — see `setTimeScale` JSDoc), so during pause the
- * actual countdown still elapses; this label keeps the UI honest about
- * the user's intent without misrepresenting the underlying state.
+ * When `paused` is true the countdown reads `paused` rather than a wall
+ * clock figure. Modifier expiry is itself wall-clock-bound (see
+ * `setTimeScale` JSDoc), so the countdown still elapses during pause;
+ * this label keeps the UI honest about the user's intent without
+ * misrepresenting the underlying state.
  */
-function renderModifierTray(host: HTMLElement, agent: Agent, paused: boolean): void {
-  host.innerHTML = '';
-  const now = agent.clock.now();
-  for (const mod of agent.modifiers.list()) {
-    const li = document.createElement('li');
-    const icon = mod.visual?.hudIcon;
-    const name = mod.visual?.label ?? mod.id;
-    const label = icon ? `${icon} ${name}` : name;
-    li.textContent = label;
-    if (typeof mod.expiresAt === 'number') {
-      const time = document.createElement('span');
-      time.className = 'mod-time';
-      if (paused) {
-        time.textContent = ' paused';
-      } else {
-        const remainingMs = Math.max(0, mod.expiresAt - now);
-        time.textContent = ` ${formatRemaining(remainingMs)}`;
+type ModifierChip = { li: HTMLLIElement; time: HTMLSpanElement | null; label: string };
+
+function createModifierTrayRenderer(host: HTMLElement): {
+  update: (agent: Agent, paused: boolean) => void;
+} {
+  const chips = new Map<string, ModifierChip>();
+  return {
+    update(agent, paused) {
+      const now = agent.clock.now();
+      const list = agent.modifiers.list();
+      const seen = new Set<string>();
+
+      for (const mod of list) {
+        seen.add(mod.id);
+        const icon = mod.visual?.hudIcon;
+        const name = mod.visual?.label ?? mod.id;
+        const label = icon ? `${icon} ${name}` : name;
+
+        let chip = chips.get(mod.id);
+        if (!chip) {
+          const li = document.createElement('li');
+          li.textContent = label;
+          let time: HTMLSpanElement | null = null;
+          if (typeof mod.expiresAt === 'number') {
+            time = document.createElement('span');
+            time.className = 'mod-time';
+            li.appendChild(time);
+          }
+          chip = { li, time, label };
+          chips.set(mod.id, chip);
+          host.appendChild(li);
+        } else if (chip.label !== label) {
+          // Label changed (e.g. visual swap) — rewrite text, preserve time span.
+          chip.li.textContent = label;
+          if (chip.time) chip.li.appendChild(chip.time);
+          chip.label = label;
+        }
+
+        if (chip.time) {
+          const nextText = paused
+            ? ' paused'
+            : ` ${formatRemaining(Math.max(0, (mod.expiresAt ?? now) - now))}`;
+          if (chip.time.textContent !== nextText) chip.time.textContent = nextText;
+        }
       }
-      li.appendChild(time);
-    }
-    host.appendChild(li);
-  }
+
+      for (const [id, chip] of chips) {
+        if (!seen.has(id)) {
+          chip.li.remove();
+          chips.delete(id);
+        }
+      }
+    },
+  };
 }
 
 function formatAge(seconds: number): string {


### PR DESCRIPTION
## Summary

A review of `examples/nurture-pet/` for memory leaks and hot-path
performance turned up several per-frame inefficiencies and some
teardown gaps that would matter under HMR or a future in-place reset.
All seven findings are addressed in this PR.

### Per-frame wins (items 1–4)

- **Cache need refs at mount** (`ui.ts`) — the HUD update loop no
  longer calls `document.querySelector` 10× per RAF. Refs are resolved
  once when each need bar is built.
- **Diffing modifier tray** (`ui.ts`) — replaced the
  `innerHTML = ''` + full rebuild with a per-id chip cache that only
  rewrites the countdown `textContent` in the steady state. Chips are
  added on apply, removed on expiry.
- **Persistent trace section hosts** (`traceView.ts`) — the four
  Decision Trace sections are built once; each frame computes a
  string signature per section and only assigns `innerHTML` if it
  changed. Opening the trace panel is no longer a ~60 FPS DOM rebuild
  loop.
- **Drop the double HUD update** (`main.ts`) — removed the
  `bindAgentToStore` updater. The RAF loop already covers steady-state
  repaints; the bound updater was rendering the HUD a second time on
  every agent event.

### Teardown plumbing (items 5–7)

- **Capture `agent.subscribe` handles** — `mountHud` now returns a
  `dispose()`; `main.ts` also captures its modifier-decorator
  subscription.
- **Cancel RAF on teardown** — the game loop tracks its handle and a
  `stopped` flag so `cancelAnimationFrame` actually works. A
  `disposeDemo()` ties it all together and is wired to Vite HMR
  `import.meta.hot.dispose` (via an inline type cast — no new demo
  deps) so edits during `npm run demo:dev` no longer stack a second
  RAF loop / listener.
- **Blob URL try/finally** (`ui.ts` export flow) — `revokeObjectURL`
  now runs in a `finally` block, so an exception between
  `createObjectURL` and revoke can't leak the URL.

No library code changed; this is a demo-only refactor, so no changeset
is needed.

## Test plan

- [x] `npm run verify` — format, lint, typecheck, 336 tests, build (all green)
- [x] `npx tsc --noEmit` inside `examples/nurture-pet/` — clean
- [x] `npm run build` inside `examples/nurture-pet/` — builds, no warnings
- [ ] Manual: open the demo, toggle the Decision Trace panel, confirm
      the modifier countdown updates smoothly and that `Performance`
      profiler shows a noticeable drop in scripting / layout time
      per frame
- [ ] Manual: during `npm run demo:dev`, edit `ui.ts` and confirm the
      HMR reload doesn't stack RAF loops (single loop visible in
      DevTools Performance)

https://claude.ai/code/session_016e6kz5dowzHTvnCWND6y26