### PR TITLE
fix(test): extend barrel-import timeout to 30s for coverage runs (PR #46 CI)

### DIFF
--- a/tests/unit/events/AgentTickedEvent.test.ts
+++ b/tests/unit/events/AgentTickedEvent.test.ts
@@ -34,8 +34,13 @@ describe('AgentTicked event vocabulary', () => {
     expect(event.trace).toBe(traceStub);
   });
 
+  // First-load of the `src/index.js` barrel under v8 coverage
+  // instrumentation can exceed the default 5s timeout on cold /
+  // CPU-constrained runners (seen as a flake on GitHub `ubuntu-latest`).
+  // Bumping to 30s keeps the re-export check without the timing
+  // sensitivity.
   it('is re-exported from the public barrel', async () => {
     const barrel = await import('../../../src/index.js');
     expect(barrel.AGENT_TICKED).toBe('AgentTicked');
-  });
+  }, 30000);
 });


### PR DESCRIPTION
## Summary

PR #46's Test job was still red after the alias fix in #48. Root cause
was **not** another module-resolution problem — it was a flaky 5s
timeout on a dynamic-import test under v8 coverage instrumentation.

The offending test:

```ts
// tests/unit/events/AgentTickedEvent.test.ts:37
it('is re-exported from the public barrel', async () => {
  const barrel = await import('../../../src/index.js');
  expect(barrel.AGENT_TICKED).toBe('AgentTicked');
});
```

That `import()` is the first thing to drag the whole `src/` barrel through
v8 coverage instrumentation. On cold, CPU-constrained runners (GitHub
`ubuntu-latest`) the load crosses vitest's default 5s per-test timeout.

Reproduced locally: with the alias fix from #48 in place and `dist/`
absent, `npm run test:coverage` fails roughly 1 in 3 runs on this exact
test. After the bump, 5/5 runs green. Full `npm run verify` green too
(353/353 tests).

## Change

Pass an explicit `30000` ms timeout to the test. The test still performs
the re-export check — we just absorb the worst-case cold-load cost we've
observed (~20s under coverage).

```ts
it(
  'is re-exported from the public barrel',
  async () => { ... },
  30000,
);
```

Kept the comment terse but explicit so the next reader understands it's
about v8 coverage cold-load time, not a real perf regression.

## Test plan

- [x] Reproduced the flake locally (1/5 failed pre-fix on the exact CI
      command `npm run test:coverage`).
- [x] 5/5 consecutive runs green post-fix.
- [x] `npm run verify` green (353 tests, 61 files, build clean).

Once this lands in `feat/cognition-switcher-demo`, PR #46's CI should
finally go fully green.
