### PR TITLE
fix(agent): 0.9.5 unify facade publishEvent with internal publish

### DIFF
--- a/.changeset/facade-publish-event-unify.md
+++ b/.changeset/facade-publish-event-unify.md
@@ -1,0 +1,13 @@
+---
+'agentonomous': patch
+---
+
+Fix: route `AgentFacade.publishEvent` through the internal publish path so
+reactive-handler and module-onInstall events appear in the tick trace's
+`emitted` list and are observed by the autosave event-trigger tracker.
+
+Previously the facade wrote straight to `eventBus.publish`, bypassing
+`emittedThisTick` and `AutoSaveTracker.observeEvent`. Subscribers saw the
+event but the `DecisionTrace` did not, and event-gated autosaves never
+fired for facade-published types. The fix unifies the facade with the
+existing skill-context publish path — no public API change.

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -892,7 +892,7 @@ export class Agent {
       rng: this.rng,
       logger: this.logger,
       publishEvent: (event: DomainEvent) => {
-        this.eventBus.publish(event);
+        this._internalPublish(event);
       },
       invokeSkill: async (skillId, params) => {
         await this.cognitionPipeline.invokeSkillAction(

--- a/tests/unit/agent/Agent-facade-publish.test.ts
+++ b/tests/unit/agent/Agent-facade-publish.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentModule } from '../../../src/agent/AgentModule.js';
+import { createAgent } from '../../../src/agent/createAgent.js';
+import type { DomainEvent } from '../../../src/events/DomainEvent.js';
+import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
+import { InMemorySnapshotStore } from '../../../src/persistence/InMemorySnapshotStore.js';
+import { ManualClock } from '../../../src/ports/ManualClock.js';
+
+/**
+ * Regression coverage for `AgentFacade.publishEvent`. The facade must publish
+ * through the same internal path used by skill contexts and kernel-originated
+ * events — i.e. `_internalPublish` — so facade-emitted events (a) land on the
+ * current tick's `DecisionTrace.emitted` list and (b) are observed by the
+ * autosave event-trigger tracker. Both invariants regressed when the facade
+ * was wired straight to `eventBus.publish()`.
+ */
+describe('AgentFacade.publishEvent', () => {
+  it('places facade-published events into the current tick trace', async () => {
+    const bus = new InMemoryEventBus();
+    const publisher: AgentModule = {
+      id: 'facade-publisher',
+      reactiveHandlers: [
+        {
+          on: 'Trigger',
+          handle: (_event, facade) => {
+            facade.publishEvent({
+              type: 'FacadeCustom',
+              at: facade.clock.now(),
+            } as DomainEvent);
+          },
+        },
+      ],
+    };
+
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      eventBus: bus,
+      modules: [publisher],
+      persistence: false,
+    });
+
+    // Seed a Trigger onto the bus so Stage 1 dispatches the reactive handler
+    // mid-tick. The handler then publishes FacadeCustom via the facade — the
+    // code path the fix unifies with `_internalPublish`.
+    bus.publish({ type: 'Trigger', at: 0 } as DomainEvent);
+
+    const trace = await agent.tick(0.016);
+
+    expect(trace.emitted.some((e) => e.type === 'FacadeCustom')).toBe(true);
+  });
+
+  it('observes facade-published events through the autosave tracker', async () => {
+    const bus = new InMemoryEventBus();
+    const publisher: AgentModule = {
+      id: 'facade-publisher',
+      reactiveHandlers: [
+        {
+          on: 'Trigger',
+          handle: (_event, facade) => {
+            facade.publishEvent({
+              type: 'FacadeCustom',
+              at: facade.clock.now(),
+            } as DomainEvent);
+          },
+        },
+      ],
+    };
+
+    const store = new InMemorySnapshotStore();
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      eventBus: bus,
+      modules: [publisher],
+      persistence: {
+        store,
+        autoSave: { enabled: true, onEvents: ['FacadeCustom'] },
+        autoSaveKey: 'test-pet',
+      },
+    });
+
+    // First tick: no Trigger on the bus → no FacadeCustom → no save.
+    await agent.tick(0);
+    expect(await store.list()).toEqual([]);
+
+    // Seed Trigger; Stage 1 dispatches the reactive handler, which publishes
+    // FacadeCustom via the facade. With the fix, the autosave tracker's
+    // `observeEvent('FacadeCustom')` fires and `shouldSave()` flips true by
+    // end of tick.
+    bus.publish({ type: 'Trigger', at: 0 } as DomainEvent);
+    await agent.tick(0);
+
+    expect(await store.list()).toEqual(['test-pet']);
+  });
+});


### PR DESCRIPTION
## Summary
- `AgentFacade.publishEvent` now routes through `_internalPublish`, matching the path `CognitionPipeline.skillContext().publishEvent` already uses.
- Facade-published events (from reactive handlers, module `onInstall` hooks) now appear on `DecisionTrace.emitted` and are observed by `AutoSaveTracker.observeEvent`.
- No public API change — fixes a latent divergence between facade and skill-context publish semantics.

## Why
Previously the facade wrote straight to `eventBus.publish`, bypassing both `emittedThisTick` (trace inclusion) and `autoSaveTracker.observeEvent` (autosave triggers). Reactive handlers and module `onInstall` hooks that published events produced traces that disagreed with what subscribers saw, and their events never triggered event-gated autosaves.

## Test plan
- [x] New `tests/unit/agent/Agent-facade-publish.test.ts` — two regression cases (trace inclusion + autosave observation). Both fail pre-fix, pass post-fix.
- [x] `npm run verify` green locally (format/lint/typecheck/375 tests/build).
- [x] Existing integration determinism test (`tests/integration/nurture-pet-deterministic.test.ts`) still green — its facade-publish assertion compares run-to-run determinism and remains byte-identical.

## Test design note
Plan 0.9.5 originally sketched a pre-tick facade publish pattern, but `Agent.tick` unconditionally clears `emittedThisTick` at tick entry (`src/agent/Agent.ts:335`), so a pre-tick publish would be wiped before the trace is built. The test was adjusted to exercise the facade from inside a reactive handler (same pattern as the existing determinism integration test) — the fix is still fully covered, and the test actually fails pre-fix.

Addresses remediation plan Workstream 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)