### PR TITLE
feat(cognition): 0.9.4 Reasoner.reset() harmonization

### DIFF
--- a/.changeset/reasoner-reset-harmonization.md
+++ b/.changeset/reasoner-reset-harmonization.md
@@ -1,0 +1,19 @@
+---
+'agentonomous': minor
+---
+
+**feat(cognition):** `Reasoner` port now exposes an optional `reset()` hook.
+The `Agent` kernel invokes it at two fixed call sites:
+
+- Synchronously after `Agent.setReasoner(next)`, on the **incoming** reasoner.
+- At the very end of `Agent.restore(...)`, after the catch-up-tick loop, on the
+  **live** reasoner.
+
+`MistreevousReasoner` and `JsSonReasoner` already implement `reset()` — they now
+formally satisfy the port contract and carry JSDoc linking to it.
+`BrainJsReasoner` deliberately opts out: it has no ephemeral between-tick
+state, and the kernel's null-safe `reset?.()` call handles the absence without
+requiring a no-op.
+
+No schema changes. No breaking changes. Stateless reasoners may continue to
+omit `reset()`.

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -599,6 +599,12 @@ export class Agent {
     ) {
       throw new TypeError('setReasoner: expected a Reasoner with a selectIntention method.');
     }
+    // `reset` is optional, but when present it MUST be callable. Validating
+    // here fails fast at swap-time rather than mid-restore (where a thrown
+    // TypeError would leave the agent in a partially-restored state).
+    if (reasoner.reset !== undefined && typeof reasoner.reset !== 'function') {
+      throw new TypeError('setReasoner: reasoner.reset must be a function when present.');
+    }
     this.reasoner = reasoner;
     reasoner.reset?.();
   }

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -662,6 +662,13 @@ export class Agent {
    *
    * If `opts.catchUp` is set, the agent sub-steps forward from
    * `snapshot.snapshotAt` to `clock.now()` using `runCatchUp`.
+   *
+   * After all subsystem rehydration and catch-up ticks complete,
+   * `this.reasoner.reset?.()` is invoked so the first live post-restore
+   * tick starts from a known-clean baseline. Reset fires _after_
+   * catch-up, not before — catch-up ticks are synthetic and their
+   * residual reasoner state (mid-sequence BT nodes, plan accumulators)
+   * is intentionally discarded.
    */
   async restore(
     snapshot: AgentSnapshot,
@@ -742,6 +749,8 @@ export class Agent {
         chunkOpts,
       );
     }
+
+    this.reasoner.reset?.();
   }
 
   /**

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -582,8 +582,11 @@ export class Agent {
    * driving the tick loop from outside the agent (UI handler, framework
    * `onPreUpdate`) see this as "applies from the next tick"; a swap
    * issued from a Stage-1 reactive handler is used within the same
-   * tick. Nothing is transferred from the outgoing reasoner — adapters
-   * that want continuity should persist their own state.
+   * tick. Nothing is transferred from the outgoing reasoner; the
+   * incoming reasoner's `reset?()` fires synchronously after assignment
+   * so the next tick starts from a known-clean baseline. Identity swaps
+   * (re-setting the current reasoner) still fire reset — the kernel
+   * treats every call as a fresh assignment.
    *
    * Throws `TypeError` if `reasoner` is null / undefined / lacks
    * `selectIntention`.
@@ -597,6 +600,7 @@ export class Agent {
       throw new TypeError('setReasoner: expected a Reasoner with a selectIntention method.');
     }
     this.reasoner = reasoner;
+    reasoner.reset?.();
   }
 
   /** Current cognition reasoner. */

--- a/src/cognition/adapters/brainjs/BrainJsReasoner.ts
+++ b/src/cognition/adapters/brainjs/BrainJsReasoner.ts
@@ -75,6 +75,13 @@ export interface BrainJsReasonerOptions<
  * `.train()` consults `Math.random` for weight initialisation and SGD
  * shuffling. Train offline, serialise with `.toJSON()`, and rehydrate
  * at construction time via `new NeuralNetwork().fromJSON(saved)`.
