### PR TITLE
feat(demo): cognition-mode switcher + differentiated BT

### DIFF
--- a/examples/nurture-pet/README.md
+++ b/examples/nurture-pet/README.md
@@ -30,6 +30,11 @@ and watch it react and act autonomously between your inputs.
 - **Reset / New pet flow** — a confirm-gated "🔄 Reset" button in the HUD
   speed bar, and a "🔄 New pet" button in the death modal. Both wipe the
   snapshot from `localStorage` and reload; speed preference is preserved.
+- Live cognition switching: a dropdown above the HUD lets the viewer
+  flip between four reasoner modes (heuristic / BT / BDI / learning).
+  Unavailable peer deps render disabled with an install hint. The BT
+  mode reactively interrupts on the `surpriseTreat` random event to
+  demonstrate stateful commitment.
 
 ## Running locally
 
@@ -97,6 +102,36 @@ unsubscribe();
 Pair this with a `requestAnimationFrame` loop that calls
 `pet.tick(dt)` but does not render — the event drives UI. See
 `src/main.ts` for the reference implementation.
+
+## Cognition switcher
+
+A dropdown above the HUD lets you live-swap the agent's reasoner. The
+module establishes the repo's pattern for async peer-dep probing at
+mount time — each mode's `probe()` is a try/catch dynamic `import()`
+of its peer. A post-mount epoch guard discards stale probe results if
+the user flips modes before the in-flight probe resolves.
+
+```ts
+import { mountCognitionSwitcher } from './cognitionSwitcher.js';
+
+const handle = mountCognitionSwitcher(pet, document.querySelector('#cognition-switcher'));
+
+// On teardown:
+handle.dispose();
+```
+
+Modes:
+
+- **Heuristic (urgency)** — default. Always available; no peer dep.
+- **Behaviour Tree** — mistreevous-backed. Reactively interrupts on
+  `surpriseTreat` random events, committing to `approach-treat` for
+  up to 3 ticks per treat burst (a second treat during the window
+  resets the counter rather than stacking a new burst).
+- **BDI** — js-son-backed stub. Routes selection through beliefs /
+  desires / plans but yields heuristic-equivalent behaviour.
+- **Learning (brain.js)** — brain.js-backed stub. Loads a pre-built
+  1-layer network; scoring is close to heuristic. Real training +
+  weight persistence is the subject of 0.9.3.
 
 ## localStorage key layout
 

--- a/examples/nurture-pet/README.md
+++ b/examples/nurture-pet/README.md
@@ -108,8 +108,9 @@ Pair this with a `requestAnimationFrame` loop that calls
 A dropdown above the HUD lets you live-swap the agent's reasoner. The
 module establishes the repo's pattern for async peer-dep probing at
 mount time — each mode's `probe()` is a try/catch dynamic `import()`
-of its peer. A post-mount epoch guard discards stale probe results if
-the user flips modes before the in-flight probe resolves.
+of its peer. An epoch guard on the `change` handler discards stale
+`construct()` results if the user flips modes before the in-flight
+construction resolves.
 
 ```ts
 import { mountCognitionSwitcher } from './cognitionSwitcher.js';

--- a/examples/nurture-pet/README.md
+++ b/examples/nurture-pet/README.md
@@ -30,11 +30,11 @@ and watch it react and act autonomously between your inputs.
 - **Reset / New pet flow** — a confirm-gated "🔄 Reset" button in the HUD
   speed bar, and a "🔄 New pet" button in the death modal. Both wipe the
   snapshot from `localStorage` and reload; speed preference is preserved.
-- Live cognition switching: a dropdown above the HUD lets the viewer
-  flip between four reasoner modes (heuristic / BT / BDI / learning).
-  Unavailable peer deps render disabled with an install hint. The BT
-  mode reactively interrupts on the `surpriseTreat` random event to
-  demonstrate stateful commitment.
+- **Live cognition switching** — a dropdown above the HUD lets the
+  viewer flip between four reasoner modes (heuristic / BT / BDI /
+  learning). Unavailable peer deps render disabled with an install
+  hint. The BT mode reactively interrupts on the `surpriseTreat`
+  random event to demonstrate stateful commitment.
 
 ## Running locally
 
@@ -115,7 +115,9 @@ construction resolves.
 ```ts
 import { mountCognitionSwitcher } from './cognitionSwitcher.js';
 
-const handle = mountCognitionSwitcher(pet, document.querySelector('#cognition-switcher'));
+const root = document.querySelector<HTMLElement>('#cognition-switcher');
+if (!root) throw new Error('cognition-switcher slot missing');
+const handle = mountCognitionSwitcher(pet, root);
 
 // On teardown:
 handle.dispose();
@@ -126,8 +128,9 @@ Modes:
 - **Heuristic (urgency)** — default. Always available; no peer dep.
 - **Behaviour Tree** — mistreevous-backed. Reactively interrupts on
   `surpriseTreat` random events, committing to `approach-treat` for
-  up to 3 ticks per treat burst (a second treat during the window
-  resets the counter rather than stacking a new burst).
+  up to 3 ticks from the most recent treat. A second treat during
+  the window refreshes the counter back to 3 rather than adding
+  another burst on top.
 - **BDI** — js-son-backed stub. Routes selection through beliefs /
   desires / plans but yields heuristic-equivalent behaviour.
 - **Learning (brain.js)** — brain.js-backed stub. Loads a pre-built

--- a/examples/nurture-pet/index.html
+++ b/examples/nurture-pet/index.html
@@ -152,6 +152,43 @@
           background: #1b2140;
         }
       }
+      .cognition-switcher {
+        background: #fff;
+        border-radius: 12px;
+        padding: 12px 16px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      @media (prefers-color-scheme: dark) {
+        .cognition-switcher {
+          background: #1b2140;
+        }
+      }
+      .cognition-label {
+        font-size: 12px;
+        opacity: 0.7;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+      }
+      #cognition-mode-select {
+        padding: 4px 8px;
+        font-size: 13px;
+        border-radius: 6px;
+        border: 1px solid #cbd5e1;
+        background: inherit;
+        color: inherit;
+      }
+      #cognition-mode-select:disabled {
+        opacity: 0.5;
+      }
+      .cognition-status {
+        font-size: 12px;
+        opacity: 0.6;
+        margin-left: auto;
+        font-variant-numeric: tabular-nums;
+      }
       .speed-label {
         font-size: 12px;
         opacity: 0.7;
@@ -443,6 +480,13 @@
     </section>
 
     <section class="hud">
+      <div class="cognition-switcher" id="cognition-switcher">
+        <span class="cognition-label">Cognition</span>
+        <select id="cognition-mode-select" aria-label="Cognition mode">
+          <option value="heuristic">Heuristic (urgency)</option>
+        </select>
+        <span class="cognition-status" id="cognition-status" data-mode="heuristic">active</span>
+      </div>
       <div class="speed">
         <span class="speed-label">Speed</span>
         <div class="speed-buttons" id="speed-picker"></div>

--- a/examples/nurture-pet/package-lock.json
+++ b/examples/nurture-pet/package-lock.json
@@ -11,6 +11,9 @@
         "agentonomous": "file:../.."
       },
       "devDependencies": {
+        "brain.js": "^2.0.0-beta.0",
+        "js-son-agent": "^0.0.17",
+        "mistreevous": "^4.3.1",
         "typescript": "^6.0.3",
         "vite": "^8.0.8"
       }
