### PR TITLE
fix(test): stub brain.js for vite import-analysis in CI (actual PR #46 fix)

### DIFF
--- a/tests/examples/stubs/brain-js.ts
+++ b/tests/examples/stubs/brain-js.ts
@@ -1,0 +1,34 @@
+/**
+ * Test-only stub for the optional `brain.js` peer dep.
+ *
+ * `brain.js` is declared as an **optional** peer of `agentonomous` and
+ * as a devDep of the `nurture-pet` demo workspace — **not** a root
+ * devDep. That's intentional: its transitive dep chain (`gpu.js` →
+ * `gl`) needs an X11 native build that explodes on headless CI. See
+ * `src/cognition/adapters/brainjs/brain.d.ts` for the ambient typedef
+ * that lets TS compile without it installed.
+ *
+ * At runtime, the demo's `learning.ts` wraps `await import('brain.js')`
+ * in a try/catch precisely so a missing peer degrades gracefully
+ * (option renders disabled). But Vite's `vite:import-analysis` plugin
+ * eagerly resolves every dynamic import's specifier at transform time
+ * before the try/catch can run — and root `npm ci` on CI doesn't
+ * install `brain.js`, so transform fails.
+ *
+ * This stub exists so the vitest alias in `vite.config.ts` can route
+ * `import('brain.js')` to something resolvable. The tests in
+ * `tests/examples/cognitionSwitcher.test.ts` never call
+ * `learningMode.construct()` — they only care whether the probe
+ * resolves — so exporting a placeholder `NeuralNetwork` is enough to
+ * keep the module shape plausible without pulling the native chain.
+ */
+export class NeuralNetwork<In = unknown, Out = unknown> {
+  run(_input: In): Out {
+    throw new Error('brain.js stub: NeuralNetwork.run() is not implemented in the test stub.');
+  }
+  fromJSON(_json: unknown): this {
+    return this;
+  }
+}
+
+export default { NeuralNetwork };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -161,6 +161,21 @@ export default defineConfig({
         find: /^agentonomous$/,
         replacement: resolve(__dirname, 'src/index.ts'),
       },
+      // `brain.js` is an optional peer of `agentonomous` and a devDep of
+      // the `nurture-pet` demo workspace — not a root devDep (its
+      // `gpu.js` → `gl` chain needs X11 native build headers that
+      // explode on headless CI). The demo's `learning.ts` guards its
+      // `await import('brain.js')` with try/catch so a missing peer
+      // degrades gracefully, but `vite:import-analysis` resolves the
+      // specifier at transform time before the try/catch can run, so
+      // root `npm ci` CI fails before the first test executes. Alias
+      // to a test-local stub that exports a placeholder `NeuralNetwork`
+      // — the cognitionSwitcher tests never call `learningMode.construct()`,
+      // only check whether the probe resolved, so the stub is enough.
+      {
+        find: /^brain\.js$/,
+        replacement: resolve(__dirname, 'tests/examples/stubs/brain-js.ts'),
+      },
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

**This is the actual CI fix for PR #46's test job.** The earlier timeout
bump in #49 addressed a flake that happened to coexist but wasn't the
real failure. Thanks for pasting the log — here's what CI was really
saying:

```
FAIL  tests/examples/cognitionSwitcher.test.ts
Error: Failed to resolve import "brain.js" from "examples/nurture-pet/src/cognition/learning.ts"
  Plugin: vite:import-analysis
```

## Root cause

`brain.js` is declared as an **optional** peer of `agentonomous` and a
devDep of the `nurture-pet` demo workspace — **not** a root devDep. That
was a deliberate call (its `gpu.js` → `gl` dep chain needs X11 native
build headers; the existing `src/cognition/adapters/brainjs/brain.d.ts`
header explains the rationale).

Root `npm ci` therefore never installs `brain.js`. The demo's `learning.ts`
wraps `await import('brain.js')` in a try/catch so a missing peer degrades
gracefully — **at runtime**. But vite's `vite:import-analysis` plugin
resolves every dynamic import specifier at *transform time*, before the
try/catch can run. Transform fails, `cognitionSwitcher.test.ts` never even
loads, and the whole test file reports as failed.

This passed locally because npm had hoisted `brain.js` from
`examples/nurture-pet/node_modules` when vite walked up the tree. In CI
the demo workspace is never installed, so nothing to hoist from. I
reproduced the failure exactly by `mv examples/nurture-pet/node_modules/brain.js /tmp/` then running `npm run test:coverage`.

## Fix

Add a vitest-only alias `brain.js` → a test-local stub exporting a
placeholder `NeuralNetwork` class:

- `tests/examples/stubs/brain-js.ts` — minimal stub (throws on `run()`,
  no-ops `fromJSON`) with a header explaining why it exists.
- `vite.config.ts` — `test.alias` entry `{ find: /^brain\.js$/, replacement: '…/stubs/brain-js.ts' }`.

The `cognitionSwitcher.test.ts` suite never calls
`learningMode.construct()` — it only checks whether each mode's probe
resolved, which the stub satisfies trivially. Root devDeps stay clean;
the native build chain stays far away from CI.

## Test plan

- [x] Reproduced the CI failure locally by removing `brain.js` from every
      `node_modules` tree.
- [x] `npm run test:coverage` — 353/353 pass, 5/5 consecutive runs green.
- [x] `npm run verify` green (format, lint, typecheck, test, build) with
      `brain.js` absent.
- [x] Build output unaffected — `dist/cognition/adapters/brainjs/index.js`
      still emits with `brain.js` marked external as before.
