### PR TITLE
feat: AgentTicked bus event (0.9.1 library)

### DIFF
--- a/.changeset/agent-ticked-event.md
+++ b/.changeset/agent-ticked-event.md
@@ -1,0 +1,16 @@
+---
+'agentonomous': minor
+---
+
+Emit a new `AgentTicked` domain event at the end of every non-halted
+tick. Consumers subscribing via `agent.subscribe` now receive a per-tick
+signal without polling `getState()` from a `requestAnimationFrame`
+companion loop. Additive only — no existing event or type changes.
+
+Payload carries `tickNumber` (1-indexed, monotonic), `virtualDtSeconds`,
+`wallDtSeconds`, `selectedAction` summary (or `null`), and a `trace`
+reference to the full `DecisionTrace` for consumers who want the complete
+tick record. The event is published after the tick's `DecisionTrace` is
+assembled, so the meta-event is intentionally **not** included in the
+trace's `emitted` array. Replay-equivalence: identical seed → identical
+`AgentTicked` sequence.

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -2,11 +2,13 @@ import type { DomainEvent } from '../events/DomainEvent.js';
 import type { EventBusPort } from '../events/EventBusPort.js';
 import {
   AGENT_DIED,
+  AGENT_TICKED,
   LIFE_STAGE_CHANGED,
   MODIFIER_APPLIED,
   MODIFIER_EXPIRED,
   MODIFIER_REMOVED,
   type AgentDiedEvent,
+  type AgentTickedEvent,
   type LifeStageChangedEvent,
   type ModifierAppliedEvent,
   type ModifierRemovedEvent,
@@ -60,6 +62,7 @@ import { INTERACTION_REQUESTED } from '../interaction/InteractionRequestedEvent.
 import type { AgentFacade } from './AgentFacade.js';
 import type { AgentIdentity } from './AgentIdentity.js';
 import type { AgentModule, ReactiveHandler } from './AgentModule.js';
+import { isInvokeSkillAction } from './AgentAction.js';
 import type { ControlMode } from './ControlMode.js';
 import type { DecisionTrace } from './DecisionTrace.js';
 import { InvalidTimeScaleError, MissingDependencyError } from './errors.js';
@@ -202,6 +205,8 @@ export class Agent {
   protected readonly modules: AgentModule[] = [];
   /** Events queued for inclusion in the current tick's `emitted` field. */
   protected emittedThisTick: DomainEvent[] = [];
+  /** 1-indexed count of `AgentTicked` events emitted. Resets only on reconstruction. */
+  protected ticksEmitted: number = 0;
 
   // =========================================================================
   // Internal tick helpers (extracted under src/agent/internal/).
@@ -333,7 +338,9 @@ export class Agent {
     const stageTransitions = this.lifecycleTicker.run(virtualDtSeconds, tickStartedAt);
 
     // Stage 1: perceive — drain pending events from the bus.
-    const perceived = this.eventBus.drain();
+    // `AgentTicked` is a meta-event emitted at the end of each completed tick;
+    // it must not re-enter the cognition pipeline as a perceived stimulus.
+    const perceived = this.eventBus.drain().filter((e) => e.type !== AGENT_TICKED);
     await this.dispatchReactiveHandlers(perceived);
 
     // Stage 1.5: random events — publish seeded random events onto the bus.
@@ -368,7 +375,7 @@ export class Agent {
         halted: true,
         perceived,
         actions: [],
-        emitted: this.emittedThisTick,
+        emitted: [...this.emittedThisTick],
       };
     }
 
@@ -417,9 +424,33 @@ export class Agent {
       halted: false,
       perceived,
       actions,
-      emitted: this.emittedThisTick,
+      emitted: [...this.emittedThisTick],
       ...(deltas ? { deltas } : {}),
     };
+
+    // Emit AgentTicked as the final act of a completed tick. Placed
+    // AFTER trace assembly (with its snapshot-copied `emitted`) so the
+    // meta-event does not appear in its own trace.emitted. Publish
+    // flows through `this.publish(...)` so subscribers receive it via
+    // `agent.subscribe` like any other event.
+    this.ticksEmitted += 1;
+    const firstAction = actions[0];
+    const selectedAction =
+      firstAction === undefined
+        ? null
+        : isInvokeSkillAction(firstAction)
+          ? { type: firstAction.type, skillId: firstAction.skillId }
+          : { type: firstAction.type };
+    this.publish({
+      type: AGENT_TICKED,
+      at: tickStartedAt,
+      agentId: this.identity.id,
+      tickNumber: this.ticksEmitted,
+      virtualDtSeconds,
+      wallDtSeconds: Math.max(0, dtSeconds),
+      selectedAction,
+      trace,
+    } satisfies AgentTickedEvent);
 
     await this.maybeAutoSave();
     return trace;

--- a/src/events/standardEvents.ts
+++ b/src/events/standardEvents.ts
@@ -1,3 +1,4 @@
+import type { DecisionTrace } from '../agent/DecisionTrace.js';
 import type { LifeStage } from '../lifecycle/LifeStage.js';
 import type { Modifier } from '../modifiers/Modifier.js';
 import type { MoodCategory } from '../mood/Mood.js';
@@ -124,4 +125,33 @@ export interface MoodChangedEvent extends DomainEvent {
   to: MoodCategory;
   valence: number | undefined;
   fxHint?: string;
+}
+
+// --- Tick lifecycle (0.9.1) ---
+export const AGENT_TICKED = 'AgentTicked' as const;
+
+/**
+ * Emitted at the end of every non-halted tick, after the `DecisionTrace`
+ * is assembled. Consumers subscribe via `agent.subscribe` to drive UI /
+ * store updates without polling `agent.getState()` in a companion loop.
+ *
+ * The event is **not** included in `trace.emitted` — the trace's
+ * `emitted` array is snapshot-copied at assembly, before this event is
+ * published, so the meta-event cannot self-reference. Replay
+ * equivalence under a fixed seed: identical input sequence produces
+ * identical `AgentTicked` sequence (ordering, payloads).
+ */
+export interface AgentTickedEvent extends DomainEvent {
+  type: typeof AGENT_TICKED;
+  agentId: string;
+  /** 1-indexed, monotonic. Resets only on reconstruction (not on restore). */
+  tickNumber: number;
+  /** `wallDtSeconds * timeScale` advanced this tick. */
+  virtualDtSeconds: number;
+  /** The `dtSeconds` argument the host loop passed to `tick()`. */
+  wallDtSeconds: number;
+  /** Summary of the action the agent selected this tick, or `null` if none. */
+  selectedAction: { type: string; skillId?: string } | null;
+  /** The full tick trace. Same object returned by `agent.tick()`. */
+  trace: DecisionTrace;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,6 +250,7 @@ export {
   MOOD_CHANGED,
   SKILL_COMPLETED,
   SKILL_FAILED,
+  AGENT_TICKED,
   type NeedCriticalEvent,
   type NeedSafeEvent,
   type NeedSatisfiedEvent,
@@ -261,6 +262,7 @@ export {
   type MoodChangedEvent,
   type SkillCompletedEvent,
   type SkillFailedEvent,
+  type AgentTickedEvent,
 } from './events/standardEvents.js';
 
 // Ports — the determinism seams.

--- a/tests/integration/agent-ticked-replay.test.ts
+++ b/tests/integration/agent-ticked-replay.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_TICKED,
+  createAgent,
+  defaultPetInteractionModule,
+  defineRandomEvent,
+  defineSpecies,
+  ExpressMeowSkill,
+  InMemoryMemoryAdapter,
+  ManualClock,
+  RandomEventTicker,
+  SeededRng,
+  SkillRegistry,
+  type AgentTickedEvent,
+  type DomainEvent,
+} from '../../src/index.js';
+
+/**
+ * Replay-equivalence proof for the 0.9.1 AgentTicked event.
+ *
+ * Two agents built with identical seed + clock + species + modules,
+ * stepped through the same dt pattern, must produce byte-identical
+ * `AgentTicked` sequences (ordering, payloads).
+ *
+ * Species + helper shape mirror `parallel-agent-determinism.test.ts`
+ * so the two suites stay in lock-step.
+ */
+const AGENT_ID = 'replay-whiskers';
+
+function buildAgent() {
+  const clock = new ManualClock(1_700_000_000_000);
+  const rng = new SeededRng('agent-ticked-replay');
+  const events: DomainEvent[] = [];
+
+  const species = defineSpecies({
+    id: 'cat',
+    needs: [
+      { id: 'hunger', level: 1, decayPerSec: 0.2, criticalThreshold: 0.3 },
+      { id: 'cleanliness', level: 1, decayPerSec: 0.15, criticalThreshold: 0.25 },
+      { id: 'happiness', level: 0.8, decayPerSec: 0.1, criticalThreshold: 0.25 },
+      { id: 'energy', level: 1, decayPerSec: 0.12, criticalThreshold: 0.2 },
+      { id: 'health', level: 1, decayPerSec: 0.01, criticalThreshold: 0.2 },
+    ],
+    lifecycle: {
+      schedule: [
+        { stage: 'egg', atSeconds: 0 },
+        { stage: 'kitten', atSeconds: 3 },
+        { stage: 'adult', atSeconds: 12 },
+      ],
+    },
+  });
+
+  const skills = new SkillRegistry();
+  skills.registerAll(defaultPetInteractionModule.skills ?? []);
+  skills.register(ExpressMeowSkill);
+
+  const randomEvents = new RandomEventTicker([
+    defineRandomEvent({
+      id: 'surpriseTreat',
+      probabilityPerSecond: 0.3,
+      cooldownSeconds: 5,
+      emit: () => ({ type: 'RandomEvent', subtype: 'surpriseTreat', at: 0 }),
+    }),
+  ]);
+
+  const agent = createAgent({
+    id: AGENT_ID,
+    species,
+    clock,
+    rng,
+    memory: new InMemoryMemoryAdapter(),
+    modules: [defaultPetInteractionModule],
+    skills,
+    randomEvents,
+  });
+
+  // Structural clone on push — matches parallel-agent-determinism.test.ts:90.
+  agent.subscribe((e) => {
+    events.push({ ...e });
+  });
+
+  return { agent, clock, events };
+}
+
+describe('AgentTicked replay equivalence', () => {
+  it('produces byte-identical AgentTicked payloads across two seeded runs', async () => {
+    const a = buildAgent();
+    const b = buildAgent();
+
+    for (let i = 0; i < 20; i++) {
+      a.clock.advance(100);
+      b.clock.advance(100);
+      await a.agent.tick(0.1);
+      await b.agent.tick(0.1);
+    }
+
+    const aTicked = a.events.filter((e) => e.type === AGENT_TICKED) as AgentTickedEvent[];
+    const bTicked = b.events.filter((e) => e.type === AGENT_TICKED) as AgentTickedEvent[];
+
+    expect(aTicked).toHaveLength(20);
+    expect(bTicked).toHaveLength(20);
+    expect(aTicked).toEqual(bTicked);
+  });
+});

--- a/tests/unit/agent/Agent.test.ts
+++ b/tests/unit/agent/Agent.test.ts
@@ -6,6 +6,10 @@ import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
 import { ManualClock } from '../../../src/ports/ManualClock.js';
 import { SeededRng } from '../../../src/ports/SeededRng.js';
 import { InvalidTimeScaleError, MissingDependencyError } from '../../../src/agent/errors.js';
+import { AGENT_TICKED, type AgentTickedEvent } from '../../../src/events/standardEvents.js';
+import { ArrayScriptedController } from '../../../src/agent/ScriptedController.js';
+import { createAgent } from '../../../src/agent/createAgent.js';
+import type { DomainEvent } from '../../../src/events/DomainEvent.js';
 
 function baseDeps(overrides: Partial<AgentDependencies> = {}): AgentDependencies {
   const identity: AgentIdentity = {
@@ -304,5 +308,88 @@ describe('Agent (M2 shell)', () => {
 
       expect(observed).toEqual([3, 0]);
     });
+  });
+});
+
+describe('AgentTicked emission', () => {
+  it('emits exactly one AgentTicked event per completed tick, after trace is assembled', async () => {
+    const bus = new InMemoryEventBus();
+    const events: DomainEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(1_000),
+      rng: 0,
+      eventBus: bus,
+    });
+
+    const trace1 = await agent.tick(0.1);
+
+    const ticked1 = events.filter((e) => e.type === AGENT_TICKED) as AgentTickedEvent[];
+    expect(ticked1).toHaveLength(1);
+    expect(ticked1[0]!.tickNumber).toBe(1);
+    expect(ticked1[0]!.agentId).toBe('pet');
+    expect(ticked1[0]!.wallDtSeconds).toBeCloseTo(0.1);
+    expect(ticked1[0]!.virtualDtSeconds).toBeCloseTo(0.1);
+    expect(trace1.emitted.some((e) => e.type === AGENT_TICKED)).toBe(false);
+    expect(ticked1[0]!.trace).toBe(trace1);
+
+    const trace2 = await agent.tick(0.1);
+    const ticked2 = events.filter((e) => e.type === AGENT_TICKED) as AgentTickedEvent[];
+    expect(ticked2).toHaveLength(2);
+    expect(ticked2[1]!.tickNumber).toBe(2);
+    expect(trace2.emitted.some((e) => e.type === AGENT_TICKED)).toBe(false);
+    expect(ticked2[1]!.trace).toBe(trace2);
+  });
+
+  it('does not emit AgentTicked on a halted short-circuit tick', async () => {
+    const bus = new InMemoryEventBus();
+    const events: DomainEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      eventBus: bus,
+    });
+
+    agent.kill('test');
+    events.length = 0;
+
+    const trace = await agent.tick(0.1);
+    expect(trace.halted).toBe(true);
+    expect(events.filter((e) => e.type === AGENT_TICKED)).toHaveLength(0);
+  });
+
+  it('populates selectedAction with the first action of the tick, or null', async () => {
+    const bus = new InMemoryEventBus();
+    const events: DomainEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+    const scripted = new ArrayScriptedController([
+      [{ type: 'noop' }],
+      [{ type: 'invoke-skill', skillId: 'meow' }],
+      [],
+    ]);
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      eventBus: bus,
+      controlMode: 'scripted',
+      scripted,
+    });
+
+    await agent.tick(0.1);
+    await agent.tick(0.1);
+    await agent.tick(0.1);
+
+    const ticked = events.filter((e) => e.type === AGENT_TICKED) as AgentTickedEvent[];
+    expect(ticked).toHaveLength(3);
+    expect(ticked[0]!.selectedAction).toEqual({ type: 'noop' });
+    expect(ticked[1]!.selectedAction).toEqual({ type: 'invoke-skill', skillId: 'meow' });
+    expect(ticked[2]!.selectedAction).toBeNull();
   });
 });

