### PR TITLE
docs(plans): 0.9.4 reasoner-reset + 0.9.3 brainjs-training-persistence

### DIFF
--- a/.claude/plans/0.9.3-brainjs-training-persistence.md
+++ b/.claude/plans/0.9.3-brainjs-training-persistence.md
@@ -1,0 +1,773 @@
+# 0.9.3 brain.js Training Persistence — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if
+> subagents available) or superpowers:executing-plans to implement this plan. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a demo-side "Train" button that runs a short brain.js training
+batch on a synthetic dataset, persists the trained network via
+`network.toJSON()` into its own localStorage key, rehydrates the persisted
+network on reload, and wires the network's scalar output into `interpret()` so
+trained state is reflected in gameplay (occasional idle ticks below the urgency
+threshold). No library changes — demo-internal only.
+
+**Architecture:** Single demo PR, **cut from `develop` after 0.9.4 merges**. One
+new mode-gated button mounted inside `#cognition-switcher`. One click handler
+that generates 30 pairs from the demo's seeded RNG, calls `.train()`
+synchronously on the main thread, writes `.toJSON()` to
+`agentonomous/<agentId>/brainjs-network`. The learning-mode factory's
+`construct()` checks that key first and falls back to the existing
+`learning.network.json` default when absent. `interpret()` changes from a
+straight pass-through to an urgency-gate that returns `null` (idle) when the
+network's scalar output drops below a constant threshold. Reset clears both the
+agent snapshot and the brainjs-network keys so "fresh start" stays a single
+concept. Tests extend the existing `tests/examples/stubs/brain-js.ts` shim with
+minimal `.train()` / `.toJSON()` so CI keeps avoiding the brain.js native
+build.
+
+**Tech Stack:** TypeScript (strict + `exactOptionalPropertyTypes`), vitest
+(+ jsdom env), Vite for the demo build. brain.js as an optional peer. ESM with
+`.js` extensions on relative imports.
+
+**Design reference:** Design section approved in the 0.9.3 brainstorm (Q1(b),
+Q2(b), Q3(a), Q4(a), Q5(a)). Scope decisions there are out of scope to revisit
+here. Relies on `v1-comprehensive-plan.md:115–124` for the framing and on the
+0.9.4 `Reasoner.reset()` harmonization shipping first (even though the brain.js
+adapter opts out of reset, the cognition mode rebuilds on switcher selection
+and we want the port contract landed before the demo exercises a second
+round-trip of persisted adapter state).
+
+---
+
+## File Structure
+
+### New files
+
+- `tests/examples/learningMode.train.test.ts` — test suite covering button
+  visibility under mode gating, train invocation, persistence, rehydration on
+  fresh construction, reset-wipes-network.
+
+### Modified files
+
+- `tests/examples/stubs/brain-js.ts` — extend the stub with minimal `.train()`
+  (records the last batch it received) and `.toJSON()` (returns a deterministic
+  sentinel derived from recorded calls). Change `run()` from throwing to
+  returning `[0.5]` so `construct()` is testable without the native peer.
+- `examples/nurture-pet/index.html` — add `<button id="train-network"
+hidden>Train</button>` inside the existing `#cognition-switcher` container.
+- `examples/nurture-pet/src/cognitionSwitcher.ts` — in the `onChange` path,
+  toggle the Train button visibility based on selected mode id (show only for
+  `learning`). Attach the train click handler once at mount, not per-change.
+  Expose the reasoner instance to the train handler via closure or a small
+  internal setter (whichever matches the existing switcher's style — check
+  before deciding).
+- `examples/nurture-pet/src/cognition/learning.ts` — two changes:
+  1. Before `network.fromJSON(networkJson)`, check
+     `localStorage.getItem('agentonomous/<agentId>/brainjs-network')`; if
+     present and parses, use that instead of the default asset.
+  2. Rewrite `interpret()` to apply the `URGENCY_THRESHOLD` gate before falling
+     back to `topCandidate()`.
+- `examples/nurture-pet/src/ui.ts` — in the existing reset handler
+  (`mountResetButton`), add a `localStorage.removeItem(...)` call for the
+  brainjs-network key alongside the existing snapshot key removal.
+
+### Deliberately untouched
+
+- `examples/nurture-pet/src/cognition/learning.network.json` — the hand-authored
+  default asset stays as-is. Trained state only lives in localStorage.
+- Any file under `src/` — this is a demo-only PR. If execution uncovers a
+  required library change, stop and treat it as a scope escape.
+
+---
+
+## Task 0: Prerequisites + cut topic branch
+
+**Files:** none (git only).
+
+- [ ] **Step 1: Confirm 0.9.4 is merged to `develop`.**
+
+Run: `git log --oneline origin/develop --grep="reasoner.reset\|0.9.4" -5`
+Expected: at least one commit referencing the 0.9.4 reset harmonization.
+If none, stop and merge 0.9.4 first.
+
+- [ ] **Step 2: Confirm clean tree + pull develop.**
+
+Run: `git switch develop && git status && git pull --ff-only origin develop`
+Expected: `nothing to commit, working tree clean` and a fast-forward (or
+already up to date).
+
+- [ ] **Step 3: Cut the topic branch.**
+
+Run: `git switch -c feat/brainjs-training-persistence`
+
+---
+
+## Task 1: Extend the brain.js test stub
+
+**Files:**
+
+- Modify: `tests/examples/stubs/brain-js.ts`
+
+- [ ] **Step 1: Replace the class body.**
+
+Replace the current `NeuralNetwork` class (lines 25–32) with:
+
+```ts
+export class NeuralNetwork<In = unknown, Out = unknown> {
+  #weights: unknown = null;
+  #lastTrain: unknown = null;
+
+  run(_input: In): Out {
+    // Stable scalar makes urgency-gate tests deterministic without a real net.
+    return [0.5] as unknown as Out;
+  }
+
+  fromJSON(json: unknown): this {
+    this.#weights = json;
+    return this;
+  }
+
+  toJSON(): unknown {
+    return { stub: true, trainedFrom: this.#lastTrain, seededFrom: this.#weights };
+  }
+
+  train(pairs: unknown, _opts: unknown): void {
+    this.#lastTrain = pairs;
+  }
+}
+```
+
+Update the surrounding JSDoc (lines 1–24) to reflect that the stub now covers
+`run()` with a stable value and records `.train()` / `.toJSON()` for assertion.
+Delete the sentence claiming `run()` throws.
+
+- [ ] **Step 2: Typecheck.**
+
+Run: `npm run typecheck`
+Expected: no errors. Existing `cognitionSwitcher.test.ts` doesn't touch
+`run()` / `train()` / `toJSON()`, so it's unaffected.
+
+- [ ] **Step 3: Test suite still green.**
+
+Run: `npm test`
+Expected: all existing tests pass.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add tests/examples/stubs/brain-js.ts
+git commit -m "test(demo): extend brain.js stub with train/toJSON + stable run
+
+Prepares the stub for 0.9.3's training-persistence tests. run() now
+returns a stable [0.5] so construct() and urgency-gate logic are
+testable without the native peer. train() records the last pair batch;
+toJSON() returns a deterministic sentinel. No behavior change for
+existing tests."
+```
+
+---
+
+## Task 2: Mount the Train button (mode-gated visibility)
+
+**Files:**
+
+- Create: `tests/examples/learningMode.train.test.ts`
+- Modify: `examples/nurture-pet/index.html`
+- Modify: `examples/nurture-pet/src/cognitionSwitcher.ts`
+
+- [ ] **Step 1: Write the failing test.**
+
+Create `tests/examples/learningMode.train.test.ts` with only the visibility
+test for now. Mirror the fixture setup from `tests/examples/cognitionSwitcher.test.ts`
+(DOM bootstrapping, agent construction, switcher mount).
+
+```ts
+import { describe, expect, it } from 'vitest';
+// ...same imports as cognitionSwitcher.test.ts
+// + whatever helper extracts the switcher-mount flow
+
+describe('Train button visibility', () => {
+  it('is hidden on initial mount (default mode is heuristic)', async () => {
+    const { document } = await mountDemo();
+    const btn = document.getElementById('train-network');
+    expect(btn).not.toBeNull();
+    expect(btn!.hasAttribute('hidden')).toBe(true);
+  });
+
+  it('becomes visible when the user selects learning mode', async () => {
+    const { document, selectMode } = await mountDemo();
+    await selectMode('learning');
+    const btn = document.getElementById('train-network')!;
+    expect(btn.hasAttribute('hidden')).toBe(false);
+  });
+
+  it('returns to hidden when the user selects a non-learning mode', async () => {
+    const { document, selectMode } = await mountDemo();
+    await selectMode('learning');
+    await selectMode('heuristic');
+    const btn = document.getElementById('train-network')!;
+    expect(btn.hasAttribute('hidden')).toBe(true);
+  });
+});
+```
+
+> **Helper note:** if `mountDemo()` + `selectMode()` don't already exist as test
+> helpers, extract them from `cognitionSwitcher.test.ts`'s beforeEach setup
+> into a shared `tests/examples/helpers/mountDemo.ts` and import from there.
+> Keep the extraction surgical — don't refactor unrelated test code.
+
+- [ ] **Step 2: Run it; confirm failure.**
+
+Run: `npm test -- learningMode.train`
+Expected: `#train-network` element is null (not yet in DOM).
+
+- [ ] **Step 3: Add the button to `index.html`.**
+
+Inside the existing `<div id="cognition-switcher">` block (around lines
+483–489 of `examples/nurture-pet/index.html`), append:
+
+```html
+<button id="train-network" type="button" hidden>Train</button>
+```
+
+Adjacent to the existing `<select id="cognition-mode-select">` and
+`<span id="cognition-status">`. The `hidden` attribute is load-time default.
+
+- [ ] **Step 4: Wire the mode-gate toggle in `cognitionSwitcher.ts`.**
+
+In the `onChange` path of the switcher — where the new reasoner is assigned —
+also toggle the Train button's `hidden` attribute:
+
+```ts
+const trainBtn = document.getElementById('train-network') as HTMLButtonElement | null;
+if (trainBtn) {
+  if (nextMode.id === 'learning') trainBtn.removeAttribute('hidden');
+  else trainBtn.setAttribute('hidden', '');
+}
+```
+
+Read the current `onChange` implementation first (`cognitionSwitcher.ts`
+lines 93–122) and place the toggle at a natural seam — after the reasoner
+assignment, before the status flash.
+
+- [ ] **Step 5: Run the tests.**
+
+Run: `npm test -- learningMode.train`
+Expected: all three visibility tests pass.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add examples/nurture-pet/index.html examples/nurture-pet/src/cognitionSwitcher.ts tests/examples/learningMode.train.test.ts
+git commit -m "feat(demo): mode-gated Train button for learning mode
+
+Mounts <button id='train-network' hidden> inside #cognition-switcher.
+Visibility toggles with the selected cognition mode — shown only when
+'learning' is active. Click handler lands in the next commit.
+
+Extracts the DOM-bootstrap helpers into tests/examples/helpers/mountDemo.ts
+for reuse across the cognitionSwitcher + learningMode suites."
+```
+
+_(Drop the helper-extraction line if you didn't extract any — adjust the
+message to match reality.)_
+
+---
+
+## Task 3: Train click handler — generate pairs + call `.train()` + persist
+
+**Files:**
+
+- Modify: `tests/examples/learningMode.train.test.ts`
+- Modify: `examples/nurture-pet/src/cognitionSwitcher.ts`
+
+- [ ] **Step 1: Add the failing tests.**
+
+Append a new `describe('Train click handler', () => { ... })` block to the
+existing test file:
+
+```ts
+describe('Train click handler', () => {
+  it('invokes NeuralNetwork.train() with 30 synthetic pairs when clicked', async () => {
+    const { document, selectMode, getStubNetwork } = await mountDemo();
+    await selectMode('learning');
+    const btn = document.getElementById('train-network') as HTMLButtonElement;
+
+    btn.click();
+    await waitForTrainingFlush(); // poll until button re-enables
+
+    const pairs = getStubNetwork().lastTrainPairs();
+    expect(pairs).toHaveLength(30);
+    expect(pairs.every((p) => 'input' in p && 'output' in p)).toBe(true);
+    expect(pairs.every((p) => typeof p.output.score === 'number')).toBe(true);
+  });
+
+  it('writes the trained network to localStorage under the agent-scoped key', async () => {
+    const { document, selectMode, agentId } = await mountDemo();
+    await selectMode('learning');
+    const btn = document.getElementById('train-network') as HTMLButtonElement;
+
+    btn.click();
+    await waitForTrainingFlush();
+
+    const raw = localStorage.getItem(`agentonomous/${agentId}/brainjs-network`);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.stub).toBe(true); // matches our extended stub's toJSON()
+    expect(parsed.trainedFrom).toHaveLength(30);
+  });
+
+  it('disables the button and changes its text during training, then restores', async () => {
+    const { document, selectMode } = await mountDemo();
+    await selectMode('learning');
+    const btn = document.getElementById('train-network') as HTMLButtonElement;
+
+    const clickPromise = fireClickAndCapture(btn); // helper: reads btn state between click and await
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toBe('Training…');
+    await clickPromise;
+
+    expect(btn.disabled).toBe(false);
+    expect(btn.textContent).toBe('Train');
+  });
+});
+```
+
+- [ ] **Step 2: Run it; confirm failure.**
+
+Run: `npm test -- learningMode.train`
+Expected: the three new tests fail — no click handler wired yet.
+
+- [ ] **Step 3: Implement the click handler in `cognitionSwitcher.ts`.**
+
+In the switcher module, attach a one-time click listener on `#train-network`
+at mount time (not per-mode-change). The handler needs access to the current
+`BrainJsReasoner` instance — thread it through a closure or the existing
+reasoner reference, whichever matches the switcher's current state management.
+
+```ts
+async function onTrainClick(
+  btn: HTMLButtonElement,
+  adapter: { getNetwork: () => { train: (p: unknown, o: unknown) => void; toJSON: () => unknown } },
+  agentId: string,
+  rng: () => number,
+): Promise<void> {
+  btn.disabled = true;
+  const originalText = btn.textContent ?? 'Train';
+  btn.textContent = 'Training…';
+
+  try {
+    const pairs = Array.from({ length: 30 }, () => {
+      const needs = {
+        hunger: rng(),
+        cleanliness: rng(),
+        happiness: rng(),
+        energy: rng(),
+        health: rng(),
+      };
+      const urgency = 1 - Math.min(...Object.values(needs));
+      return { input: needs, output: { score: urgency } };
+    });
+
+    const network = adapter.getNetwork();
+    network.train(pairs, { iterations: 100, errorThresh: 0.005 });
+
+    localStorage.setItem(
+      `agentonomous/${agentId}/brainjs-network`,
+      JSON.stringify(network.toJSON()),
+    );
+
+    // Brief success flash via #cognition-status — 1500ms then reverts.
+    flashStatus('Trained ✓', 1500);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = originalText;
+  }
+}
+```
+
+Wire the listener at switcher mount time. Use the demo's existing seeded RNG
+(from `seed.ts`) so training pairs are reproducible under a fixed seed.
+
+- [ ] **Step 4: Run the tests.**
+
+Run: `npm test -- learningMode.train`
+Expected: all train-click tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add examples/nurture-pet/src/cognitionSwitcher.ts tests/examples/learningMode.train.test.ts
+git commit -m "feat(demo): wire Train button to generate pairs + persist network
+
+Click handler generates 30 synthetic (needs → urgency) pairs from the
+demo's seeded RNG, runs network.train() with 100 iterations, and
+writes network.toJSON() to agentonomous/<agentId>/brainjs-network. Button
+disables + shows 'Training…' during the synchronous train call and
+reverts on completion. Status flash signals success."
+```
+
+---
+
+## Task 4: Rehydrate from localStorage in `learning.ts`
+
+**Files:**
+
+- Modify: `tests/examples/learningMode.train.test.ts`
+- Modify: `examples/nurture-pet/src/cognition/learning.ts`
+
+- [ ] **Step 1: Add the failing tests.**
+
+Append:
+
+```ts
+describe('learningMode.construct() hydration order', () => {
+  it('loads from localStorage when the brainjs-network key is present', async () => {
+    const agentId = 'test-pet';
+    const savedNet = { stub: true, trainedFrom: 'fake-prior-training' };
+    localStorage.setItem(`agentonomous/${agentId}/brainjs-network`, JSON.stringify(savedNet));
+
+    const { getStubNetwork } = await mountDemo({ agentId });
+    await selectMode('learning');
+
+    // Verify fromJSON() was called with the localStorage payload, NOT the default asset.
+    expect(getStubNetwork().lastFromJSON()).toEqual(savedNet);
+  });
+
+  it('falls back to the default learning.network.json when the key is absent', async () => {
+    const agentId = 'test-pet';
+    localStorage.removeItem(`agentonomous/${agentId}/brainjs-network`);
+
+    const { getStubNetwork } = await mountDemo({ agentId });
+    await selectMode('learning');
+
+    const loaded = getStubNetwork().lastFromJSON() as { type?: string; sizes?: number[] };
+    // The default asset has sizes: [5, 1]. (See learning.network.json.)
+    expect(loaded.sizes).toEqual([5, 1]);
+  });
+});
+```
+
+> **Stub helper addition:** in Task 1's stub, add a `lastFromJSON()`
+> inspection getter if it's not already on the exported shape. Surgical
+> extension — keep the stub tight.
+
+- [ ] **Step 2: Run it; confirm failure.**
+
+Run: `npm test -- learningMode.train`
+Expected: the hydration-from-localStorage test fails — `construct()` currently
+always loads from the default asset.
+
+- [ ] **Step 3: Implement hydration in `learning.ts`.**
+
+Replace the `construct()` body in `examples/nurture-pet/src/cognition/learning.ts`
+around the `network.fromJSON(networkJson)` call (line 51):
+
+```ts
+const Net = NeuralNetwork as new () => {
+  fromJSON: (json: unknown) => unknown;
+  run: (input: unknown) => unknown;
+};
+const network = new Net();
+
+const key = `agentonomous/${agentId}/brainjs-network`;
+const persisted = localStorage.getItem(key);
+let seed: unknown = networkJson;
+if (persisted !== null) {
+  try {
+    seed = JSON.parse(persisted);
+  } catch {
+    // Corrupt value — fall back to default. No user-visible action needed.
+    seed = networkJson;
+  }
+}
+network.fromJSON(seed);
+```
+
+Thread `agentId` into `construct()` — either via the `CognitionModeSpec`'s
+signature (if that's how other modes get it) or via a module-scoped setter
+called from `main.ts`. **Check the existing signature before changing it** —
+if `construct()` doesn't receive `agentId`, the smallest change is a
+`setAgentId(id)` export on this module called once from `main.ts` after the
+agent is created. Do not widen `CognitionModeSpec` unless every mode needs it.
+
+- [ ] **Step 4: Run the tests.**
+
+Run: `npm test -- learningMode.train`
+Expected: both hydration tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add examples/nurture-pet/src/cognition/learning.ts tests/examples/stubs/brain-js.ts tests/examples/learningMode.train.test.ts
+git commit -m "feat(demo): hydrate learning-mode network from localStorage
+
+construct() checks agentonomous/<agentId>/brainjs-network first and
+falls back to the learning.network.json default asset when the key is
+absent or unparseable. Corrupt stored values silently revert to default
+— no user-visible error; the Train button regenerates valid state."
+```
+
+---
+
+## Task 5: Reset wiring — wipe the brainjs-network key too
+
+**Files:**
+
+- Modify: `tests/examples/learningMode.train.test.ts`
+- Modify: `examples/nurture-pet/src/ui.ts`
+
+- [ ] **Step 1: Add the failing test.**
+
+Append:
+
+```ts
+describe('Reset button clears trained network', () => {
+  it('removes agentonomous/<agentId>/brainjs-network when Reset is clicked', async () => {
+    const agentId = 'test-pet';
+    localStorage.setItem(
+      `agentonomous/${agentId}/brainjs-network`,
+      JSON.stringify({ stub: true, trainedFrom: 'prior' }),
+    );
+
+    const { document, confirmReset } = await mountDemo({ agentId });
+    const resetBtn = document.getElementById('reset-button') as HTMLButtonElement;
+
+    resetBtn.click();
+    await confirmReset();
+
+    expect(localStorage.getItem(`agentonomous/${agentId}/brainjs-network`)).toBeNull();
+  });
+});
+```
+
+> **Helper note:** Reset is confirm-gated — `confirmReset()` should auto-accept
+> the confirmation modal. Look at how `cognitionSwitcher.test.ts` or other
+> existing tests handle the confirm flow before writing a new helper.
+
+- [ ] **Step 2: Run it; confirm failure.**
+
+Run: `npm test -- learningMode.train`
+Expected: the brainjs-network key is still present after reset.
+
+- [ ] **Step 3: Add the cleanup line in `ui.ts`.**
+
+In `mountResetButton` (or wherever the existing reset handler lives — search
+`ui.ts` for `removeItem` to find the adjacent snapshot-cleanup call), add:
+
+```ts
+localStorage.removeItem(`agentonomous/${agentId}/brainjs-network`);
+```
+
+Place it immediately after the existing snapshot-key removal line so the two
+cleanups are visually grouped.
+
+- [ ] **Step 4: Run the test.**
+
+Run: `npm test -- learningMode.train`
+Expected: all reset tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add examples/nurture-pet/src/ui.ts tests/examples/learningMode.train.test.ts
+git commit -m "feat(demo): Reset also wipes the trained brainjs-network
+
+mountResetButton now removes agentonomous/<agentId>/brainjs-network
+alongside the agent snapshot key. Reset stays a single 'fresh start'
+concept — next learning-mode construct() falls back to the default
+network asset."
+```
+
+---
+
+## Task 6: `interpret()` urgency gate (behavioral change)
+
+**Files:**
+
+- Modify: `examples/nurture-pet/src/cognition/learning.ts`
+
+> **No new unit tests** for this task: the stub's `run()` returns a stable
+> `[0.5]`, and the urgency threshold is a constant. Any unit assertion
+> collapses to either "always idles" or "never idles" depending on threshold
+> choice — neither tests anything meaningful. Behavioral verification is a
+> manual smoke in Task 7.
+
+- [ ] **Step 1: Add the threshold constant and rewrite `interpret()`.**
+
+Near the top of `learning.ts`, add:
+
+```ts
+const URGENCY_THRESHOLD = 0.35;
+```
+
+Replace the existing `interpret` function inside `construct()`:
+
+```ts
+interpret: (output, _ctx, helpers) => {
+  const urgency = Array.isArray(output)
+    ? (output[0] as number)
+    : ((output as { score?: number }).score ?? 0);
+  if (urgency < URGENCY_THRESHOLD) return null;
+  const top = helpers.topCandidate();
+  return top ? top.intention : null;
+},
+```
+
+Update the module-level JSDoc (lines 5–13) to reflect the change: drop the
+sentence saying the network's output is ignored; replace with a sentence
+documenting the urgency gate and that `URGENCY_THRESHOLD = 0.35` was picked
+empirically to produce a visible idle rate given the default network.
+
+- [ ] **Step 2: Typecheck + full test.**
+
+Run: `npm run verify`
+Expected: all stages green.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add examples/nurture-pet/src/cognition/learning.ts
+git commit -m "feat(demo): urgency-gate interpret() in learning mode
+
+Network scalar output is now wired into intention selection as an
+urgency gate: the pet idles this tick when the network's score falls
+below URGENCY_THRESHOLD (0.35). Visible demo effect — trained and
+untrained networks produce different idle rates, making training
+observable in the trace view. Threshold is empirical; may be tuned
+during manual smoke."
+```
+
+---
+
+## Task 7: Manual smoke test
+
+**Files:** none (manual verification).
+
+- [ ] **Step 1: Build the library.**
+
+Run: `npm run build`
+Expected: clean `dist/` output.
+
+- [ ] **Step 2: Start the demo.**
+
+Run: `npm run demo:dev`
+Expected: Vite dev server at `http://localhost:5173`.
+
+- [ ] **Step 3: Verify initial state.**
+
+- Open the demo in a fresh private window (clean localStorage).
+- Switch to Learning mode. Train button appears.
+- Watch the trace view for ~15 seconds. Note the idle-tick frequency
+  (how often "selected: null" appears).
+
+- [ ] **Step 4: Train and verify persistence.**
+
+- Click Train. Button disables + shows "Training…" + brief "Trained ✓" flash.
+- Open DevTools → Application → Local Storage.
+- Verify `agentonomous/<agentId>/brainjs-network` key exists with
+  a JSON value (start of `{"type":"NeuralNetwork"` or similar real
+  brain.js output — NOT the stub sentinel since this is the real peer).
+- Watch the trace view for ~15 seconds again. Idle-tick frequency should be
+  noticeably different from pre-training.
+
+- [ ] **Step 5: Verify rehydration on reload.**
+
+- Hard reload (Ctrl+Shift+R).
+- Switch back to Learning mode (the switcher resets to heuristic on reload).
+- Trace view should match the post-training state from Step 4, NOT the
+  pre-training default.
+
+- [ ] **Step 6: Verify Reset wipes.**
+
+- Click Reset. Confirm the dialog.
+- Check DevTools localStorage: `agentonomous/<agentId>/brainjs-network` is
+  gone. Agent snapshot key is also gone.
+- Switch to Learning mode. Trace should match the pre-training baseline
+  from Step 3.
+
+- [ ] **Step 7: Tune threshold if needed.**
+
+If Steps 3 and 4 produce indistinguishable idle rates, either:
+
+- Raise `URGENCY_THRESHOLD` until baseline produces clear idle ticks, or
+- Adjust the training label function so post-training urgency systematically
+  shifts.
+
+If tuning is needed, add a commit:
+
+```bash
+git add examples/nurture-pet/src/cognition/learning.ts
+git commit -m "tune(demo): URGENCY_THRESHOLD for visible pre/post-train divergence"
+```
+
+---
+
+## Task 8: Verify, PR, cleanup
+
+**Files:** none.
+
+- [ ] **Step 1: Full pre-PR gate.**
+
+Run: `npm run verify`
+Expected: `format:check`, `lint`, `typecheck`, `test`, `build` all green.
+
+- [ ] **Step 2: Push and open PR.**
+
+```bash
+git push -u origin feat/brainjs-training-persistence
+gh pr create --base develop --title "feat(demo): 0.9.3 brain.js training persistence" --body "$(cat <<'EOF'
+## Summary
+- Mode-gated Train button inside #cognition-switcher — visible only when Learning mode is active.
+- Click handler generates 30 synthetic (needs → urgency) pairs from the demo's seeded RNG and runs `network.train()` for 100 iterations on the main thread.
+- Trained network persists to `agentonomous/<agentId>/brainjs-network` (parallel to existing seed/speed keys, not inside the agent snapshot).
+- `learning.ts` rehydrates from that key on `construct()`; falls back to the bundled `learning.network.json` default when absent.
+- `interpret()` now wires the network's scalar output into an urgency gate — pet idles this tick below `URGENCY_THRESHOLD` (0.35). Trained state is observably different from default in the trace view.
+- Reset wipes both the agent snapshot and the brainjs-network key.
+- No library changes.
+- Tests extend the existing brain.js stub with minimal `.train()`/`.toJSON()`/stable `.run()` so CI keeps avoiding the native peer.
+
+Depends on 0.9.4 reset-harmonization being on `develop`.
+
+## Test plan
+- [ ] `npm run verify` green locally (format, lint, typecheck, test, build).
+- [ ] New test file `tests/examples/learningMode.train.test.ts` covers button visibility, click → train → persist, hydration from localStorage, reset-wipes-network.
+- [ ] Manual smoke in Chrome verifies persistence across reload and visible pre/post-training trace divergence.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: After merge — local cleanup.**
+
+```bash
+git switch develop
+git pull origin develop
+git branch -d feat/brainjs-training-persistence
+git fetch --prune origin
+```
+
+Delete the remote branch via the merged-PR UI if the repo doesn't auto-delete.
+
+---
+
+## Risks & escape hatches
+
+| Risk                                                                             | Mitigation                                                                                                                                                                   |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| URGENCY_THRESHOLD tuning doesn't produce visible divergence                      | Task 7 step 7 bakes tuning into the smoke flow. Adjust threshold or label function.                                                                                          |
+| brain.js `.train()` blocks noticeably on slower hardware                         | Iteration count is bounded (100) on a bounded dataset (30 pairs). If reports surface post-merge, open a follow-up for the worker path (deferred in Q4(b)).                   |
+| Existing `cognitionSwitcher.test.ts` breaks when the stub `run()` stops throwing | That test never calls `construct()` (per its setup code) so `run()` isn't exercised. Regression would mean the test was silently relying on the throw — treat as a real bug. |
+| Agent-ID threading to `construct()` requires widening `CognitionModeSpec`        | Task 4 Step 3 escape: use a module-scoped `setAgentId()` on `learning.ts` called from `main.ts` instead of changing the shared spec.                                         |
+| Vite's `vite:import-analysis` plugin chokes on the new localStorage path         | Not expected — localStorage is a runtime concern, not an import-graph concern. If seen, surface via `npm run demo:dev` failure and treat as unrelated.                       |
+
+## Out of scope (hard — if any of these appears during execution, stop and defer)
+
+- Any change under `src/` (library code). Demo-only PR.
+- Training-from-play observation buffer (deferred per Q1(c)).
+- Web worker training (deferred per Q4(b)).
+- Forget / cross-pet persistence (deferred per Q3(b)/(c)).
+- Wiring `AgentSnapshot.beliefs` (out of scope per 0.9.4 Q3(a)).
+- Replacing or regenerating `learning.network.json`. The default asset stays as-is.
+- Refactoring the existing cognition switcher beyond the new toggle + listener attachment.

--- a/.claude/plans/0.9.4-reasoner-reset-harmonization.md
+++ b/.claude/plans/0.9.4-reasoner-reset-harmonization.md
@@ -1,0 +1,644 @@
+# 0.9.4 `Reasoner.reset()` Harmonization — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if
+> subagents available) or superpowers:executing-plans to implement this plan. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lift `reset()` to the `Reasoner` port as an optional method and have the
+kernel invoke it at two fixed call sites — after `Agent.setReasoner(next)` (on the
+incoming reasoner) and after `Agent.restore(...)` (on the live reasoner, after
+catch-up). Any stateful reasoner gets correct clean-slate semantics for free; the
+`BrainJsReasoner` stays opt-out because it has no ephemeral state to clear.
+
+**Architecture:** Single bundled PR. One optional method added to the `Reasoner`
+interface. Two three-line changes to `Agent.ts` (both call sites use
+`reasoner.reset?.()` so the null-safe chain handles opt-out adapters without a
+kernel-side branch). `MistreevousReasoner` and `JsSonReasoner` already have
+working `reset()` methods that match the contract — only JSDoc is added. No
+schema changes. Tests for kernel invocation use a spy reasoner; tests for adapter
+semantics live in each adapter's existing test file.
+
+**Tech Stack:** TypeScript (strict + `exactOptionalPropertyTypes`), vitest, ESM
+with `.js` extensions on relative imports. No new runtime deps.
+
+**Design reference:** See the chat design section approved in the 0.9.4
+brainstorm (Q1(b), Q2(a), Q3(a)). Scope decisions locked there are out of scope
+to revisit here. No separate design doc — v1-comprehensive-plan.md:126–148
+already contains the design; the chat approval layered the three remaining
+decisions on top.
+
+---
+
+## File Structure
+
+### New files
+
+- `tests/unit/agent/Agent-setReasoner-reset.test.ts` — spy-reasoner kernel tests
+  for the `setReasoner` → `reset` invocation.
+- `tests/unit/agent/Agent-restore-reset.test.ts` — spy-reasoner kernel tests for
+  the `restore` → `reset` invocation, verifying reset fires _after_ the catch-up
+  loop.
+- `.changeset/<random>.md` — minor-bump changeset (via `npm run changeset`).
+
+### Modified files
+
+- `src/cognition/reasoning/Reasoner.ts` — add optional `reset?(): void` to the
+  `Reasoner` interface with JSDoc pinning the two call-site contract.
+- `src/agent/Agent.ts` — invoke `reasoner.reset?.()` at the end of `setReasoner`
+  (~line 599) and at the very end of `restore`, after the catch-up loop
+  (~line 740).
+- `src/cognition/adapters/mistreevous/MistreevousReasoner.ts` — add a one-line
+  JSDoc above the existing `reset()` method linking it to the port contract.
+- `src/cognition/adapters/js-son/JsSonReasoner.ts` — same JSDoc addition above
+  the existing `reset()`.
+- `src/cognition/adapters/brainjs/BrainJsReasoner.ts` — add a class-level JSDoc
+  sentence explaining why this adapter does **not** implement `reset()` ("no
+  ephemeral between-tick state; trained network weights are consumer-owned and
+  hydrated via the constructor").
+- `tests/unit/cognition/adapters/mistreevous/MistreevousReasoner.test.ts` — new
+  test exercising BT `RUNNING` → `reset()` → `READY`.
+- `tests/unit/cognition/adapters/js-son/JsSonReasoner.test.ts` — new test
+  exercising mutated beliefs → `reset()` → initial beliefs.
+
+### Deliberately untouched
+
+- `src/cognition/reasoning/UrgencyReasoner.ts` / `NoopReasoner.ts` — stateless;
+  no `reset()` needed (optional-method contract permits opt-out).
+- `src/persistence/AgentSnapshot.ts` — the `beliefs` field stays unused (out of
+  scope for 0.9.4 per Q3(a)).
+
+---
+
+## Task 0: Cut topic branch
+
+**Files:** none (git only).
+
+- [ ] **Step 1: Confirm clean tree on develop.**
+
+Run: `git status && git branch --show-current`
+Expected: `On branch develop`, `nothing to commit, working tree clean`.
+
+- [ ] **Step 2: Pull develop.**
+
+Run: `git pull --ff-only origin develop`
+Expected: `Already up to date.` or a fast-forward.
+
+- [ ] **Step 3: Cut the topic branch.**
+
+Run: `git switch -c feat/reasoner-reset-harmonization`
+Expected: `Switched to a new branch 'feat/reasoner-reset-harmonization'`.
+
+---
+
+## Task 1: Extend the `Reasoner` port
+
+**Files:**
+
+- Modify: `src/cognition/reasoning/Reasoner.ts`
+
+- [ ] **Step 1: Add `reset?(): void` to the interface with contract JSDoc.**
+
+Replace the existing `Reasoner` interface (currently lines 29–32) with:
+
+```ts
+export interface Reasoner {
+  /** Choose an intention this tick, or `null` for idle. */
+  selectIntention(ctx: ReasonerContext): Intention | null;
+
+  /**
+   * Clear ephemeral between-tick state so the next tick starts from a
+   * known-clean baseline. The kernel invokes this at exactly two points:
+   *
+   * 1. Immediately after `Agent.setReasoner(next)` — on the **incoming**
+   *    reasoner. The outgoing reasoner is discarded without a reset call.
+   * 2. At the very end of `Agent.restore(...)`, after the catch-up-tick
+   *    loop — on the **live** reasoner. Resetting post-catch-up means the
+   *    first live post-restore tick starts fresh regardless of the chunk
+   *    size used for catch-up.
+   *
+   * Never called mid-tick. Implementors should clear plan/BT state and
+   * per-tick accumulators. Long-lived architecture — trained network
+   * weights, configured policies, persona biases — MUST be preserved.
+   * Stateless reasoners can omit this method entirely.
+   */
+  reset?(): void;
+}
+```
+
+- [ ] **Step 2: Verify typecheck still passes.**
+
+Run: `npm run typecheck`
+Expected: no errors. All three adapters satisfy the updated interface — the two
+that already have `reset()` match the optional signature; `BrainJsReasoner` is
+permitted to omit.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/cognition/reasoning/Reasoner.ts
+git commit -m "feat(cognition): add optional reset() hook to Reasoner port
+
+Additive-optional port method. No call sites yet — kernel wiring lands
+in the next commits. Mistreevous and js-son adapters already implement
+it; brain.js opts out (stateless).
+
+Refs v1-comprehensive-plan.md:126-148."
+```
+
+---
+
+## Task 2: Wire `setReasoner` → `reset()`
+
+**Files:**
+
+- Create: `tests/unit/agent/Agent-setReasoner-reset.test.ts`
+- Modify: `src/agent/Agent.ts:591–600`
+
+- [ ] **Step 1: Write the failing test.**
+
+Create `tests/unit/agent/Agent-setReasoner-reset.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { Agent } from '../../../src/agent/Agent.js';
+import { ManualClock } from '../../../src/ports/clock/ManualClock.js';
+import { SeededRng } from '../../../src/ports/rng/SeededRng.js';
+import type { Reasoner, ReasonerContext } from '../../../src/cognition/reasoning/Reasoner.js';
+
+function makeSpyReasoner() {
+  return {
+    selectIntention: vi.fn((_ctx: ReasonerContext) => null),
+    reset: vi.fn(() => undefined),
+  } satisfies Required<Reasoner>;
+}
+
+function makeAgent() {
+  return new Agent({
+    id: 'test',
+    clock: new ManualClock(0),
+    rng: new SeededRng(1),
+    // ...minimal deps — mirror the shape used in Agent-setReasoner.test.ts
+  });
+}
+
+describe('Agent.setReasoner → Reasoner.reset', () => {
+  it('invokes reset() on the incoming reasoner exactly once, after assignment', () => {
+    const agent = makeAgent();
+    const incoming = makeSpyReasoner();
+
+    agent.setReasoner(incoming);
+
+    expect(incoming.reset).toHaveBeenCalledTimes(1);
+    expect(incoming.selectIntention).not.toHaveBeenCalled(); // reset precedes selection
+  });
+
+  it('does NOT invoke reset() on the outgoing reasoner', () => {
+    const agent = makeAgent();
+    const outgoing = makeSpyReasoner();
+    const incoming = makeSpyReasoner();
+
+    agent.setReasoner(outgoing);
+    outgoing.reset.mockClear();
+    agent.setReasoner(incoming);
+
+    expect(outgoing.reset).not.toHaveBeenCalled();
+    expect(incoming.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires reset() even when the same reasoner instance is re-set (identity is irrelevant)', () => {
+    const agent = makeAgent();
+    const spy = makeSpyReasoner();
+
+    agent.setReasoner(spy);
+    agent.setReasoner(spy);
+
+    expect(spy.reset).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not throw when the incoming reasoner omits reset()', () => {
+    const agent = makeAgent();
+    const resetless: Reasoner = {
+      selectIntention: () => null,
+    };
+
+    expect(() => agent.setReasoner(resetless)).not.toThrow();
+  });
+});
+```
+
+> **Implementation note:** mirror the exact `makeAgent()` construction from
+> `tests/unit/agent/Agent-setReasoner.test.ts` — the fixture there already
+> encapsulates the minimal-deps boilerplate (species, needs, bus, etc.). Import
+> or copy it rather than re-deriving.
+
+- [ ] **Step 2: Run it; confirm the first test fails.**
+
+Run: `npm test -- Agent-setReasoner-reset`
+Expected: first test fails — `incoming.reset` received 0 calls, expected 1.
+
+- [ ] **Step 3: Wire the reset call in `Agent.setReasoner`.**
+
+Edit `src/agent/Agent.ts:591–600`. After `this.reasoner = reasoner;` (line 599),
+append:
+
+```ts
+reasoner.reset?.();
+```
+
+Update the JSDoc above `setReasoner` (currently roughly lines 580–590) to
+mention reset. Concretely: replace the sentence "Nothing is transferred from the
+outgoing reasoner — adapters that want continuity should persist their own
+state." with "Nothing is transferred from the outgoing reasoner; the incoming
+reasoner's `reset?()` fires synchronously after assignment so the next tick
+starts from a known-clean baseline."
+
+- [ ] **Step 4: Run the test suite.**
+
+Run: `npm test -- Agent-setReasoner-reset`
+Expected: all four tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/agent/Agent.ts tests/unit/agent/Agent-setReasoner-reset.test.ts
+git commit -m "feat(agent): invoke Reasoner.reset() after setReasoner swap
+
+Kernel fires reset?() on the incoming reasoner synchronously, after
+assignment. The outgoing reasoner is discarded without a reset call.
+Identity swaps still fire reset — JSDoc documents this.
+
+Spy-reasoner tests cover: invocation count, outgoing skipped, identity
+swap, reset omission."
+```
+
+---
+
+## Task 3: Wire `Agent.restore` → `reset()` (after catch-up)
+
+**Files:**
+
+- Create: `tests/unit/agent/Agent-restore-reset.test.ts`
+- Modify: `src/agent/Agent.ts:662–741`
+
+- [ ] **Step 1: Write the failing test.**
+
+Create `tests/unit/agent/Agent-restore-reset.test.ts`. Two assertions:
+
+1. `restore()` invokes `this.reasoner.reset?.()` exactly once.
+2. Reset fires **after** the catch-up-tick loop — assert the spy's `reset` call
+   order is _after_ the spy's `selectIntention` calls (which fire during
+   catch-up ticks).
+
+Sketch:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { Agent } from '../../../src/agent/Agent.js';
+// ...same imports as Task 2
+
+describe('Agent.restore → Reasoner.reset', () => {
+  it('invokes reset() on the live reasoner exactly once, after catch-up ticks', async () => {
+    // Build an agent, snapshot it with a deliberate stale-ness window so
+    // restore's catch-up loop runs (e.g. clock advanced by a second before
+    // restore is called).
+    const { agent, snapshot } = await buildSnapshotWithCatchUpWindow();
+
+    const spy = {
+      selectIntention: vi.fn(() => null),
+      reset: vi.fn(() => undefined),
+    };
+    const callLog: string[] = [];
+    spy.selectIntention.mockImplementation(() => {
+      callLog.push('select');
+      return null;
+    });
+    spy.reset.mockImplementation(() => {
+      callLog.push('reset');
+    });
+
+    agent.setReasoner(spy);
+    spy.reset.mockClear(); // ignore the setReasoner-triggered reset
+    callLog.length = 0;
+
+    await agent.restore(snapshot);
+
+    expect(spy.reset).toHaveBeenCalledTimes(1);
+    expect(callLog.at(-1)).toBe('reset'); // reset is the LAST call, after catch-up selects
+  });
+
+  it('does not throw when the live reasoner omits reset()', async () => {
+    const { agent, snapshot } = await buildSnapshotWithCatchUpWindow();
+    const resetless: Reasoner = { selectIntention: () => null };
+    agent.setReasoner(resetless);
+
+    await expect(agent.restore(snapshot)).resolves.not.toThrow();
+  });
+});
+```
+
+> **Implementation note:** `buildSnapshotWithCatchUpWindow()` should snapshot at
+> `t=0`, advance the `ManualClock` by e.g. 2 seconds, then return both the agent
+> and the snapshot. The restore call will then invoke catch-up `tick()`s, giving
+> the spy's `selectIntention` a chance to fire before the final reset. If
+> building this helper pushes past ~10 lines, mirror
+> `Agent-persistence.test.ts`'s fixture instead.
+
+- [ ] **Step 2: Run it; confirm failure.**
+
+Run: `npm test -- Agent-restore-reset`
+Expected: first test fails — `spy.reset` received 0 calls.
+
+- [ ] **Step 3: Wire the reset call in `Agent.restore`.**
+
+Edit `src/agent/Agent.ts`. At the very end of the `restore()` method — after the
+`await runCatchUp(...)` call at line 730–739, before the closing `}` at line 741
+— append:
+
+```ts
+this.reasoner.reset?.();
+```
+
+Update the JSDoc above `restore()` to add (as a final paragraph): "After all
+subsystem rehydration and catch-up ticks complete, `this.reasoner.reset?()` is
+invoked so the first live post-restore tick starts from a known-clean baseline.
+Reset fires _after_ catch-up, not before — catch-up ticks are synthetic and
+their residual reasoner state (mid-sequence BT nodes, plan accumulators) is
+intentionally discarded."
+
+- [ ] **Step 4: Run the test suite.**
+
+Run: `npm test -- Agent-restore-reset`
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/agent/Agent.ts tests/unit/agent/Agent-restore-reset.test.ts
+git commit -m "feat(agent): invoke Reasoner.reset() at end of restore
+
+Kernel fires reset?() on the live reasoner as the final step of
+Agent.restore(), after the catch-up-tick loop. Catch-up ticks are
+synthetic; their residual reasoner state is intentionally discarded so
+the first live post-restore tick starts fresh regardless of chunk size.
+
+Spy-reasoner tests cover invocation count, ordering after catch-up, and
+reset omission (no throw)."
+```
+
+---
+
+## Task 4: `MistreevousReasoner` — add JSDoc + reset behavior test
+
+**Files:**
+
+- Modify: `src/cognition/adapters/mistreevous/MistreevousReasoner.ts:147–150`
+- Modify: `tests/unit/cognition/adapters/mistreevous/MistreevousReasoner.test.ts`
+
+- [ ] **Step 1: Write the failing-if-regressed test.**
+
+In the existing test file, add a new `describe('reset()', () => { ... })` block
+at the bottom. Construct an adapter whose tree has a `Sequence` with a
+deliberately long-running node; step once so the tree is `RUNNING`; call
+`reset()`; assert the tree is back at `READY` (e.g. by asserting the next
+`selectIntention` call emits the tree's _first-child_ intention, not the
+resumed node).
+
+The exact BT definition should use fixtures from the existing tests in that file
+so we don't invent a third scenario.
+
+- [ ] **Step 2: Run the test.**
+
+Run: `npm test -- MistreevousReasoner`
+Expected: the new test passes immediately (no implementation change — adapter's
+existing `reset()` already matches the contract).
+
+- [ ] **Step 3: Add JSDoc above the existing `reset()`.**
+
+Replace the existing `reset()` method body (lines 147–150 of
+`MistreevousReasoner.ts`) with:
+
+```ts
+  /**
+   * Returns the BT to `READY`. Any `RUNNING` node state — including
+   * mid-sequence continuations — is cleared. Implements the `Reasoner.reset`
+   * port contract (see `src/cognition/reasoning/Reasoner.ts`).
+   */
+  reset(): void {
+    this.tree.reset();
+  }
+```
+
+- [ ] **Step 4: Run the full test suite.**
+
+Run: `npm test`
+Expected: all tests still pass (no behavior change; JSDoc only plus new test).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/cognition/adapters/mistreevous/MistreevousReasoner.ts tests/unit/cognition/adapters/mistreevous/MistreevousReasoner.test.ts
+git commit -m "test(cognition): verify MistreevousReasoner.reset clears BT state
+
+Existing reset() already matched the port contract — adds JSDoc pointing
+at the port + a unit test asserting BT RUNNING → reset → READY. No
+behavior change."
+```
+
+---
+
+## Task 5: `JsSonReasoner` — add JSDoc + reset behavior test
+
+**Files:**
+
+- Modify: `src/cognition/adapters/js-son/JsSonReasoner.ts:182–184`
+- Modify: `tests/unit/cognition/adapters/js-son/JsSonReasoner.test.ts`
+
+- [ ] **Step 1: Write the failing-if-regressed test.**
+
+In the existing test file, add a new `describe('reset()', () => { ... })` block
+at the bottom. Construct an adapter from initial beliefs; step `selectIntention`
+once (which internally calls `agent.next()` and mutates beliefs); capture
+`adapter.getBeliefs()`; call `reset()`; assert `adapter.getBeliefs()` is deep
+equal to the initial beliefs object.
+
+- [ ] **Step 2: Run the test.**
+
+Run: `npm test -- JsSonReasoner`
+Expected: passes immediately (existing `reset()` already rebuilds the agent from
+init).
+
+- [ ] **Step 3: Add JSDoc above the existing `reset()`.**
+
+Replace lines 182–184 of `JsSonReasoner.ts` with:
+
+```ts
+  /**
+   * Rebuilds the wrapped js-son agent from the constructor's initial options:
+   * beliefs revert to the initial map; desires and plans are reinstalled from
+   * the saved descriptors. Implements the `Reasoner.reset` port contract
+   * (see `src/cognition/reasoning/Reasoner.ts`).
+   */
+  reset(): void {
+    this.agent = this.buildAgent();
+  }
+```
+
+- [ ] **Step 4: Run the full test suite.**
+
+Run: `npm test`
+Expected: all tests still pass.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add src/cognition/adapters/js-son/JsSonReasoner.ts tests/unit/cognition/adapters/js-son/JsSonReasoner.test.ts
+git commit -m "test(cognition): verify JsSonReasoner.reset restores initial beliefs
+
+Existing reset() already matched the port contract — adds JSDoc pointing
+at the port + a unit test asserting mutated beliefs → reset → initial
+beliefs. No behavior change."
+```
+
+---
+
+## Task 6: `BrainJsReasoner` — class-level JSDoc note
+
+**Files:**
+
+- Modify: `src/cognition/adapters/brainjs/BrainJsReasoner.ts`
+
+- [ ] **Step 1: Add the JSDoc sentence.**
+
+Above the `BrainJsReasoner` class declaration, extend the existing class JSDoc
+(or add one if absent) with a dedicated paragraph:
+
+```
+ * This adapter does not implement `Reasoner.reset()`. It has no
+ * ephemeral between-tick state: the wrapped `NeuralNetwork` is used in
+ * forward-pass-only mode and its weights are consumer-owned (hydrated
+ * via the constructor and preserved for the adapter's lifetime). The
+ * kernel's null-safe `reset?.()` call handles the absence without
+ * requiring a no-op here.
+```
+
+- [ ] **Step 2: Verify typecheck still passes.**
+
+Run: `npm run typecheck`
+Expected: no errors. (No code change; JSDoc only.)
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/cognition/adapters/brainjs/BrainJsReasoner.ts
+git commit -m "docs(cognition): document BrainJsReasoner's reset opt-out
+
+Adds a class-level JSDoc paragraph explaining why this adapter does not
+implement Reasoner.reset(): stateless at selection time, consumer-owned
+weights. The kernel's optional-chain reset?.() handles the absence."
+```
+
+---
+
+## Task 7: Verify, changeset, PR
+
+**Files:**
+
+- Create: `.changeset/<random>.md`
+
+- [ ] **Step 1: Full pre-PR gate.**
+
+Run: `npm run verify`
+Expected: `format:check`, `lint`, `typecheck`, `test`, `build` all green. Fail
+fast: if any stage fails, fix before continuing.
+
+- [ ] **Step 2: Create the changeset.**
+
+Run: `npm run changeset`
+Or use the `new-changeset` skill.
+
+Content:
+
+```md
+---
+'agentonomous': minor
+---
+
+**feat(cognition):** `Reasoner` port now exposes an optional `reset()` hook.
+The `Agent` kernel invokes it at two fixed call sites:
+
+- Synchronously after `Agent.setReasoner(next)`, on the **incoming** reasoner.
+- At the very end of `Agent.restore(...)`, after the catch-up-tick loop, on the
+  **live** reasoner.
+
+`MistreevousReasoner` and `JsSonReasoner` already implement `reset()` — they now
+formally satisfy the port contract and carry JSDoc linking to it.
+`BrainJsReasoner` deliberately opts out: it has no ephemeral between-tick
+state, and the kernel's null-safe `reset?.()` call handles the absence without
+requiring a no-op.
+
+No schema changes. No breaking changes. Stateless reasoners may continue to
+omit `reset()`.
+```
+
+- [ ] **Step 3: Commit the changeset.**
+
+```bash
+git add .changeset/*.md
+git commit -m "chore(changeset): 0.9.4 Reasoner.reset harmonization"
+```
+
+- [ ] **Step 4: Push and open the PR.**
+
+```bash
+git push -u origin feat/reasoner-reset-harmonization
+gh pr create --base develop --title "feat(cognition): 0.9.4 Reasoner.reset() harmonization" --body "$(cat <<'EOF'
+## Summary
+- Lifts `reset()` to the `Reasoner` port as an optional method.
+- `Agent.setReasoner(next)` invokes `next.reset?.()` synchronously.
+- `Agent.restore(...)` invokes `this.reasoner.reset?.()` at the very end, after the catch-up-tick loop — so live post-restore ticks start fresh regardless of catch-up chunk size.
+- `MistreevousReasoner` + `JsSonReasoner` already had matching `reset()`; JSDoc now links them to the port contract + new unit tests pin the semantics.
+- `BrainJsReasoner` opts out (stateless; consumer-owned weights). Class JSDoc documents the rationale.
+
+Unblocks 0.9.3 (brain.js training persistence flow).
+
+## Test plan
+- [ ] `npm run verify` green locally (format, lint, typecheck, test, build).
+- [ ] Spy-reasoner kernel tests: `Agent-setReasoner-reset`, `Agent-restore-reset`.
+- [ ] Adapter reset behavior tests: `MistreevousReasoner`, `JsSonReasoner`.
+- [ ] No schema changes — existing persistence tests still green.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: After merge — local cleanup.**
+
+```bash
+git switch develop
+git pull origin develop
+git branch -d feat/reasoner-reset-harmonization
+git fetch --prune origin
+```
+
+Also delete the remote topic branch via the merged-PR UI if the repo setting
+didn't auto-delete.
+
+---
+
+## Risks & escape hatches
+
+| Risk                                                                                                            | Mitigation                                                                                                                      |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Identity-swap surprise — consumer calls `setReasoner(currentReasoner)` expecting a no-op and gets a reset       | JSDoc on both `setReasoner` and the port's `reset?()` documents this. Test 3 in Task 2 pins the behavior.                       |
+| Restore ordering — reset wipes reasoner state from catch-up ticks                                               | Intentional. JSDoc on `restore()` documents that catch-up tick state is synthetic and discarded.                                |
+| A future subsystem publishes events during restore that the reasoner consumes, and reset wipes that consumption | No current subsystem does this. If one is added, the subsystem's JSDoc should call out the ordering constraint. Flag in review. |
+| `buildSnapshotWithCatchUpWindow()` helper in Task 3 grows beyond a small fixture                                | If it crosses ~15 lines, import `Agent-persistence.test.ts`'s existing fixture instead of writing a new one.                    |
+
+## Out of scope (hard — if any of these appears during execution, stop and defer)
+
+- Wiring `AgentSnapshot.beliefs` (per Q3(a) — 0.9.3 doesn't need it either).
+- Making `reset()` required on the port (deferred to 1.1 kernel modularization).
+- Adding `reset()` to `UrgencyReasoner` / `NoopReasoner` (no state to clear).
+- Reasoner-level snapshot/restore hooks.
+- Any change to `setReasoner`'s existing type-validation behavior.

--- a/.claude/plans/v1-comprehensive-plan.md
+++ b/.claude/plans/v1-comprehensive-plan.md
@@ -10,7 +10,7 @@
 >
 > Revised 2026-04-20: 0.9.1, 0.9.2, and 0.9.6 marked shipped. 0.9.5
 > repurposed from "Excalibur subpath rename" (cancelled — `integrations/
-> <vendor>/` is the intentional convention for engine/rendering peers,
+<vendor>/` is the intentional convention for engine/rendering peers,
 > distinct from `<category>/adapters/<vendor>/` used for cognition
 > peers) to "Docs polish pass (alignment only)".
 
