### PR TITLE
fix(test): alias agentonomous subpaths so tests run without dist/ (PR #46 CI)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -136,6 +136,32 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    // Resolve `agentonomous` + its adapter subpaths against `src/` at test
+    // time. Without this, vitest hits the root `package.json` exports
+    // map (→ `./dist/*`), which requires a prior `npm run build` — but
+    // CI runs tests *before* build (and `npm run verify` runs them in
+    // that order locally too). The demo files in `examples/nurture-pet/`
+    // intentionally import from `agentonomous` + its subpaths so they
+    // stay consumer-realistic; the alias keeps the tests that exercise
+    // those demo files working without a build artifact dependency.
+    alias: [
+      {
+        find: /^agentonomous\/cognition\/adapters\/mistreevous$/,
+        replacement: resolve(__dirname, 'src/cognition/adapters/mistreevous/index.ts'),
+      },
+      {
+        find: /^agentonomous\/cognition\/adapters\/js-son$/,
+        replacement: resolve(__dirname, 'src/cognition/adapters/js-son/index.ts'),
+      },
+      {
+        find: /^agentonomous\/cognition\/adapters\/brainjs$/,
+        replacement: resolve(__dirname, 'src/cognition/adapters/brainjs/index.ts'),
+      },
+      {
+        find: /^agentonomous$/,
+        replacement: resolve(__dirname, 'src/index.ts'),
+      },
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

PR #46's CI was red on the **Test (Vitest)** job. Root cause: the demo
sources (and the tests that import them) do

```ts
await import('agentonomous/cognition/adapters/mistreevous');
```

at runtime. Vitest resolves that bare specifier through the root
`package.json` `exports` map — which points at `./dist/cognition/adapters/mistreevous/index.js`.
CI runs tests **before** build, so `dist/` doesn't exist and the dynamic
import fails with `ERR_MODULE_NOT_FOUND`. Both `tests/examples/btMode.test.ts`
and the pre-existing `tests/examples/cognitionSwitcher.test.ts` fall over
on this.

It passed locally because `dist/` was left behind from a previous
`npm run build`. On a fresh clone (`rm -rf dist && npm test`) the failure
reproduces — I confirmed this locally.

## Fix

Add `test.alias` entries in `vite.config.ts` that map `agentonomous` and
its three adapter subpaths to `src/*/index.ts` directly. Tests stop
depending on build artefacts; the demo sources keep their
consumer-realistic imports unchanged.

```ts
alias: [
  { find: /^agentonomous\/cognition\/adapters\/mistreevous$/, replacement: '…/src/cognition/adapters/mistreevous/index.ts' },
  { find: /^agentonomous\/cognition\/adapters\/js-son$/,      replacement: '…/src/cognition/adapters/js-son/index.ts' },
  { find: /^agentonomous\/cognition\/adapters\/brainjs$/,     replacement: '…/src/cognition/adapters/brainjs/index.ts' },
  { find: /^agentonomous$/,                                   replacement: '…/src/index.ts' },
]
```

## Test plan

- [x] `mv dist /tmp/ && npx vitest run tests/examples/` — 8/8 pass
      (was 0/8 without aliases). Dist restored after.
- [x] `npm run verify` green on a clean clone: 353/353 tests, 61 files.
- [x] Build still emits the normal adapter chunks (`dist/cognition/adapters/*`).