--- a/tests/unit/events/AgentTickedEvent.test.ts
+++ b/tests/unit/events/AgentTickedEvent.test.ts
@@ -33,4 +33,9 @@ describe('AgentTicked event vocabulary', () => {
     expect(event.tickNumber).toBe(1);
     expect(event.trace).toBe(traceStub);
   });
+
+  it('is re-exported from the public barrel', async () => {
+    const barrel = await import('../../../src/index.js');
+    expect(barrel.AGENT_TICKED).toBe('AgentTicked');
+  });
 });

--- a/tests/unit/events/AgentTickedEvent.test.ts
+++ b/tests/unit/events/AgentTickedEvent.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { AGENT_TICKED, type AgentTickedEvent } from '../../../src/events/standardEvents.js';
+import type { DecisionTrace } from '../../../src/agent/DecisionTrace.js';
+
+describe('AgentTicked event vocabulary', () => {
+  it('exports the constant as the exact string literal `"AgentTicked"`', () => {
+    expect(AGENT_TICKED).toBe('AgentTicked');
+  });
+
+  it('accepts a well-formed event shape at compile time', () => {
+    const traceStub: DecisionTrace = {
+      agentId: 'test',
+      tickStartedAt: 1000,
+      virtualDtSeconds: 0.1,
+      controlMode: 'autonomous',
+      stage: 'alive',
+      halted: false,
+      perceived: [],
+      actions: [],
+      emitted: [],
+    };
+    const event: AgentTickedEvent = {
+      type: AGENT_TICKED,
+      at: 1000,
+      agentId: 'test',
+      tickNumber: 1,
+      virtualDtSeconds: 0.1,
+      wallDtSeconds: 0.01,
+      selectedAction: null,
+      trace: traceStub,
+    };
+    expect(event.type).toBe('AgentTicked');
+    expect(event.tickNumber).toBe(1);
+    expect(event.trace).toBe(traceStub);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `AGENT_TICKED` / `AgentTickedEvent` to the standard event vocabulary.
- `Agent.tick()` emits `AgentTicked` at the end of every non-halted tick,
  after the `DecisionTrace` is assembled. Payload carries the trace
  reference so subscribers don't need a closure cache.
- Snapshot-copies `trace.emitted` at both assembly sites to prevent
  aliased mutation (the meta-event cannot appear in its own trace).
- Excludes `AgentTicked` from the next tick's `perceived` stream —
  meta-events must not feed the cognition pipeline.
- Replay-equivalence integration test pins determinism under a fixed
  seed + clock.

Implements the library half of 0.9.1 from
`.claude/plans/0.9.1-agent-ticked-event.md`. Demo wiring follows in a
companion PR after this merges.

## Test plan

- [x] `npm run lint` / `typecheck` / `test` / `build` all green locally.
- [x] 343/343 tests passing (342 prior + 1 new integration test).
- [x] Bundle size 31.14 kB gzipped core (35 kB budget respected).
- [ ] `npm run format:check` fails locally on 227 unrelated files due
      to Windows CRLF line endings (same failure on `develop`). Git
      index holds LF on all touched files, so CI should pass.

## Plan deviation (accepted during review)

Task 1.3 added a Stage 1 drain filter that excludes `AgentTicked` from
the agent's own `perceived` stream. The existing test at
`tests/unit/agent/Agent.test.ts:53` would break without it, and the
behavior (meta-events don't self-perceive) is architecturally sound.
Plan doc on `develop` will be updated post-merge to document this
invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)