@@ -34,13 +34,13 @@ showcase, and concrete LLM providers are **post-v1** (1.1+ / Phase B).
 
 Status against the MVP demo spec:
 
-| Chapter              | Spec requirement                                    | Actual state                                                                                                                                   | Remaining                                     |
-| -------------------- | --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| A — Living agent     | Needs decay, HUD, autonomy observable               | ✅ Done. Decay calibrated (`BASE_TIME_SCALE = 10`). HUD renders needs + modifiers + interactions.                                              | —                                             |
-| B — Decision Trace   | Trace panel with needs, candidates, selected action | ✅ Done. `traceView.ts` with progressive disclosure.                                                                                           | Polish only                                   |
-| C — Cognition switch | Dropdown for heuristic / BT / BDI / learning        | ✅ Done. `setReasoner` shipped in P4 (`c58d5f7`); switcher + BT / BDI / brain.js modes shipped in PR #46 + polish #47–#50.                     | —                                             |
-| D — JSON config      | Read/edit/apply species JSON                        | ✅ Done. `speciesConfig.ts` with `applyOverride()`.                                                                                            | Polish only                                   |
-| E — Determinism      | Seed display, replay, new-seed                      | ✅ Done. `seed.ts` panel mounted; D2 parallel-agent determinism integration test shipped (PR #23).                                            | brain.js training persistence (0.9.3)         |
+| Chapter              | Spec requirement                                    | Actual state                                                                                                               | Remaining                             |
+| -------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| A — Living agent     | Needs decay, HUD, autonomy observable               | ✅ Done. Decay calibrated (`BASE_TIME_SCALE = 10`). HUD renders needs + modifiers + interactions.                          | —                                     |
+| B — Decision Trace   | Trace panel with needs, candidates, selected action | ✅ Done. `traceView.ts` with progressive disclosure.                                                                       | Polish only                           |
+| C — Cognition switch | Dropdown for heuristic / BT / BDI / learning        | ✅ Done. `setReasoner` shipped in P4 (`c58d5f7`); switcher + BT / BDI / brain.js modes shipped in PR #46 + polish #47–#50. | —                                     |
+| D — JSON config      | Read/edit/apply species JSON                        | ✅ Done. `speciesConfig.ts` with `applyOverride()`.                                                                        | Polish only                           |
+| E — Determinism      | Seed display, replay, new-seed                      | ✅ Done. `seed.ts` panel mounted; D2 parallel-agent determinism integration test shipped (PR #23).                         | brain.js training persistence (0.9.3) |
 
 Carried forward from the post-P4 implementation review:
 
@@ -406,21 +406,21 @@ Captured so nothing gets lost. Not on the critical path.
 
 ## Sequencing at a glance
 
-| Phase | Step                                           | Depends on    | PR scope                            |
-| ----- | ---------------------------------------------- | ------------- | ----------------------------------- |
-| 0.9.0 | 0.9.1 `AgentTicked` event                      | —             | 1 PR (minor bump) — shipped         |
-| 0.9.0 | 0.9.2 `setReasoner` + dropdown                 | 0.9.1         | 2 PRs (library + demo) — shipped    |
-| 0.9.0 | 0.9.4 `Reasoner.reset()` harmonization         | 0.9.2         | 1 bundled PR or 4 small             |
-| 0.9.0 | 0.9.3 brain.js persistence                     | 0.9.4         | 1 demo PR                           |
-| 0.9.0 | 0.9.5 Docs polish pass (alignment only)        | 0.9.3         | 1 docs PR                           |
-| 0.9.0 | 0.9.6 D-items                                  | —             | shipped in-flight (PRs #17–#31)     |
-| 0.9.0 | 0.9.7 Soak + DoD                               | all above     | 1 PR                                |
-| 0.9.0 | Promote + tag                                  | all above     | —                                   |
-| 1.0.0 | 1.0.1 `_internalPublish`/`_internalDie` rename | 0.9.0 shipped | 1 PR (major)                        |
-| 1.0.0 | 1.0.2 `LlmProviderPort`                        | 1.0.1         | 1 PR                                |
-| 1.0.0 | 1.0.3 Narrow surface                           | 1.0.2         | 1 PR                                |
-| 1.0.0 | 1.0.4 API/JSDoc audit                          | 1.0.3         | 1 PR                                |
-| 1.0.0 | 1.0.5 Changeset + publish                      | 1.0.4         | 1 PR                                |
+| Phase | Step                                           | Depends on    | PR scope                         |
+| ----- | ---------------------------------------------- | ------------- | -------------------------------- |
+| 0.9.0 | 0.9.1 `AgentTicked` event                      | —             | 1 PR (minor bump) — shipped      |
+| 0.9.0 | 0.9.2 `setReasoner` + dropdown                 | 0.9.1         | 2 PRs (library + demo) — shipped |
+| 0.9.0 | 0.9.4 `Reasoner.reset()` harmonization         | 0.9.2         | 1 bundled PR or 4 small          |
+| 0.9.0 | 0.9.3 brain.js persistence                     | 0.9.4         | 1 demo PR                        |
+| 0.9.0 | 0.9.5 Docs polish pass (alignment only)        | 0.9.3         | 1 docs PR                        |
+| 0.9.0 | 0.9.6 D-items                                  | —             | shipped in-flight (PRs #17–#31)  |
+| 0.9.0 | 0.9.7 Soak + DoD                               | all above     | 1 PR                             |
+| 0.9.0 | Promote + tag                                  | all above     | —                                |
+| 1.0.0 | 1.0.1 `_internalPublish`/`_internalDie` rename | 0.9.0 shipped | 1 PR (major)                     |
+| 1.0.0 | 1.0.2 `LlmProviderPort`                        | 1.0.1         | 1 PR                             |
+| 1.0.0 | 1.0.3 Narrow surface                           | 1.0.2         | 1 PR                             |
+| 1.0.0 | 1.0.4 API/JSDoc audit                          | 1.0.3         | 1 PR                             |
+| 1.0.0 | 1.0.5 Changeset + publish                      | 1.0.4         | 1 PR                             |
 
 **Estimated sessions:** 0.9.0 in **~3 sessions** (9–11 PRs, with
 bundling options noted below). 1.0.0 in **~2 sessions** (5 PRs) after.
@@ -507,20 +507,20 @@ Plan-document edits may be committed directly to `develop` (see
 memory: `feedback_plan_crafting_on_develop`). Implementation PRs still
 follow the standard topic-branch flow defined in `CLAUDE.md`.
 
-| #   | Step  | Plan file                               | PRs inside        | Status                                                         |
-| --- | ----- | --------------------------------------- | ----------------- | -------------------------------------------------------------- |
-| 1   | 0.9.1 | `0.9.1-agent-ticked-event.md`           | library + demo    | Shipped — library #44, demo #45                                |
-| 2   | 0.9.2 | `0.9.2-set-reasoner-and-switcher.md`    | library + demo    | Shipped — library c58d5f7 (in P4), demo #46 + polish #47–#50   |
-| 3   | 0.9.4 | `0.9.4-reasoner-reset-harmonization.md` | 1 bundled library | Not drafted — **next up**                                      |
-| 4   | 0.9.3 | `0.9.3-brainjs-persistence.md`          | demo              | Not drafted — follows 0.9.4                                    |
-| 5   | 0.9.5 | `0.9.5-docs-polish.md`                  | 1 docs            | Not drafted — follows 0.9.3; alignment-only scope              |
+| #   | Step  | Plan file                               | PRs inside        | Status                                                             |
+| --- | ----- | --------------------------------------- | ----------------- | ------------------------------------------------------------------ |
+| 1   | 0.9.1 | `0.9.1-agent-ticked-event.md`           | library + demo    | Shipped — library #44, demo #45                                    |
+| 2   | 0.9.2 | `0.9.2-set-reasoner-and-switcher.md`    | library + demo    | Shipped — library c58d5f7 (in P4), demo #46 + polish #47–#50       |
+| 3   | 0.9.4 | `0.9.4-reasoner-reset-harmonization.md` | 1 bundled library | Not drafted — **next up**                                          |
+| 4   | 0.9.3 | `0.9.3-brainjs-persistence.md`          | demo              | Not drafted — follows 0.9.4                                        |
+| 5   | 0.9.5 | `0.9.5-docs-polish.md`                  | 1 docs            | Not drafted — follows 0.9.3; alignment-only scope                  |
 | 6   | 0.9.6 | —                                       | —                 | Shipped in-flight — D1 #21, D2 #23, D3 #24, D5 #31, D6 #17, D7 #18 |
-| 7   | 0.9.7 | `0.9.7-soak-and-promote.md`             | 1 + release       | Not drafted                                                    |
-| 8   | 1.0.1 | `1.0.1-internal-rename.md`              | 1 major           | Not drafted                                                    |
-| 9   | 1.0.2 | `1.0.2-llm-provider-port.md`            | 1                 | Not drafted                                                    |
-| 10  | 1.0.3 | `1.0.3-narrow-public-surface.md`        | 1                 | Not drafted                                                    |
-| 11  | 1.0.4 | `1.0.4-api-jsdoc-audit.md`              | 1                 | Not drafted                                                    |
-| 12  | 1.0.5 | `1.0.5-changeset-and-publish.md`        | 1 + release       | Not drafted                                                    |
+| 7   | 0.9.7 | `0.9.7-soak-and-promote.md`             | 1 + release       | Not drafted                                                        |
+| 8   | 1.0.1 | `1.0.1-internal-rename.md`              | 1 major           | Not drafted                                                        |
+| 9   | 1.0.2 | `1.0.2-llm-provider-port.md`            | 1                 | Not drafted                                                        |
+| 10  | 1.0.3 | `1.0.3-narrow-public-surface.md`        | 1                 | Not drafted                                                        |
+| 11  | 1.0.4 | `1.0.4-api-jsdoc-audit.md`              | 1                 | Not drafted                                                        |
+| 12  | 1.0.5 | `1.0.5-changeset-and-publish.md`        | 1 + release       | Not drafted                                                        |
 
 **Update this table** as plans are drafted (`Drafted`), enter execution
 (`In progress`), or ship (`Shipped — <PR link or tag>`). The table is


### PR DESCRIPTION
## Summary
- Adds `.claude/plans/0.9.4-reasoner-reset-harmonization.md` — lift `reset()` to the `Reasoner` port as an optional method; kernel invokes it after `Agent.setReasoner` (on incoming) and at the very end of `Agent.restore` after catch-up (on live). Mistreevous + js-son already match; brainjs opts out (stateless).
- Adds `.claude/plans/0.9.3-brainjs-training-persistence.md` — demo-side Train button inside `#cognition-switcher` persists a trained brain.js network to `agentonomous/<agentId>/brainjs-network` alongside the agent snapshot, rehydrates on reload, and wires the network's scalar output into `interpret()` via an urgency gate.
- Both plans lock in brainstorm decisions (Q1–Q3 for 0.9.4; Q1–Q5 for 0.9.3) and carry explicit out-of-scope lists so implementation PRs stay inside the approved envelope.
- No code changes. Execution order will be 0.9.4 first, then 0.9.3 (depends on 0.9.4 being on `develop`).

## Test plan
- [ ] Plans render correctly on GitHub (tables, code blocks, `- [ ]` checkboxes).
- [ ] File paths and line-number citations in both plans point at real current code (`src/cognition/reasoning/Reasoner.ts`, `src/agent/Agent.ts:591–741`, `examples/nurture-pet/src/cognition/learning.ts`, etc.).
- [ ] Each plan's "Out of scope" list is aligned with the brainstorm decisions referenced in the "Design reference" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)