### PR TITLE
chore: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Enforce LF line endings for all text files.
+#
+# Why: .editorconfig and .prettierrc both request LF, but without this
+# file Git's per-user `core.autocrlf` setting can convert to CRLF on
+# checkout on Windows. That conversion is invisible in `git diff` (both
+# sides get normalized before comparison) but trips `prettier --check`
+# and creates phantom "248 files changed" status noise after a
+# `prettier --write .` run.
+#
+# `text=auto eol=lf` tells Git to (a) detect text vs binary, (b) store
+# text with LF, and (c) check text out with LF on every platform —
+# regardless of `core.autocrlf`.
+* text=auto eol=lf


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` with `* text=auto eol=lf`.
- `git add --renormalize .` touched zero files — repo's existing index is already LF-clean.
- Prevents the "hundreds of files changed with no visible diff" symptom that appears on Windows when `core.autocrlf=true` interacts with `prettier --write`.

## Why
`.editorconfig` and `.prettierrc` both request LF. On Windows, per-user `core.autocrlf=true` checks files out as CRLF anyway. `prettier --write .` then normalizes them back to LF, which:
- Makes `git status` report 248 modified files,
- Makes `git diff` show nothing (both sides get normalized before comparison),
- And occasionally lets a real prettier content issue slip past local checks into CI.

`.gitattributes` tells Git to store and check out text as LF regardless of per-user config — so the working tree matches what CI (Linux) sees.

## Companion local step (not in this PR)
Windows contributors should also run once:

\`\`\`bash
git config --global core.autocrlf false
git config --global core.eol lf
\`\`\`

This doesn't block the PR — `.gitattributes` already overrides `core.autocrlf` — but it stops Git from warning `"LF will be replaced by CRLF the next time Git touches it"` on every commit.

## Test plan
- [ ] CI format:check passes (no content changes, just new file).
- [ ] After merge, a Windows contributor pulling develop and running `prettier --write .` sees zero modified files (verified mentally; not automated here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)