+ *
+ * This adapter does not implement `Reasoner.reset()`. It has no
+ * ephemeral between-tick state: the wrapped `NeuralNetwork` is used in
+ * forward-pass-only mode and its weights are consumer-owned (hydrated
+ * via the constructor and preserved for the adapter's lifetime). The
+ * kernel's null-safe `reset?.()` call handles the absence without
+ * requiring a no-op here.
  */
 export class BrainJsReasoner<
   In extends BrainJsNetworkData = BrainJsNetworkData,

--- a/src/cognition/adapters/js-son/JsSonReasoner.ts
+++ b/src/cognition/adapters/js-son/JsSonReasoner.ts
@@ -175,9 +175,11 @@ export class JsSonReasoner implements Reasoner {
   }
 
   /**
-   * Rebuild the underlying js-son `Agent` from the original options.
-   * Use after major state shifts — js-son agents are stateful (beliefs
-   * accumulate across `next()` calls) so there's no built-in "rewind".
+   * Rebuilds the wrapped js-son agent from the constructor's initial
+   * options: beliefs revert to the initial map; desires and plans are
+   * reinstalled from the saved descriptors. Implements the
+   * `Reasoner.reset` port contract (see
+   * `src/cognition/reasoning/Reasoner.ts`).
    */
   reset(): void {
     this.agent = this.buildAgent();

--- a/src/cognition/adapters/mistreevous/MistreevousReasoner.ts
+++ b/src/cognition/adapters/mistreevous/MistreevousReasoner.ts
@@ -144,7 +144,11 @@ export class MistreevousReasoner implements Reasoner {
     return this.selected;
   }
 
-  /** Reset the underlying tree to READY. Use after major state shifts. */
+  /**
+   * Returns the BT to `READY`. Any `RUNNING` node state — including
+   * mid-sequence continuations — is cleared. Implements the `Reasoner.reset`
+   * port contract (see `src/cognition/reasoning/Reasoner.ts`).
+   */
   reset(): void {
     this.tree.reset();
   }

--- a/src/cognition/reasoning/Reasoner.ts
+++ b/src/cognition/reasoning/Reasoner.ts
@@ -29,4 +29,22 @@ export interface ReasonerContext {
 export interface Reasoner {
   /** Choose an intention this tick, or `null` for idle. */
   selectIntention(ctx: ReasonerContext): Intention | null;
+
+  /**
+   * Clear ephemeral between-tick state so the next tick starts from a
+   * known-clean baseline. The kernel invokes this at exactly two points:
+   *
+   * 1. Immediately after `Agent.setReasoner(next)` — on the **incoming**
+   *    reasoner. The outgoing reasoner is discarded without a reset call.
+   * 2. At the very end of `Agent.restore(...)`, after the catch-up-tick
+   *    loop — on the **live** reasoner. Resetting post-catch-up means the
+   *    first live post-restore tick starts fresh regardless of the chunk
+   *    size used for catch-up.
+   *
+   * Never called mid-tick. Implementors should clear plan/BT state and
+   * per-tick accumulators. Long-lived architecture — trained network
+   * weights, configured policies, persona biases — MUST be preserved.
+   * Stateless reasoners can omit this method entirely.
+   */
+  reset?(): void;
 }

--- a/tests/unit/agent/Agent-restore-reset.test.ts
+++ b/tests/unit/agent/Agent-restore-reset.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Agent, type AgentDependencies } from '../../../src/agent/Agent.js';
+import type { AgentIdentity } from '../../../src/agent/AgentIdentity.js';
+import type { AgentSnapshot } from '../../../src/persistence/AgentSnapshot.js';
+import type { Reasoner } from '../../../src/cognition/reasoning/Reasoner.js';
+import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
+import { ManualClock } from '../../../src/ports/ManualClock.js';
+import { SeededRng } from '../../../src/ports/SeededRng.js';
+
+function baseDeps(overrides: Partial<AgentDependencies> = {}): AgentDependencies {
+  const identity: AgentIdentity = {
+    id: 'whiskers',
+    name: 'Whiskers',
+    version: '0.0.0',
+    role: 'npc',
+    species: 'cat',
+  };
+  return {
+    identity,
+    eventBus: new InMemoryEventBus(),
+    clock: new ManualClock(1_000),
+    rng: new SeededRng('seed'),
+    ...overrides,
+  };
+}
+
+/**
+ * Build an agent + snapshot pair whose restore() will run catch-up ticks:
+ * snapshot is taken at clock t=1000, then the clock advances 2 seconds so
+ * restore's catch-up loop has work to do.
+ */
+function buildSnapshotWithCatchUpWindow(): { agent: Agent; snapshot: AgentSnapshot } {
+  const clock = new ManualClock(1_000);
+  const agent = new Agent(baseDeps({ clock }));
+  const snapshot = agent.snapshot();
+  clock.advance(2_000);
+  return { agent, snapshot };
+}
+
+describe('Agent.restore → Reasoner.reset', () => {
+  it('invokes reset() on the live reasoner exactly once, after catch-up ticks', async () => {
+    const { agent, snapshot } = buildSnapshotWithCatchUpWindow();
+
+    const callLog: string[] = [];
+    const spy = {
+      selectIntention: vi.fn(() => {
+        callLog.push('select');
+        return null;
+      }),
+      reset: vi.fn(() => {
+        callLog.push('reset');
+      }),
+    } satisfies Required<Reasoner>;
+
+    agent.setReasoner(spy);
+    // setReasoner itself fires reset — discard that call before measuring restore.
+    spy.reset.mockClear();
+    callLog.length = 0;
+
+    await agent.restore(snapshot, { catchUp: true });
+
+    expect(spy.reset).toHaveBeenCalledTimes(1);
+    expect(spy.selectIntention).toHaveBeenCalled();
+    expect(callLog.at(-1)).toBe('reset');
+  });
+
+  it('does not throw when the live reasoner omits reset()', async () => {
+    const { agent, snapshot } = buildSnapshotWithCatchUpWindow();
+    const resetless: Reasoner = { selectIntention: () => null };
+    agent.setReasoner(resetless);
+
+    await expect(agent.restore(snapshot, { catchUp: true })).resolves.not.toThrow();
+  });
+});

--- a/tests/unit/agent/Agent-setReasoner-reset.test.ts
+++ b/tests/unit/agent/Agent-setReasoner-reset.test.ts
@@ -63,4 +63,18 @@ describe('Agent.setReasoner → Reasoner.reset', () => {
 
     expect(() => agent.setReasoner(resetless)).not.toThrow();
   });
+
+  it('throws TypeError when reset is defined but not callable', () => {
+    // Optional-chain `reset?.()` guards null/undefined but would still throw
+    // at invocation time if `reset` is a truthy non-function. Validating at
+    // set-time localises the failure so mid-restore partial-state bugs
+    // cannot arise from a malformed reasoner installed via setReasoner.
+    const agent = makeAgent();
+    const malformed = {
+      selectIntention: () => null,
+      reset: 'not a function',
+    } as unknown as Reasoner;
+
+    expect(() => agent.setReasoner(malformed)).toThrow(TypeError);
+  });
 });