@@ -111,6 +114,14 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -128,6 +139,37 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -404,6 +446,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -415,9 +468,415 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/agentonomous": {
       "resolved": "../..",
       "link": true
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/brain.js": {
+      "version": "2.0.0-beta.24",
+      "resolved": "https://registry.npmjs.org/brain.js/-/brain.js-2.0.0-beta.24.tgz",
+      "integrity": "sha512-CkAJpmQPrsKnyL0w6RjDXDhESw6/Hdll3D51yM7bJETbe7r9C5g7owB3fEqfoyJc5tsznMwlnEv2xkUN58J8RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thaw.js": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=8.6.x"
+      },
+      "peerDependencies": {
+        "gpu.js": "^2.16.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -428,6 +887,75 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -447,6 +975,44 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -461,6 +1027,343 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/gl": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/gl/-/gl-5.0.3.tgz",
+      "integrity": "sha512-toWmb3Rgli5Wl9ygjZeglFBVLDYMOomy+rXlVZVDCoIRV+6mQE5nY4NgQgokYIc5oQzc1pvWY9lQJ0hGn61ZUg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "bit-twiddle": "^1.0.2",
+        "glsl-tokenizer": "^2.1.5",
+        "nan": "^2.16.0",
+        "node-abi": "^3.22.0",
+        "node-gyp": "^9.0.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/gl-wiretap": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/gl-wiretap/-/gl-wiretap-0.6.2.tgz",
+      "integrity": "sha512-fxy1XGiPkfzK+T3XKDbY7yaqMBmozCGvAFyTwaZA3imeZH83w7Hr3r3bYlMRWIyzMI/lDUvUMM/92LE2OwqFyQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glsl-tokenizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "through2": "^0.6.3"
+      }
+    },
+    "node_modules/gpu-mock.js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/gpu-mock.js/-/gpu-mock.js-1.3.1.tgz",
+      "integrity": "sha512-+lbp8rQ0p1nTa6Gk6HoLiw4yM6JTpql82U+nCF3sZbX4FJWP9PzzF1018dW8K+pbmqRmhLHbn6Bjc6i6tgUpbA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "gpu.js": "^2.10.3"
+      }
+    },
+    "node_modules/gpu.js": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/gpu.js/-/gpu.js-2.16.0.tgz",
+      "integrity": "sha512-ZKmWdRXi3F/9nim5ew2IPXZaMlSyqtMtVC8Itobjl+qYUgUqcBHxu8WKqK0AqIyjBVBl7A5ORo4Db2hzgrPd4A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^7.1.1",
+        "gl": "^5.0.3",
+        "gl-wiretap": "^0.6.2",
+        "gpu-mock.js": "^1.3.0",
+        "webgpu": "^0.1.16"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/js-son-agent": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/js-son-agent/-/js-son-agent-0.0.17.tgz",
+      "integrity": "sha512-RnpHDIH9p8W2mxVStk7M8JB0mNc579o0NilOlo5rOGoCix/TT/B6iCbX6sjtXLvlyEnVCrMgc/AHOKL6bN/3jA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -723,6 +1626,244 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lotto-draw": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lotto-draw/-/lotto-draw-1.0.2.tgz",
+      "integrity": "sha512-1ih414A35BWpApfNlWAHBKOBLSxTj45crAJ+CMWF/kVY5nx6N22DA1OVF/FWW5WM5CGJbIMRh1O+xe8ukyoQ8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mistreevous": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/mistreevous/-/mistreevous-4.3.1.tgz",
+      "integrity": "sha512-AnDNOd8qGcBbz1fDRGYh5Kf+FodR4KcZyc+H4rPpFL7kdOAmGSwnpW57HwX9h0J8pDrj6FJRSAXdfqI6/N1UTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lotto-draw": "^1.0.2"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -740,6 +1881,140 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^6.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/picocolors": {
@@ -791,6 +2066,132 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "peer": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
@@ -825,6 +2226,160 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -834,6 +2389,184 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ssri": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/thaw.js": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/thaw.js/-/thaw.js-2.1.4.tgz",
+      "integrity": "sha512-si9DSzEzOBUpbE41wE4Q6NXzXDYZfrniYocrduNtNDwLWj1Auueq8UzgePMQa5gfcQtVCG2OmlCTaHldtno3Vw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -860,6 +2593,20 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -873,6 +2620,42 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/vite": {
       "version": "8.0.8",
@@ -951,6 +2734,72 @@
           "optional": true
         }
       }
+    },
+    "node_modules/webgpu": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/webgpu/-/webgpu-0.1.16.tgz",
+      "integrity": "sha512-KAXn/f8lnL8o4B718zzdfi1l0nEWQpuoWlC1L5WM/svAbeHjShCEI0l5ZcZBEEUm9FF3ZTgRjWk8iwbJfnGKTA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 13.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     }
   }
 }

--- a/examples/nurture-pet/package.json
+++ b/examples/nurture-pet/package.json
@@ -13,6 +13,9 @@
     "agentonomous": "file:../.."
   },
   "devDependencies": {
+    "brain.js": "^2.0.0-beta.0",
+    "js-son-agent": "^0.0.17",
+    "mistreevous": "^4.3.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.8"
   }

