### PR TITLE
fix(demo): release BT after committing approach-treat (PR #46 review)

### DIFF
--- a/examples/nurture-pet/src/cognition/bt.ts
+++ b/examples/nurture-pet/src/cognition/bt.ts
@@ -80,12 +80,19 @@ export const btMode: CognitionModeSpec = {
           // mapping this intention falls through to the runner's noop
           // fallback and the trace panel shows no selection for the
           // interrupt window.
+          //
+          // Returns SUCCEEDED (not RUNNING) so the sequence completes
+          // each tick and the BT re-evaluates from root next step.
+          // RUNNING would pin the action node and bypass
+          // `IsReactingToTreat` on subsequent ticks — the counter would
+          // never decrement and `approach-treat` would be committed
+          // forever after the first surpriseTreat.
           helpers.commit({
             kind: 'react',
             type: 'approach-treat',
             target: 'treat',
           });
-          return MistreevousState.RUNNING;
+          return MistreevousState.SUCCEEDED;
         },
         PickTopCandidate(_ctx, helpers) {
           const top = helpers.topCandidate();

--- a/tests/examples/btMode.test.ts
+++ b/tests/examples/btMode.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { btMode } from '../../examples/nurture-pet/src/cognition/bt.js';
+import type { DomainEvent } from '../../src/events/DomainEvent.js';
+import type { Intention } from '../../src/cognition/Intention.js';
+import type { IntentionCandidate } from '../../src/cognition/IntentionCandidate.js';
+import type { Reasoner, ReasonerContext } from '../../src/cognition/reasoning/Reasoner.js';
+import { Modifiers } from '../../src/modifiers/Modifiers.js';
+
+const HUNGER_CANDIDATE: IntentionCandidate = {
+  intention: { kind: 'satisfy', type: 'satisfy-need:hunger' },
+  score: 0.9,
+  source: 'needs',
+};
+
+const TREAT_EVENT: DomainEvent = {
+  type: 'RandomEvent',
+  subtype: 'surpriseTreat',
+  at: 0,
+};
+
+function ctx(perceived: readonly DomainEvent[]): ReasonerContext {
+  return {
+    perceived,
+    needs: undefined,
+    modifiers: new Modifiers(),
+    candidates: [HUNGER_CANDIDATE],
+  };
+}
+
+function tick(reasoner: Reasoner, perceived: readonly DomainEvent[]): Intention | null {
+  return reasoner.selectIntention(ctx(perceived));
+}
+
+describe('btMode (cognition switcher BT)', () => {
+  it('locks in approach-treat for exactly 3 ticks after a surpriseTreat', async () => {
+    const reasoner = await btMode.construct();
+
+    // Tick 1: treat arrives → BT switches to approach-treat.
+    expect(tick(reasoner, [TREAT_EVENT])?.type).toBe('approach-treat');
+
+    // Ticks 2 + 3: no treat, but the interrupt window stays active.
+    expect(tick(reasoner, [])?.type).toBe('approach-treat');
+    expect(tick(reasoner, [])?.type).toBe('approach-treat');
+
+    // Tick 4: window has elapsed → fall back to the urgency top candidate.
+    // This is the regression guard for the RUNNING→SUCCEEDED fix: returning
+    // RUNNING from RunApproachTreat would pin the action node and never
+    // re-evaluate the IsReactingToTreat condition, so the BT would keep
+    // committing approach-treat indefinitely.
+    expect(tick(reasoner, [])?.type).toBe('satisfy-need:hunger');
+  });
+
+  it('refreshes the interrupt window when a second surpriseTreat arrives', async () => {
+    const reasoner = await btMode.construct();
+
+    expect(tick(reasoner, [TREAT_EVENT])?.type).toBe('approach-treat');
+    // Second treat during the window resets the counter back to 3.
+    expect(tick(reasoner, [TREAT_EVENT])?.type).toBe('approach-treat');
+    expect(tick(reasoner, [])?.type).toBe('approach-treat');
+    expect(tick(reasoner, [])?.type).toBe('approach-treat');
+    expect(tick(reasoner, [])?.type).toBe('satisfy-need:hunger');
+  });
+
+  it('falls back to the top candidate when no treat has been perceived', async () => {
+    const reasoner = await btMode.construct();
+    expect(tick(reasoner, [])?.type).toBe('satisfy-need:hunger');
+    expect(tick(reasoner, [])?.type).toBe('satisfy-need:hunger');
+  });
+});


### PR DESCRIPTION
## Summary

Addresses the **P1** Codex review comment on #46 (`bt.ts:88`): the BT's
`RunApproachTreat` action returned `MistreevousState.RUNNING`, which keeps
the action node active across ticks. Mistreevous resumes a running leaf on
the next step without re-entering its parent, so the
`IsReactingToTreat` condition never re-ran and `remainingTreatTicks` was
pinned at the post-decrement of the first tick. A single `surpriseTreat`
locked the BT into `approach-treat` indefinitely, defeating the intended
3-tick interrupt window.

Returning `SUCCEEDED` lets the sequence complete each tick; the BT
re-evaluates from root next step, the condition decrements the counter,
and the selector falls through to `PickTopCandidate` once the window
elapses.

## Changes

- `examples/nurture-pet/src/cognition/bt.ts` — `RunApproachTreat` now
  returns `MistreevousState.SUCCEEDED`, with a comment explaining the
  RUNNING pitfall so future readers don't regress it.
- `tests/examples/btMode.test.ts` — new regression test (3 cases):
  - 3-tick window with fallback to top candidate on tick 4
  - second-treat-during-window refresh case
  - no-treat fallback to top candidate

## On the second review comment (tsconfig include)

Codex also flagged the `examples/nurture-pet/src/**/*.ts` entry in the
root `tsconfig.json`'s `include` set, predicting TS2307 errors on a clean
`npm ci` because root devDeps don't install `brain.js`. I verified this
doesn't reproduce: `src/cognition/adapters/brainjs/brain.d.ts` is an
ambient `declare module 'brain.js'` shim that satisfies `learning.ts`'s
`await import('brain.js')` at typecheck time even when the peer isn't
installed (this is the documented purpose of the shim, see its file
header). `npm run typecheck` passes on a fresh `npm ci` checkout. The
include is needed so the `tests/examples/*.test.ts` files typecheck their
imports from the demo source — replied on the thread with the full
explanation.

## Test plan

- [x] `npm run verify` green: 353 tests pass (was 350; +3 new).
- [x] `npm run typecheck` clean (confirms the tsconfig concern doesn't
      reproduce on a clean install).
- [x] `npm run build` clean.