--- a/tests/unit/agent/Agent-setReasoner-reset.test.ts
+++ b/tests/unit/agent/Agent-setReasoner-reset.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAgent } from '../../../src/agent/createAgent.js';
+import type { Reasoner, ReasonerContext } from '../../../src/cognition/reasoning/Reasoner.js';
+import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
+import { ManualClock } from '../../../src/ports/ManualClock.js';
+
+function makeSpyReasoner() {
+  return {
+    selectIntention: vi.fn((_ctx: ReasonerContext) => null),
+    reset: vi.fn(() => undefined),
+  } satisfies Required<Reasoner>;
+}
+
+function makeAgent() {
+  return createAgent({
+    id: 'pet',
+    species: 'cat',
+    clock: new ManualClock(0),
+    rng: 0,
+    eventBus: new InMemoryEventBus(),
+  });
+}
+
+describe('Agent.setReasoner → Reasoner.reset', () => {
+  it('invokes reset() on the incoming reasoner exactly once, after assignment', () => {
+    const agent = makeAgent();
+    const incoming = makeSpyReasoner();
+
+    agent.setReasoner(incoming);
+
+    expect(incoming.reset).toHaveBeenCalledTimes(1);
+    expect(incoming.selectIntention).not.toHaveBeenCalled();
+  });
+
+  it('does NOT invoke reset() on the outgoing reasoner', () => {
+    const agent = makeAgent();
+    const outgoing = makeSpyReasoner();
+    const incoming = makeSpyReasoner();
+
+    agent.setReasoner(outgoing);
+    outgoing.reset.mockClear();
+    agent.setReasoner(incoming);
+
+    expect(outgoing.reset).not.toHaveBeenCalled();
+    expect(incoming.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires reset() even when the same reasoner instance is re-set (identity is irrelevant)', () => {
+    const agent = makeAgent();
+    const spy = makeSpyReasoner();
+
+    agent.setReasoner(spy);
+    agent.setReasoner(spy);
+
+    expect(spy.reset).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not throw when the incoming reasoner omits reset()', () => {
+    const agent = makeAgent();
+    const resetless: Reasoner = {
+      selectIntention: () => null,
+    };
+
+    expect(() => agent.setReasoner(resetless)).not.toThrow();
+  });
+});

--- a/tests/unit/cognition/adapters/JsSonReasoner.test.ts
+++ b/tests/unit/cognition/adapters/JsSonReasoner.test.ts
@@ -204,4 +204,27 @@ describe('JsSonReasoner', () => {
     expect(fresh['needs']).toBeUndefined();
     expect(fresh['counter']).toBe(0);
   });
+
+  describe('reset()', () => {
+    it('restores beliefs to the initial map exactly — port contract', () => {
+      const initial = { alive: true, mood: 'neutral', ticks: 0 };
+      const reasoner = new JsSonReasoner({
+        beliefs: { ...initial },
+        plans: [
+          Plan(
+            () => true,
+            () => [{ log: 'observed' }],
+          ),
+        ],
+      });
+
+      // Tick once — the default toBeliefs mapper injects needs/modifiers/etc.
+      // into the belief map, so the post-tick beliefs differ from initial.
+      reasoner.selectIntention(ctx([], { hunger: 0.5 }));
+      expect(reasoner.getBeliefs()).not.toEqual(initial);
+
+      reasoner.reset();
+      expect(reasoner.getBeliefs()).toEqual(initial);
+    });
+  });
 });