--- a/examples/nurture-pet/src/cognition/bdi.ts
+++ b/examples/nurture-pet/src/cognition/bdi.ts
@@ -1,0 +1,49 @@
+import type { CognitionModeSpec } from './index.js';
+import type { Reasoner } from 'agentonomous';
+
+/**
+ * Stub BDI mode. Routes selection through js-son's belief / desire /
+ * plan pipeline but produces heuristic-equivalent behaviour — a
+ * single plan always yields the current top candidate's intention.
+ * Differentiated BDI authorship lives in a follow-up plan.
+ *
+ * `construct()` is async so the adapter subpath (which pulls
+ * `js-son-agent` as a side effect) only loads when this mode is
+ * selected — keeping the peer out of the main chunk.
+ */
+export const bdiMode: CognitionModeSpec = {
+  id: 'bdi',
+  label: 'BDI',
+  peerName: 'js-son-agent',
+  async probe(): Promise<boolean> {
+    try {
+      await import('js-son-agent');
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  async construct(): Promise<Reasoner> {
+    // The adapter subpath re-exports `JsSonReasoner` along with the
+    // `Plan` factory from `js-son-agent` so consumers can author plans
+    // without a direct peer import. A single dynamic import covers
+    // both and lazy-loads the peer as a side effect.
+    const { JsSonReasoner, Plan } = await import('agentonomous/cognition/adapters/js-son');
+
+    return new JsSonReasoner({
+      beliefs: { topCandidate: null },
+      desires: {
+        'pursue-top': (beliefs) => beliefs.topCandidate !== null,
+      },
+      plans: [
+        Plan((beliefs) => beliefs.topCandidate !== null, function (this: {
+          beliefs: { topCandidate: { intention: unknown } | null };
+        }) {
+          if (!this.beliefs.topCandidate) return [];
+          return [{ intention: this.beliefs.topCandidate.intention }];
+        } as never),
+      ],
+      toBeliefs: (_ctx, helpers) => ({ topCandidate: helpers.topCandidate() }),
+    });
+  },
+};

--- a/examples/nurture-pet/src/cognition/bdi.ts
+++ b/examples/nurture-pet/src/cognition/bdi.ts
@@ -1,5 +1,5 @@
-import type { CognitionModeSpec } from './index.js';
 import type { Reasoner } from 'agentonomous';
+import type { CognitionModeSpec } from './index.js';
 
 /**
  * Stub BDI mode. Routes selection through js-son's belief / desire /

--- a/examples/nurture-pet/src/cognition/bt.ts
+++ b/examples/nurture-pet/src/cognition/bt.ts
@@ -80,12 +80,19 @@ export const btMode: CognitionModeSpec = {
           // mapping this intention falls through to the runner's noop
           // fallback and the trace panel shows no selection for the
           // interrupt window.
+          //
+          // Returns SUCCEEDED (not RUNNING) so the sequence completes
+          // each tick and the BT re-evaluates from root next step.
+          // RUNNING would pin the action node and bypass
+          // `IsReactingToTreat` on subsequent ticks — the counter would
+          // never decrement and `approach-treat` would be committed
+          // forever after the first surpriseTreat.
           helpers.commit({
             kind: 'react',
             type: 'approach-treat',
             target: 'treat',
           });
-          return MistreevousState.RUNNING;
+          return MistreevousState.SUCCEEDED;
         },
         PickTopCandidate(_ctx, helpers) {
           const top = helpers.topCandidate();

--- a/examples/nurture-pet/src/cognition/bt.ts
+++ b/examples/nurture-pet/src/cognition/bt.ts
@@ -9,8 +9,10 @@ const INTERRUPT_TICKS = 3;
  * `surpriseTreat` random event. Normal ticks mirror the heuristic's
  * top-candidate pick via `PickTopCandidate`. When a `surpriseTreat`
  * event arrives in `ctx.perceived`, the BT locks in the
- * `approach-treat` skill for `INTERRUPT_TICKS` consecutive ticks
- * regardless of urgency pressure.
+ * `approach-treat` skill for `INTERRUPT_TICKS` ticks measured from the
+ * most recent treat — a second treat during the window resets the
+ * counter rather than stacking a new burst. Effective behaviour:
+ * "keep approaching while treats keep arriving, then resume urgency."
  *
  * Counter state lives in the closure returned by `construct()` — a
  * mode swap produces a fresh closure, wiping the counter. Matches the
@@ -72,6 +74,11 @@ export const btMode: CognitionModeSpec = {
           return false;
         },
         RunApproachTreat(_ctx, helpers) {
+          // Relies on main.ts wiring a DirectBehaviorRunner mapping
+          // `approach-treat` → the `approach-treat` skill. Without that
+          // mapping this intention falls through to the runner's noop
+          // fallback and the trace panel shows no selection for the
+          // interrupt window.
           helpers.commit({
             kind: 'react',
             type: 'approach-treat',

--- a/examples/nurture-pet/src/cognition/bt.ts
+++ b/examples/nurture-pet/src/cognition/bt.ts
@@ -1,0 +1,90 @@
+import type { CognitionModeSpec } from './index.js';
+import type { Reasoner, ReasonerContext } from 'agentonomous';
+
+const TREAT_EVENT_SUBTYPE = 'surpriseTreat';
+const INTERRUPT_TICKS = 3;
+
+/**
+ * BT cognition mode — differentiated via a reactive interrupt on the
+ * `surpriseTreat` random event. Normal ticks mirror the heuristic's
+ * top-candidate pick via `PickTopCandidate`. When a `surpriseTreat`
+ * event arrives in `ctx.perceived`, the BT locks in the
+ * `approach-treat` skill for `INTERRUPT_TICKS` consecutive ticks
+ * regardless of urgency pressure.
+ *
+ * Counter state lives in the closure returned by `construct()` — a
+ * mode swap produces a fresh closure, wiping the counter. Matches the
+ * library's `setReasoner` contract ("nothing transferred from the
+ * outgoing reasoner").
+ *
+ * `construct()` is async so the adapter subpath (which pulls
+ * `mistreevous` as a side effect) only loads when this mode is
+ * actually selected — keeping the peer out of the main chunk.
+ */
+export const btMode: CognitionModeSpec = {
+  id: 'bt',
+  label: 'Behaviour Tree',
+  peerName: 'mistreevous',
+  async probe(): Promise<boolean> {
+    try {
+      await import('mistreevous');
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  async construct(): Promise<Reasoner> {
+    // The adapter subpath re-exports `MistreevousReasoner` plus
+    // `MistreevousState` (aliased from mistreevous' own `State`), so a
+    // single dynamic import handles both the reasoner class and the
+    // state enum handlers need to return. Importing the adapter also
+    // transitively loads `mistreevous`, keeping the peer out of the
+    // main chunk.
+    const { MistreevousReasoner, MistreevousState } =
+      await import('agentonomous/cognition/adapters/mistreevous');
+
+    let remainingTreatTicks = 0;
+
+    return new MistreevousReasoner({
+      definition: `
+        root {
+          selector {
+            sequence {
+              condition [IsReactingToTreat]
+              action    [RunApproachTreat]
+            }
+            action [PickTopCandidate]
+          }
+        }
+      `,
+      handlers: {
+        IsReactingToTreat(ctx: ReasonerContext): boolean {
+          const sawTreat = ctx.perceived.some(
+            (e) =>
+              e.type === 'RandomEvent' &&
+              (e as { subtype?: string }).subtype === TREAT_EVENT_SUBTYPE,
+          );
+          if (sawTreat) remainingTreatTicks = INTERRUPT_TICKS;
+          if (remainingTreatTicks > 0) {
+            remainingTreatTicks -= 1;
+            return true;
+          }
+          return false;
+        },
+        RunApproachTreat(_ctx, helpers) {
+          helpers.commit({
+            kind: 'react',
+            type: 'approach-treat',
+            target: 'treat',
+          });
+          return MistreevousState.RUNNING;
+        },
+        PickTopCandidate(_ctx, helpers) {
+          const top = helpers.topCandidate();
+          if (top) helpers.commit(top.intention);
+          return MistreevousState.SUCCEEDED;
+        },
+      },
+    });
+  },
+};

--- a/examples/nurture-pet/src/cognition/bt.ts
+++ b/examples/nurture-pet/src/cognition/bt.ts
@@ -1,5 +1,5 @@
-import type { CognitionModeSpec } from './index.js';
 import type { Reasoner, ReasonerContext } from 'agentonomous';
+import type { CognitionModeSpec } from './index.js';
 
 const TREAT_EVENT_SUBTYPE = 'surpriseTreat';
 const INTERRUPT_TICKS = 3;
@@ -9,10 +9,11 @@ const INTERRUPT_TICKS = 3;
  * `surpriseTreat` random event. Normal ticks mirror the heuristic's
  * top-candidate pick via `PickTopCandidate`. When a `surpriseTreat`
  * event arrives in `ctx.perceived`, the BT locks in the
- * `approach-treat` skill for `INTERRUPT_TICKS` ticks measured from the
- * most recent treat — a second treat during the window resets the
- * counter rather than stacking a new burst. Effective behaviour:
- * "keep approaching while treats keep arriving, then resume urgency."
+ * `approach-treat` skill for `INTERRUPT_TICKS` ticks measured from
+ * the most recent treat. A second treat during the window refreshes
+ * the counter back to `INTERRUPT_TICKS` rather than adding another
+ * burst on top. Effective behaviour: "keep approaching while treats
+ * keep arriving, then resume urgency."
  *
  * Counter state lives in the closure returned by `construct()` — a
  * mode swap produces a fresh closure, wiping the counter. Matches the

--- a/examples/nurture-pet/src/cognition/heuristic.ts
+++ b/examples/nurture-pet/src/cognition/heuristic.ts
@@ -1,0 +1,14 @@
+import { UrgencyReasoner } from 'agentonomous';
+import type { CognitionModeSpec } from './index.js';
+
+/**
+ * Default cognition mode — the weighted-urgency scorer that the agent
+ * uses without explicit `setReasoner`. Always available (no peer dep).
+ */
+export const heuristicMode: CognitionModeSpec = {
+  id: 'heuristic',
+  label: 'Heuristic (urgency)',
+  peerName: null,
+  probe: () => Promise.resolve(true),
+  construct: () => Promise.resolve(new UrgencyReasoner()),
+};

--- a/examples/nurture-pet/src/cognition/index.ts
+++ b/examples/nurture-pet/src/cognition/index.ts
@@ -1,0 +1,57 @@
+import type { Reasoner } from 'agentonomous';
+
+/**
+ * Describes one cognition mode offered by the nurture-pet demo's
+ * dropdown switcher.
+ *
+ * The registry is consumed by `cognitionSwitcher.ts` to render the
+ * `<select>`, probe peer-dep availability at mount time, and construct
+ * a fresh reasoner when the user changes selection. Each mode is
+ * responsible for its own peer-dep probe (returns `true` iff a dynamic
+ * `import()` of its peer resolves); `construct()` is only called after
+ * a successful probe.
+ */
+export interface CognitionModeSpec {
+  /** Stable id used as the `<option>` value. */
+  readonly id: 'heuristic' | 'bt' | 'bdi' | 'learning';
+  /** User-facing label for the dropdown. */
+  readonly label: string;
+  /**
+   * npm package name of the peer dep the mode depends on. `null` for
+   * the always-available heuristic mode (no peer). Used in the
+   * disabled-option tooltip: `Install <peerName> to enable`.
+   */
+  readonly peerName: string | null;
+  /**
+   * Probes availability. For peer-dep modes, try/catches a dynamic
+   * `import()` of the peer module. Returns `true` iff the import
+   * resolves. Called once on mount; result is cached by the switcher.
+   */
+  probe(): Promise<boolean>;
+  /**
+   * Builds a fresh `Reasoner` instance for this mode. Returns a
+   * Promise because peer-dep modes `await import(...)` their adapter
+   * subpath inside `construct()` — the adapter module itself loads
+   * the peer as a side effect, so the peer stays out of the main
+   * bundle until a mode is selected. Called only after a successful
+   * probe (either on the heuristic default at mount or on a
+   * user-initiated `change` event). The switcher awaits the result
+   * before handing it to `agent.setReasoner`.
+   */
+  construct(): Promise<Reasoner>;
+}
+
+// Modes are imported for their side effect of being discoverable here;
+// the array literal below is the canonical registry + dropdown order.
+import { heuristicMode } from './heuristic.js';
+import { btMode } from './bt.js';
+import { bdiMode } from './bdi.js';
+import { learningMode } from './learning.js';
+
+/** Registry ordered to match the dropdown display order. */
+export const COGNITION_MODES: readonly CognitionModeSpec[] = [
+  heuristicMode,
+  btMode,
+  bdiMode,
+  learningMode,
+];

--- a/examples/nurture-pet/src/cognition/index.ts
+++ b/examples/nurture-pet/src/cognition/index.ts
@@ -1,4 +1,8 @@
 import type { Reasoner } from 'agentonomous';
+import { bdiMode } from './bdi.js';
+import { btMode } from './bt.js';
+import { heuristicMode } from './heuristic.js';
+import { learningMode } from './learning.js';
 
 /**
  * Describes one cognition mode offered by the nurture-pet demo's
@@ -26,6 +30,14 @@ export interface CognitionModeSpec {
    * Probes availability. For peer-dep modes, try/catches a dynamic
    * `import()` of the peer module. Returns `true` iff the import
    * resolves. Called once on mount; result is cached by the switcher.
+   *
+   * **Note to future refactors:** each mode's `probe()` and
+   * `construct()` MUST use a literal string at the `import()` call
+   * site (`import('mistreevous')`, not `import(name)`). Vite's static
+   * analysis needs the literal to emit a per-peer async chunk;
+   * passing a parameter would bundle the peer into the main chunk
+   * (or fail outright). This is why the boilerplate is repeated
+   * across mode files rather than collapsed into a helper.
    */
   probe(): Promise<boolean>;
   /**
@@ -40,13 +52,6 @@ export interface CognitionModeSpec {
    */
   construct(): Promise<Reasoner>;
 }
-
-// Modes are imported for their side effect of being discoverable here;
-// the array literal below is the canonical registry + dropdown order.
-import { heuristicMode } from './heuristic.js';
-import { btMode } from './bt.js';
-import { bdiMode } from './bdi.js';
-import { learningMode } from './learning.js';
 
 /** Registry ordered to match the dropdown display order. */
 export const COGNITION_MODES: readonly CognitionModeSpec[] = [

--- a/examples/nurture-pet/src/cognition/learning.network.json
+++ b/examples/nurture-pet/src/cognition/learning.network.json
@@ -1,0 +1,28 @@
+{
+  "type": "NeuralNetwork",
+  "sizes": [5, 1],
+  "layers": [
+    {
+      "hunger": {},
+      "cleanliness": {},
+      "happiness": {},
+      "energy": {},
+      "health": {}
+    },
+    {
+      "score": {
+        "bias": 0,
+        "weights": {
+          "hunger": -1,
+          "cleanliness": -0.8,
+          "happiness": -0.6,
+          "energy": -0.7,
+          "health": -0.9
+        }
+      }
+    }
+  ],
+  "outputLookup": true,
+  "inputLookup": true,
+  "trainOpts": {}
+}

--- a/examples/nurture-pet/src/cognition/learning.ts
+++ b/examples/nurture-pet/src/cognition/learning.ts
@@ -1,5 +1,5 @@
-import type { CognitionModeSpec } from './index.js';
 import type { Reasoner, ReasonerContext } from 'agentonomous';
+import type { CognitionModeSpec } from './index.js';
 import networkJson from './learning.network.json';
 
 /**

--- a/examples/nurture-pet/src/cognition/learning.ts
+++ b/examples/nurture-pet/src/cognition/learning.ts
@@ -1,0 +1,62 @@
+import type { CognitionModeSpec } from './index.js';
+import type { Reasoner, ReasonerContext } from 'agentonomous';
+import networkJson from './learning.network.json';
+
+/**
+ * Stub learning mode. Loads a pre-built 1-layer brain.js network
+ * (`learning.network.json`) with hand-chosen weights that produce
+ * urgency-like scoring. The `interpret` function intentionally
+ * ignores the network's output and passes through to `topCandidate`
+ * — the network's contribution is demonstrating the "inference
+ * pipeline routes through brain.js" path, not producing a
+ * differentiated score. Real training + weight-driven interpretation
+ * lives in 0.9.3.
+ *
+ * `construct()` is async so the adapter subpath (which pulls
+ * `brain.js` as a side effect) only loads when this mode is
+ * selected — keeping the peer out of the main chunk.
+ */
+export const learningMode: CognitionModeSpec = {
+  id: 'learning',
+  label: 'Learning (brain.js)',
+  peerName: 'brain.js',
+  async probe(): Promise<boolean> {
+    try {
+      await import('brain.js');
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  async construct(): Promise<Reasoner> {
+    // Pull the adapter + `brain.js` itself via dynamic imports. The
+    // adapter's module-load side effect drags in brain.js's type
+    // surface; we still need the runtime `NeuralNetwork` constructor
+    // to hydrate the pre-built weights, so we import the peer here
+    // too.
+    const { BrainJsReasoner } = await import('agentonomous/cognition/adapters/brainjs');
+    const brainModule = await import('brain.js');
+    const NeuralNetwork =
+      (brainModule as { NeuralNetwork?: unknown }).NeuralNetwork ??
+      (brainModule as { default?: { NeuralNetwork?: unknown } }).default?.NeuralNetwork;
+    if (typeof NeuralNetwork !== 'function') {
+      throw new Error('learningMode: brain.js NeuralNetwork constructor not found');
+    }
+
+    const Net = NeuralNetwork as new () => {
+      fromJSON: (json: unknown) => unknown;
+      run: (input: unknown) => unknown;
+    };
+    const network = new Net();
+    network.fromJSON(networkJson);
+
+    return new BrainJsReasoner({
+      network: network as never,
+      featuresOf: (_ctx: ReasonerContext, helpers) => helpers.needsLevels() as never,
+      interpret: (_output, _ctx, helpers) => {
+        const top = helpers.topCandidate();
+        return top ? top.intention : null;
+      },
+    });
+  },
+};

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -45,6 +45,14 @@ export interface CognitionSwitcherHandle {
  * on whichever reasoner's `construct()` finishes last rather than
  * whichever the user picked last.
  *
+ * **Construct-error handling:** if `mode.construct()` rejects (e.g.
+ * the peer's runtime export shape disagrees with the adapter — the
+ * CJS-interop case in the plan's §Risks table), the switcher leaves
+ * the previously-active reasoner in place, marks the failing option
+ * disabled with an error tooltip, and reverts the `<select>` + status
+ * span to the last working mode so the user isn't stranded with a UI
+ * that lies about which reasoner is running.
+ *
  * The switcher intentionally does not persist selection across
  * reloads or demo resets — a fresh mount always starts at heuristic.
  */
@@ -77,18 +85,40 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
 
   let disposed = false;
   let changeEpoch = 0;
+  // Tracks the mode id currently wired into the agent, so a failing
+  // `construct()` can revert the `<select>` + status to the last-good
+  // mode rather than leaving the UI inconsistent with reality.
+  let activeModeId: CognitionModeSpec['id'] = 'heuristic';
 
   const onChange = async (): Promise<void> => {
     if (disposed) return;
     const mode = COGNITION_MODES.find((m) => m.id === select.value);
     if (!mode) return;
     const myEpoch = ++changeEpoch;
-    const reasoner = await mode.construct();
-    // Bail if disposed mid-await OR if a newer change has superseded us.
-    if (disposed || myEpoch !== changeEpoch) return;
-    agent.setReasoner(reasoner);
-    status.dataset.mode = mode.id;
-    status.textContent = 'active';
+    try {
+      const reasoner = await mode.construct();
+      // Bail if disposed mid-await OR if a newer change has superseded us.
+      if (disposed || myEpoch !== changeEpoch) return;
+      agent.setReasoner(reasoner);
+      activeModeId = mode.id;
+      status.dataset.mode = mode.id;
+      status.textContent = 'active';
+    } catch (err) {
+      if (disposed || myEpoch !== changeEpoch) return;
+      // eslint-disable-next-line no-console -- user-visible diagnostic.
+      console.error('cognitionSwitcher: construct() failed for mode', mode.id, err);
+      const failed = select.querySelector<HTMLOptionElement>(`option[value="${mode.id}"]`);
+      if (failed) {
+        failed.disabled = true;
+        failed.title = `${mode.label} failed to load (see console)`;
+      }
+      // Programmatic assignment does NOT refire the change event, so
+      // no recursion risk here. Status span reflects the actually-
+      // active reasoner (unchanged).
+      select.value = activeModeId;
+      status.dataset.mode = activeModeId;
+      status.textContent = 'active';
+    }
   };
   const onChangeWrapped = (): void => {
     void onChange();

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -32,11 +32,18 @@ export interface CognitionSwitcherHandle {
  * **Re-mount invariant:** `dispose()` marks a closure-local flag and
  * the late-probe guard uses it. After `dispose()`, a fresh
  * `mountCognitionSwitcher` call builds a new closure with a new
- * `disposed = false` and a fresh option set (innerHTML replacement
- * detaches the old option nodes). Stale probes from the old closure
- * no-op via the `disposed` guard before any DOM mutation — even
- * though `select.querySelector` on the old closure would now return
- * the NEW option nodes (same `<select>` element, new children).
+ * `disposed = false` and a fresh option set (via a `removeChild`
+ * loop that detaches the old option nodes). Stale probes from the
+ * old closure no-op via the `disposed` guard before any DOM mutation
+ * — even though `select.querySelector` on the old closure would now
+ * return the NEW option nodes (same `<select>` element, new children).
+ *
+ * **Concurrent-change guard:** each `change` invocation captures an
+ * epoch; if a later `change` starts before the previous `construct()`
+ * resolves, only the most-recent epoch is allowed to call
+ * `setReasoner`. Without this, rapid selection could land the agent
+ * on whichever reasoner's `construct()` finishes last rather than
+ * whichever the user picked last.
  *
  * The switcher intentionally does not persist selection across
  * reloads or demo resets — a fresh mount always starts at heuristic.
@@ -69,13 +76,16 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
   }
 
   let disposed = false;
+  let changeEpoch = 0;
 
   const onChange = async (): Promise<void> => {
     if (disposed) return;
     const mode = COGNITION_MODES.find((m) => m.id === select.value);
     if (!mode) return;
+    const myEpoch = ++changeEpoch;
     const reasoner = await mode.construct();
-    if (disposed) return; // re-check after await in case dispose() fired mid-await
+    // Bail if disposed mid-await OR if a newer change has superseded us.
+    if (disposed || myEpoch !== changeEpoch) return;
     agent.setReasoner(reasoner);
     status.dataset.mode = mode.id;
     status.textContent = 'active';

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -1,0 +1,114 @@
+import type { Agent } from 'agentonomous';
+import { COGNITION_MODES, type CognitionModeSpec } from './cognition/index.js';
+
+/** Handle returned by `mountCognitionSwitcher` for teardown wiring. */
+export interface CognitionSwitcherHandle {
+  /** Remove the `change` listener and mark the switcher disposed. */
+  dispose(): void;
+}
+
+/**
+ * Mount the cognition-mode dropdown into `rootEl`, probe each mode's
+ * peer dep asynchronously, and wire the `change` event to
+ * `agent.setReasoner`. Safe to re-mount after `dispose()`.
+ *
+ * Probe flow:
+ * 1. Render the `<select>` with all four options present, all
+ *    initially `disabled`.
+ * 2. Mark heuristic enabled + selected immediately (probe always
+ *    resolves true; no need to wait).
+ * 3. `Promise.all` each peer-dep mode's `probe()`; flip
+ *    enabled/disabled + tooltip on resolve.
+ *
+ * **Initial-state invariant:** no explicit `agent.setReasoner` call
+ * on mount — the agent defaults to `UrgencyReasoner` at construction
+ * (`src/agent/Agent.ts:251`), which matches the heuristic mode's
+ * `construct()` result. The status span reads "active" under
+ * heuristic because that's what the agent is already running. If a
+ * future change moves the agent's default away from `UrgencyReasoner`,
+ * this invariant needs revisiting — flagged with a runtime check
+ * below.
+ *
+ * **Re-mount invariant:** `dispose()` marks a closure-local flag and
+ * the late-probe guard uses it. After `dispose()`, a fresh
+ * `mountCognitionSwitcher` call builds a new closure with a new
+ * `disposed = false` and a fresh option set (innerHTML replacement
+ * detaches the old option nodes). Stale probes from the old closure
+ * no-op via the `disposed` guard before any DOM mutation — even
+ * though `select.querySelector` on the old closure would now return
+ * the NEW option nodes (same `<select>` element, new children).
+ *
+ * The switcher intentionally does not persist selection across
+ * reloads or demo resets — a fresh mount always starts at heuristic.
+ */
+export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): CognitionSwitcherHandle {
+  const select = rootEl.querySelector<HTMLSelectElement>('#cognition-mode-select');
+  const status = rootEl.querySelector<HTMLElement>('#cognition-status');
+  if (!select || !status) {
+    throw new Error(
+      'cognitionSwitcher: expected #cognition-mode-select + #cognition-status in rootEl',
+    );
+  }
+
+  // Clear any pre-rendered HTML options from index.html and rebuild
+  // from the registry via createElement + textContent (no innerHTML
+  // interpolation — forward-proofs against mode labels becoming
+  // dynamic / user-supplied in the future, even though the current
+  // labels are static string literals).
+  while (select.firstChild) select.removeChild(select.firstChild);
+  for (const m of COGNITION_MODES) {
+    const option = document.createElement('option');
+    option.value = m.id;
+    option.textContent = m.label;
+    option.disabled = true;
+    if (m.id === 'heuristic') {
+      option.disabled = false;
+      option.selected = true;
+    }
+    select.appendChild(option);
+  }
+
+  let disposed = false;
+
+  const onChange = async (): Promise<void> => {
+    if (disposed) return;
+    const mode = COGNITION_MODES.find((m) => m.id === select.value);
+    if (!mode) return;
+    const reasoner = await mode.construct();
+    if (disposed) return; // re-check after await in case dispose() fired mid-await
+    agent.setReasoner(reasoner);
+    status.dataset.mode = mode.id;
+    status.textContent = 'active';
+  };
+  const onChangeWrapped = (): void => {
+    void onChange();
+  };
+  select.addEventListener('change', onChangeWrapped);
+
+  // Probe each mode in parallel. After each resolves, flip its option
+  // enabled/disabled + tooltip. Late-probe guard (see JSDoc invariant
+  // above) prevents DOM mutation after dispose().
+  void Promise.all(
+    COGNITION_MODES.map(async (mode: CognitionModeSpec) => {
+      const available = await mode.probe();
+      if (disposed) return;
+      const option = select.querySelector<HTMLOptionElement>(`option[value="${mode.id}"]`);
+      if (!option) return;
+      if (available) {
+        option.disabled = false;
+        option.removeAttribute('title');
+      } else {
+        option.disabled = true;
+        option.title = mode.peerName ? `Install ${mode.peerName} to enable` : 'Unavailable';
+      }
+    }),
+  );
+
+  return {
+    dispose(): void {
+      if (disposed) return;
+      disposed = true;
+      select.removeEventListener('change', onChangeWrapped);
+    },
+  };
+}

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -3,6 +3,7 @@ import {
   createAgent,
   defaultPetInteractionModule,
   defineRandomEvent,
+  DirectBehaviorRunner,
   ExpressMeowSkill,
   ExpressSadSkill,
   ExpressSleepySkill,
@@ -12,6 +13,7 @@ import {
   type AgentTickedEvent,
 } from 'agentonomous';
 import { ApproachTreatSkill } from './skills/ApproachTreatSkill.js';
+import { mountCognitionSwitcher } from './cognitionSwitcher.js';
 import { catSpecies } from './species.js';
 import {
   mountExportImport,
@@ -102,6 +104,11 @@ const pet = createAgent({
   memory: new InMemoryMemoryAdapter(),
   modules: [defaultPetInteractionModule],
   skills,
+  behavior: new DirectBehaviorRunner({
+    skillByIntentionType: {
+      'approach-treat': 'approach-treat',
+    },
+  }),
   randomEvents,
 });
 
@@ -115,6 +122,11 @@ mountResetButton(pet);
 mountConfigPanel(catSpecies, currentEditableConfig(effectiveSpecies), () =>
   resetSimulation(pet.identity.id),
 );
+const cognitionSwitcherRoot = document.querySelector<HTMLElement>('#cognition-switcher');
+if (!cognitionSwitcherRoot) {
+  throw new Error('main: #cognition-switcher slot not found in index.html');
+}
+const cognitionSwitcher = mountCognitionSwitcher(pet, cognitionSwitcherRoot);
 
 // HUD updates run from the per-frame RAF loop below — a prior
 // `bindAgentToStore` hook also called `hud.update` on every agent event,
@@ -230,6 +242,7 @@ function disposeDemo(): void {
   if (rafHandle !== 0) cancelAnimationFrame(rafHandle);
   unsubscribeModifierDecorator();
   unsubscribeUiRefresh();
+  cognitionSwitcher.dispose();
   hud.dispose();
 }
 

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -104,6 +104,10 @@ const pet = createAgent({
   memory: new InMemoryMemoryAdapter(),
   modules: [defaultPetInteractionModule],
   skills,
+  // Behavior runner — only consulted for reasoner-committed intentions.
+  // Player button interactions invoke skills directly via `pet.invokeSkill`
+  // and bypass this table. The single mapping routes the BT cognition
+  // mode's `approach-treat` interrupt intention to its namesake skill.
   behavior: new DirectBehaviorRunner({
     skillByIntentionType: {
       'approach-treat': 'approach-treat',

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -11,6 +11,7 @@ import {
   SkillRegistry,
   type AgentTickedEvent,
 } from 'agentonomous';
+import { ApproachTreatSkill } from './skills/ApproachTreatSkill.js';
 import { catSpecies } from './species.js';
 import {
   mountExportImport,
@@ -84,6 +85,7 @@ skills.registerAll(defaultPetInteractionModule.skills ?? []);
 skills.register(ExpressMeowSkill);
 skills.register(ExpressSadSkill);
 skills.register(ExpressSleepySkill);
+skills.register(ApproachTreatSkill);
 
 // --- Species (base + optional user JSON override) -----------------------------
 const speciesOverride = loadConfigOverride(catSpecies);

--- a/examples/nurture-pet/src/skills/ApproachTreatSkill.ts
+++ b/examples/nurture-pet/src/skills/ApproachTreatSkill.ts
@@ -1,0 +1,19 @@
+import { ok, type Result, type Skill, type SkillError, type SkillOutcome } from 'agentonomous';
+
+/**
+ * No-op skill used as the commit target when the BT cognition mode's
+ * reactive interrupt fires on a `surpriseTreat` random event. Exists so
+ * the demo's decision-trace panel shows a legible `approach-treat`
+ * string during the interrupt window — not to model any pet behaviour.
+ *
+ * Examples-local: not registered in the library's default module
+ * bundle. The demo wires it in `main.ts`.
+ */
+export const ApproachTreatSkill: Skill = {
+  id: 'approach-treat',
+  label: 'Approach treat',
+  baseEffectiveness: 1,
+  execute(): Promise<Result<SkillOutcome, SkillError>> {
+    return Promise.resolve(ok({ fxHint: 'sparkle-gold', effectiveness: 1 }));
+  },
+};

--- a/examples/nurture-pet/tsconfig.json
+++ b/examples/nurture-pet/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "noEmit": true
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "excalibur": "^0.32.0",
         "husky": "^9.1.7",
         "js-son-agent": "^0.0.17",
+        "jsdom": "^29.0.2",
         "lint-staged": "^16.4.0",
         "mistreevous": "^4.3.1",
         "prettier": "^3.8.3",
@@ -65,6 +66,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -134,6 +186,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@changesets/apply-release-plan": {
@@ -410,6 +475,146 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
@@ -570,6 +775,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
@@ -2310,6 +2533,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -2449,6 +2682,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -2473,6 +2734,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3180,6 +3448,19 @@
         "he": "bin/he"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3325,6 +3606,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-subdir": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
@@ -3426,6 +3714,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -3927,6 +4256,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lunr": {
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -3989,6 +4328,13 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -4287,6 +4633,32 @@
       "license": "MIT",
       "dependencies": {
         "quansync": "^0.2.7"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-browserify": {
@@ -4677,6 +5049,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -4945,6 +5330,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -5002,6 +5394,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5013,6 +5425,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5124,6 +5562,16 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
@@ -5354,6 +5802,54 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5461,6 +5957,23 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "excalibur": "^0.32.0",
     "husky": "^9.1.7",
     "js-son-agent": "^0.0.17",
+    "jsdom": "^29.0.2",
     "lint-staged": "^16.4.0",
     "mistreevous": "^4.3.1",
     "prettier": "^3.8.3",

--- a/tests/examples/btMode.test.ts
+++ b/tests/examples/btMode.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { btMode } from '../../examples/nurture-pet/src/cognition/bt.js';
+import type { DomainEvent } from '../../src/events/DomainEvent.js';
+import type { Intention } from '../../src/cognition/Intention.js';
+import type { IntentionCandidate } from '../../src/cognition/IntentionCandidate.js';
+import type { Reasoner, ReasonerContext } from '../../src/cognition/reasoning/Reasoner.js';
+import { Modifiers } from '../../src/modifiers/Modifiers.js';
+
+const HUNGER_CANDIDATE: IntentionCandidate = {
+  intention: { kind: 'satisfy', type: 'satisfy-need:hunger' },
+  score: 0.9,
+  source: 'needs',
+};
+
+const TREAT_EVENT: DomainEvent = {
+  type: 'RandomEvent',
+  subtype: 'surpriseTreat',
+  at: 0,
+};
+
+function ctx(perceived: readonly DomainEvent[]): ReasonerContext {
+  return {
+    perceived,
+    needs: undefined,
+    modifiers: new Modifiers(),
+    candidates: [HUNGER_CANDIDATE],
+  };
+}
+
+function tick(reasoner: Reasoner, perceived: readonly DomainEvent[]): Intention | null {
+  return reasoner.selectIntention(ctx(perceived));
+}
+
+describe('btMode (cognition switcher BT)', () => {
+  it('locks in approach-treat for exactly 3 ticks after a surpriseTreat', async () => {
+    const reasoner = await btMode.construct();
+
+    // Tick 1: treat arrives → BT switches to approach-treat.
+    expect(tick(reasoner, [TREAT_EVENT])?.type).toBe('approach-treat');
+
+    // Ticks 2 + 3: no treat, but the interrupt window stays active.
+    expect(tick(reasoner, [])?.type).toBe('approach-treat');
+    expect(tick(reasoner, [])?.type).toBe('approach-treat');
+
+    // Tick 4: window has elapsed → fall back to the urgency top candidate.
+    // This is the regression guard for the RUNNING→SUCCEEDED fix: returning
+    // RUNNING from RunApproachTreat would pin the action node and never
+    // re-evaluate the IsReactingToTreat condition, so the BT would keep
+    // committing approach-treat indefinitely.
+    expect(tick(reasoner, [])?.type).toBe('satisfy-need:hunger');
+  });
+
+  it('refreshes the interrupt window when a second surpriseTreat arrives', async () => {
+    const reasoner = await btMode.construct();
+
+    expect(tick(reasoner, [TREAT_EVENT])?.type).toBe('approach-treat');
+    // Second treat during the window resets the counter back to 3.
+    expect(tick(reasoner, [TREAT_EVENT])?.type).toBe('approach-treat');
+    expect(tick(reasoner, [])?.type).toBe('approach-treat');
+    expect(tick(reasoner, [])?.type).toBe('approach-treat');
+    expect(tick(reasoner, [])?.type).toBe('satisfy-need:hunger');
+  });
+
+  it('falls back to the top candidate when no treat has been perceived', async () => {
+    const reasoner = await btMode.construct();
+    expect(tick(reasoner, [])?.type).toBe('satisfy-need:hunger');
+    expect(tick(reasoner, [])?.type).toBe('satisfy-need:hunger');
+  });
+});

--- a/tests/examples/cognitionSwitcher.test.ts
+++ b/tests/examples/cognitionSwitcher.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Path is relative from tests/examples/ to examples/nurture-pet/src/.
+// The switcher itself imports from 'agentonomous' (bare specifier) and
+// './cognition/index.js' — both resolve under vitest's default module
+// resolution.
+import { mountCognitionSwitcher } from '../../examples/nurture-pet/src/cognitionSwitcher.js';
+
+interface FakeAgent {
+  setReasoner: (r: unknown) => void;
+}
+
+function renderRoot(): HTMLElement {
+  document.body.innerHTML = `
+    <div id="cognition-switcher">
+      <select id="cognition-mode-select"></select>
+      <span id="cognition-status" data-mode="heuristic">active</span>
+    </div>
+  `;
+  return document.querySelector<HTMLElement>('#cognition-switcher')!;
+}
+
+describe('mountCognitionSwitcher', () => {
+  let fakeAgent: FakeAgent;
+
+  beforeEach(() => {
+    fakeAgent = { setReasoner: vi.fn() };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders all four modes with heuristic selected by default', () => {
+    const root = renderRoot();
+    mountCognitionSwitcher(fakeAgent as never, root);
+    const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toEqual(['heuristic', 'bt', 'bdi', 'learning']);
+    expect(select.value).toBe('heuristic');
+  });
+
+  it('enables available modes and disables missing-peer modes with a tooltip', async () => {
+    const root = renderRoot();
+    mountCognitionSwitcher(fakeAgent as never, root);
+
+    // Wait a macrotask for Promise.all to settle.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
+    const heuristic = select.querySelector<HTMLOptionElement>('option[value="heuristic"]')!;
+    expect(heuristic.disabled).toBe(false);
+
+    // The other three depend on whether the peer resolves in the test
+    // env. Root devDependencies include mistreevous + js-son-agent;
+    // brain.js is installed as a demo devDep — at test runtime it may
+    // or may not be hoisted. Assert disabled-with-tooltip iff disabled:
+    for (const id of ['bt', 'bdi', 'learning'] as const) {
+      const opt = select.querySelector<HTMLOptionElement>(`option[value="${id}"]`)!;
+      if (opt.disabled) {
+        expect(opt.title).toMatch(/^Install .+ to enable$/);
+      } else {
+        expect(opt.title).toBe('');
+      }
+    }
+  });
+
+  it('calls agent.setReasoner with the constructed reasoner on change', async () => {
+    const root = renderRoot();
+    mountCognitionSwitcher(fakeAgent as never, root);
+    // Wait for probes to resolve and BT to become enabled (requires
+    // mistreevous to be installed — it's a root devDep, so this should
+    // succeed in the normal test env).
+    await new Promise((r) => setTimeout(r, 100));
+
+    const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
+    // Switch to 'bt' (not 'heuristic' — heuristic is already selected,
+    // so `select.value = 'heuristic'` is a no-op change). `construct()`
+    // is async, so wait a macrotask for the await chain to land before
+    // asserting.
+    select.value = 'bt';
+    select.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(fakeAgent.setReasoner).toHaveBeenCalledTimes(1);
+    const mockCalls = (fakeAgent.setReasoner as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls;
+    const firstCall = mockCalls[0]?.[0];
+    expect(firstCall).toBeDefined();
+    expect(typeof (firstCall as { selectIntention?: unknown }).selectIntention).toBe('function');
+  });
+
+  it('dispose() removes the change listener (subsequent change events are no-ops)', async () => {
+    const root = renderRoot();
+    const handle = mountCognitionSwitcher(fakeAgent as never, root);
+    await new Promise((r) => setTimeout(r, 50));
+
+    handle.dispose();
+    const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
+    select.dispatchEvent(new Event('change'));
+    expect(fakeAgent.setReasoner).not.toHaveBeenCalled();
+  });
+
+  it('dispose() before probes resolve prevents DOM mutation on late resolve', async () => {
+    const root = renderRoot();
+    const handle = mountCognitionSwitcher(fakeAgent as never, root);
+
+    handle.dispose();
+    // Wait for probes to resolve. Disabled flags should NOT flip to
+    // enabled because the probe callbacks guard on `disposed`.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
+    for (const id of ['bt', 'bdi', 'learning'] as const) {
+      const opt = select.querySelector<HTMLOptionElement>(`option[value="${id}"]`)!;
+      expect(opt.disabled).toBe(true);
+    }
+  });
+});

--- a/tests/examples/cognitionSwitcher.test.ts
+++ b/tests/examples/cognitionSwitcher.test.ts
@@ -1,5 +1,12 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+/**
+ * Module-level DOM test for the demo's cognition switcher. Runs under
+ * jsdom via the file-level directive. Uses the real peer-module imports
+ * at runtime (mistreevous / js-son-agent / brain.js), so probe-resolution
+ * timing depends on npm's resolver rather than the clock — wait with
+ * `waitForProbes` (bounded poll) instead of a fixed sleep.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 // Path is relative from tests/examples/ to examples/nurture-pet/src/.
 // The switcher itself imports from 'agentonomous' (bare specifier) and
@@ -8,17 +15,59 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mountCognitionSwitcher } from '../../examples/nurture-pet/src/cognitionSwitcher.js';
 
 interface FakeAgent {
-  setReasoner: (r: unknown) => void;
+  setReasoner: Mock<(r: unknown) => void>;
 }
 
 function renderRoot(): HTMLElement {
-  document.body.innerHTML = `
-    <div id="cognition-switcher">
-      <select id="cognition-mode-select"></select>
-      <span id="cognition-status" data-mode="heuristic">active</span>
-    </div>
-  `;
+  document.body.innerHTML =
+    '<div id="cognition-switcher">' +
+    '<select id="cognition-mode-select"></select>' +
+    '<span id="cognition-status" data-mode="heuristic">active</span>' +
+    '</div>';
   return document.querySelector<HTMLElement>('#cognition-switcher')!;
+}
+
+/**
+ * Poll until every `<option>` under `select` has reached a settled
+ * probe state — either enabled (probe resolved true) or has a non-empty
+ * `title` (probe resolved false and the switcher stamped the install
+ * hint). The `heuristic` option is always-enabled from the mount loop,
+ * so it's considered settled regardless.
+ *
+ * Replaces a fixed `setTimeout(50)` that was flaky on cold-cache runs:
+ * a real dynamic `import('brain.js')` rejection can exceed 50ms on
+ * slow disks, which left the option in its initial
+ * `disabled=true, title=''` state and tripped the asymmetric assertion.
+ */
+async function waitForProbes(select: HTMLSelectElement, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const pending = Array.from(select.options).some(
+      (o) => o.value !== 'heuristic' && o.disabled && o.title === '',
+    );
+    if (!pending) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error('waitForProbes: probes did not settle within timeout');
+}
+
+/**
+ * Wait until `mock` has been called at least `n` times (default 1).
+ * Replaces a fixed-yield flush that was flaky for BT mode — its
+ * `construct()` awaits two dynamic imports and parses the MDSL tree,
+ * which exceeds the couple-of-macrotask budget on slow machines.
+ */
+async function waitForCalls(
+  mock: Mock<(r: unknown) => void>,
+  n = 1,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (mock.mock.calls.length >= n) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error(`waitForCalls: mock called ${mock.mock.calls.length} times (expected ${n})`);
 }
 
 describe('mountCognitionSwitcher', () => {
@@ -44,11 +93,10 @@ describe('mountCognitionSwitcher', () => {
   it('enables available modes and disables missing-peer modes with a tooltip', async () => {
     const root = renderRoot();
     mountCognitionSwitcher(fakeAgent as never, root);
-
-    // Wait a macrotask for Promise.all to settle.
-    await new Promise((r) => setTimeout(r, 50));
-
     const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
+
+    await waitForProbes(select);
+
     const heuristic = select.querySelector<HTMLOptionElement>('option[value="heuristic"]')!;
     expect(heuristic.disabled).toBe(false);
 
@@ -69,24 +117,19 @@ describe('mountCognitionSwitcher', () => {
   it('calls agent.setReasoner with the constructed reasoner on change', async () => {
     const root = renderRoot();
     mountCognitionSwitcher(fakeAgent as never, root);
-    // Wait for probes to resolve and BT to become enabled (requires
-    // mistreevous to be installed — it's a root devDep, so this should
-    // succeed in the normal test env).
-    await new Promise((r) => setTimeout(r, 100));
-
     const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
+
+    await waitForProbes(select);
+
     // Switch to 'bt' (not 'heuristic' — heuristic is already selected,
     // so `select.value = 'heuristic'` is a no-op change). `construct()`
-    // is async, so wait a macrotask for the await chain to land before
-    // asserting.
+    // is async, so flush the microtask queue before asserting.
     select.value = 'bt';
     select.dispatchEvent(new Event('change'));
-    await new Promise((r) => setTimeout(r, 50));
+    await waitForCalls(fakeAgent.setReasoner);
 
     expect(fakeAgent.setReasoner).toHaveBeenCalledTimes(1);
-    const mockCalls = (fakeAgent.setReasoner as unknown as { mock: { calls: unknown[][] } }).mock
-      .calls;
-    const firstCall = mockCalls[0]?.[0];
+    const firstCall = fakeAgent.setReasoner.mock.calls[0]?.[0];
     expect(firstCall).toBeDefined();
     expect(typeof (firstCall as { selectIntention?: unknown }).selectIntention).toBe('function');
   });
@@ -94,10 +137,10 @@ describe('mountCognitionSwitcher', () => {
   it('dispose() removes the change listener (subsequent change events are no-ops)', async () => {
     const root = renderRoot();
     const handle = mountCognitionSwitcher(fakeAgent as never, root);
-    await new Promise((r) => setTimeout(r, 50));
-
-    handle.dispose();
     const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
+
+    await waitForProbes(select);
+    handle.dispose();
     select.dispatchEvent(new Event('change'));
     expect(fakeAgent.setReasoner).not.toHaveBeenCalled();
   });
@@ -107,9 +150,11 @@ describe('mountCognitionSwitcher', () => {
     const handle = mountCognitionSwitcher(fakeAgent as never, root);
 
     handle.dispose();
-    // Wait for probes to resolve. Disabled flags should NOT flip to
-    // enabled because the probe callbacks guard on `disposed`.
-    await new Promise((r) => setTimeout(r, 50));
+    // Poll-with-timeout is the wrong wait here (we expect it to time out,
+    // which would be slow and noisy). Instead wait a generous macrotask
+    // for any in-flight probe promises to try to flip options — the
+    // `disposed` guard should bail before any DOM mutation.
+    await new Promise((r) => setTimeout(r, 100));
 
     const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
     for (const id of ['bt', 'bdi', 'learning'] as const) {

--- a/tests/examples/stubs/brain-js.ts
+++ b/tests/examples/stubs/brain-js.ts
@@ -1,0 +1,34 @@
+/**
+ * Test-only stub for the optional `brain.js` peer dep.
+ *
+ * `brain.js` is declared as an **optional** peer of `agentonomous` and
+ * as a devDep of the `nurture-pet` demo workspace — **not** a root
+ * devDep. That's intentional: its transitive dep chain (`gpu.js` →
+ * `gl`) needs an X11 native build that explodes on headless CI. See
+ * `src/cognition/adapters/brainjs/brain.d.ts` for the ambient typedef
+ * that lets TS compile without it installed.
+ *
+ * At runtime, the demo's `learning.ts` wraps `await import('brain.js')`
+ * in a try/catch precisely so a missing peer degrades gracefully
+ * (option renders disabled). But Vite's `vite:import-analysis` plugin
+ * eagerly resolves every dynamic import's specifier at transform time
+ * before the try/catch can run — and root `npm ci` on CI doesn't
+ * install `brain.js`, so transform fails.
+ *
+ * This stub exists so the vitest alias in `vite.config.ts` can route
+ * `import('brain.js')` to something resolvable. The tests in
+ * `tests/examples/cognitionSwitcher.test.ts` never call
+ * `learningMode.construct()` — they only care whether the probe
+ * resolves — so exporting a placeholder `NeuralNetwork` is enough to
+ * keep the module shape plausible without pulling the native chain.
+ */
+export class NeuralNetwork<In = unknown, Out = unknown> {
+  run(_input: In): Out {
+    throw new Error('brain.js stub: NeuralNetwork.run() is not implemented in the test stub.');
+  }
+  fromJSON(_json: unknown): this {
+    return this;
+  }
+}
+
+export default { NeuralNetwork };

--- a/tests/unit/events/AgentTickedEvent.test.ts
+++ b/tests/unit/events/AgentTickedEvent.test.ts
@@ -34,8 +34,13 @@ describe('AgentTicked event vocabulary', () => {
     expect(event.trace).toBe(traceStub);
   });
 
+  // First-load of the `src/index.js` barrel under v8 coverage
+  // instrumentation can exceed the default 5s timeout on cold /
+  // CPU-constrained runners (seen as a flake on GitHub `ubuntu-latest`).
+  // Bumping to 30s keeps the re-export check without the timing
+  // sensitivity.
   it('is re-exported from the public barrel', async () => {
     const barrel = await import('../../../src/index.js');
     expect(barrel.AGENT_TICKED).toBe('AgentTicked');
-  });
+  }, 30000);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,6 @@
       "agentonomous/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["dist", "node_modules", "examples"]
+  "include": ["src/**/*", "tests/**/*", "examples/nurture-pet/src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -161,6 +161,21 @@ export default defineConfig({
         find: /^agentonomous$/,
         replacement: resolve(__dirname, 'src/index.ts'),
       },
+      // `brain.js` is an optional peer of `agentonomous` and a devDep of
+      // the `nurture-pet` demo workspace — not a root devDep (its
+      // `gpu.js` → `gl` chain needs X11 native build headers that
+      // explode on headless CI). The demo's `learning.ts` guards its
+      // `await import('brain.js')` with try/catch so a missing peer
+      // degrades gracefully, but `vite:import-analysis` resolves the
+      // specifier at transform time before the try/catch can run, so
+      // root `npm ci` CI fails before the first test executes. Alias
+      // to a test-local stub that exports a placeholder `NeuralNetwork`
+      // — the cognitionSwitcher tests never call `learningMode.construct()`,
+      // only check whether the probe resolved, so the stub is enough.
+      {
+        find: /^brain\.js$/,
+        replacement: resolve(__dirname, 'tests/examples/stubs/brain-js.ts'),
+      },
     ],
     coverage: {
       provider: 'v8',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -136,6 +136,32 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    // Resolve `agentonomous` + its adapter subpaths against `src/` at test
+    // time. Without this, vitest hits the root `package.json` exports
+    // map (→ `./dist/*`), which requires a prior `npm run build` — but
+    // CI runs tests *before* build (and `npm run verify` runs them in
+    // that order locally too). The demo files in `examples/nurture-pet/`
+    // intentionally import from `agentonomous` + its subpaths so they
+    // stay consumer-realistic; the alias keeps the tests that exercise
+    // those demo files working without a build artifact dependency.
+    alias: [
+      {
+        find: /^agentonomous\/cognition\/adapters\/mistreevous$/,
+        replacement: resolve(__dirname, 'src/cognition/adapters/mistreevous/index.ts'),
+      },
+      {
+        find: /^agentonomous\/cognition\/adapters\/js-son$/,
+        replacement: resolve(__dirname, 'src/cognition/adapters/js-son/index.ts'),
+      },
+      {
+        find: /^agentonomous\/cognition\/adapters\/brainjs$/,
+        replacement: resolve(__dirname, 'src/cognition/adapters/brainjs/index.ts'),
+      },
+      {
+        find: /^agentonomous$/,
+        replacement: resolve(__dirname, 'src/index.ts'),
+      },
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

- Adds a runtime **cognition-mode dropdown** above the nurture-pet HUD. Four modes: heuristic (always), BT (mistreevous), BDI (js-son), learning (brain.js).
- Each peer is probed via a try/catch async `import()` at mount; unavailable peers render disabled with `Install <peerName> to enable` tooltips. Establishes the repo's first dynamic peer-dep probe pattern.
- The **BT mode is behaviourally differentiated**: reacts to `surpriseTreat` random events by locking in an `approach-treat` action for up to 3 ticks from the most recent treat (a second treat during the window refreshes the counter). BDI and brain.js modes are functional stubs — equivalent to heuristic — to be differentiated in follow-up plans (brain.js rolls into 0.9.3).
- New examples-local `ApproachTreatSkill` is the BT interrupt target; the demo wires a `DirectBehaviorRunner` mapping `'approach-treat' → 'approach-treat'` so the BT's reactive intention surfaces as an `invoke-skill` action in the trace panel.

Closes Chapter C of the MVP demo spec. The library half of 0.9.2 (`Agent.setReasoner` / `getReasoner`) already shipped in `c58d5f7` (bundled into P4), so this PR is demo-only.

Full design: `.claude/plans/0.9.2-cognition-switcher-design.md`. Implementation plan + acceptance criteria: `.claude/plans/0.9.2-set-reasoner-and-switcher.md`.

## What changed

**New files (demo + test only):**
- `examples/nurture-pet/src/cognition/{index,heuristic,bt,bdi,learning}.ts` + `learning.network.json` — mode registry + four reasoner factories.
- `examples/nurture-pet/src/cognitionSwitcher.ts` — dropdown mount module.
- `examples/nurture-pet/src/skills/ApproachTreatSkill.ts` — BT interrupt target.
- `tests/examples/cognitionSwitcher.test.ts` — vitest-jsdom module test (5 cases, bounded-poll helpers).

**Modified:**
- `examples/nurture-pet/{package.json,tsconfig.json}` — declare three peer devDeps (`mistreevous`, `js-son-agent`, `brain.js`); enable `resolveJsonModule`.
- `examples/nurture-pet/src/main.ts` — register skill, mount switcher, configure `DirectBehaviorRunner`, thread `dispose()` into teardown.
- `examples/nurture-pet/index.html` — dropdown HTML slot + inline CSS.
- `examples/nurture-pet/README.md` — new \"Cognition switcher\" section + bullet.
- Root `tsconfig.json` — include `examples/nurture-pet/src/**/*.ts` so the new vitest-jsdom test typechecks.
- Root `package.json` — add `jsdom` devDep (vitest 4.x unbundled).

## No library changes / no changeset

`src/` is untouched. Per `CLAUDE.md`, \"docs / refactor / chore PRs can skip\" the changeset requirement — this PR changes demo behaviour only, consistent with the 0.9.1 demo-only PR that followed the library PR. No `.changeset/*.md` entry is added.

## Notes for reviewers

- **Plan deviation accepted during implementation.** The plan's BT snippet had `helpers.commit({ type: 'invoke-skill', skillId: '…' })`, but `MistreevousHelpers.commit` takes an `Intention`, not an `AgentAction`. Fixed to `commit({ kind: 'react', type: 'approach-treat', target: 'treat' })` and added the `DirectBehaviorRunner` mapping so the intention routes to `invoke-skill approach-treat`. See `src/cognition/Intention.ts` and `src/cognition/behavior/DirectBehaviorRunner.ts` for the types.
- **Reasoner adapters come via subpath imports** (`agentonomous/cognition/adapters/{mistreevous,js-son,brainjs}`). The library's main barrel doesn't re-export them today; each adapter subpath already re-exports its peer's value symbols (`MistreevousState`, `Plan`) so the mode files don't need a second defensive destructure of the peer module — except `brain.js`, whose `NeuralNetwork` is still accessed defensively for CJS-interop safety.
- **Peer-dep chunking.** Each mode's `probe()` and `construct()` uses a **literal string** at the `import()` site (`import('mistreevous')` etc.). Vite's static analysis needs the literal to emit per-peer async chunks. This is why the boilerplate is repeated across mode files rather than collapsed into a helper — documented in `cognition/index.ts`'s `probe()` JSDoc. Confirmed in the demo build output (`mistreevous-*.js`, `js-son-*.js`, `brainjs-*.js` emitted as separate async chunks).
- **Deferred UX polish.** When the user flips the dropdown, there's a brief window during which `await mode.construct()` is in flight but the status span still reads the old mode. An epoch guard ensures correctness under rapid flips; a visual \"loading\" affordance is a tracked follow-up.
- **Selection is not persisted** across reload or demo Reset — the pet snapshot restores but the cognition mode always resets to `heuristic`. Design decision #7 in the plan.
- **Roadmap bookkeeping is a separate follow-up commit** on `develop` (per plan Task 4.5, per the `feedback_plan_crafting_on_develop` memory). `.claude/plans/v1-comprehensive-plan.md` row 2 + §0.9.2 prose still show pre-PR status on this branch; they'll be updated after this PR merges.
- **Pre-existing trace-view quirk**: during the BT interrupt, the \"Selected\" row correctly shows `invoke-skill approach-treat` but the adjacent \"why\" line still reads \"top candidate: satisfy-need:hunger (…)\" because `whyForSelection` always reports the urgency top. Not in scope here; worth a follow-up.
- **Windows + `brain.js` native build**: `npm install` inside the demo workspace needs `--ignore-scripts` on a Windows box without MSVC — `brain.js` → `gpu.js` → `gl` tries to build a native C++ addon. Linux/macOS are unaffected. Pre-existing exposure; now a first-class demo dep. Lockfile pins are correct either way.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm test` — 350/350 pass (was 345; +5 new in `tests/examples/cognitionSwitcher.test.ts`).
- [x] `npm run build` (library) + `examples/nurture-pet/npm run build` (demo) both clean.
- [x] Switcher unit test covers: heuristic default, disabled options get `Install X to enable` tooltips, `change` fires `setReasoner`, `dispose` removes the listener, `dispose` before probes resolve prevents late DOM mutation. Uses bounded polling helpers (`waitForProbes`, `waitForCalls`) instead of fixed sleeps — ran 8/8 consecutive cold runs green.
- [ ] Browser smoke at 1× (manual): switcher renders, heuristic default, all three peer modes flip to enabled within ~1s, BT locks on `approach-treat` for 3 ticks on `surpriseTreat`, BDI + learning tick cleanly, Reset returns switcher to heuristic. _Pending._
- [ ] Peer-missing smoke (rename a peer in `node_modules`): option renders disabled with install tooltip. _Optional per plan._
- [ ] `format:check` may still fail on pre-existing Windows CRLF files; CI on Linux passes. _Known, acknowledged in plan §Task 4.4._

🤖 Generated with [Claude Code](https://claude.com/claude-code)