--- a/tests/unit/cognition/adapters/MistreevousReasoner.test.ts
+++ b/tests/unit/cognition/adapters/MistreevousReasoner.test.ts
@@ -189,4 +189,33 @@ describe('MistreevousReasoner', () => {
     reasoner.reset();
     expect(reasoner.getTreeState()).toBe(MistreevousState.READY);
   });
+
+  describe('reset()', () => {
+    it('clears a RUNNING node back to READY — port contract', () => {
+      // Mirrors the RUNNING-continuity fixture: a long-running handler
+      // that would otherwise stay RUNNING across multiple selectIntention
+      // ticks. reset() must wipe that mid-sequence state.
+      let stepsRemaining = 5;
+      const reasoner = new MistreevousReasoner({
+        definition: 'root { action [longRunning] }',
+        handlers: {
+          longRunning: (_c, helpers) => {
+            if (stepsRemaining > 0) {
+              stepsRemaining -= 1;
+              return MistreevousState.RUNNING;
+            }
+            helpers.commit({ kind: 'satisfy', type: 'finally-done' });
+            return MistreevousState.SUCCEEDED;
+          },
+        },
+      });
+
+      // One tick — tree enters RUNNING and the handler consumed one step.
+      reasoner.selectIntention(ctx([]));
+      expect(reasoner.getTreeState()).toBe(MistreevousState.RUNNING);
+
+      reasoner.reset();
+      expect(reasoner.getTreeState()).toBe(MistreevousState.READY);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Lifts `reset()` to the `Reasoner` port as an optional method.
- `Agent.setReasoner(next)` invokes `next.reset?.()` synchronously after assignment.
- `Agent.restore(...)` invokes `this.reasoner.reset?.()` at the very end, after the catch-up-tick loop — so live post-restore ticks start fresh regardless of catch-up chunk size.
- `MistreevousReasoner` + `JsSonReasoner` already had matching `reset()`; JSDoc now links them to the port contract + new unit tests pin the semantics (BT `RUNNING` → `READY`, mutated beliefs → initial beliefs).
- `BrainJsReasoner` opts out (stateless; consumer-owned weights). Class JSDoc documents the rationale.

Unblocks 0.9.3 (brain.js training persistence flow).

## Test plan
- [x] `npm run verify` green locally (format:check, lint, typecheck, test, build).
- [x] Spy-reasoner kernel tests: `Agent-setReasoner-reset`, `Agent-restore-reset`.
- [x] Adapter reset behavior tests: `MistreevousReasoner`, `JsSonReasoner`.
- [x] No schema changes — existing persistence tests still green (12/12).
- [x] Changeset (`minor` bump) under `.changeset/reasoner-reset-harmonization.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)