### PR TITLE
chore(persistence): 0.9.6 remove dead AgentSnapshot.pendingEvents field

### DIFF
--- a/.changeset/snapshot-drop-pending-events.md
+++ b/.changeset/snapshot-drop-pending-events.md
@@ -1,0 +1,15 @@
+---
+'agentonomous': minor
+---
+
+Remove unused `pendingEvents` field from `AgentSnapshot`.
+
+The field was declared on the public interface but never populated by
+`Agent.snapshot()` nor read by `Agent.restore()` — a dead promise in the
+public type. Consumers cannot have been relying on it, but the type-level
+shape narrows, so this is shipped as a minor bump. Wire format is
+byte-identical: because the field was optional and never written,
+`JSON.stringify(snapshot)` already omitted the key.
+
+If event-queue persistence is genuinely wanted later, re-introduce with a
+real implementation rather than restoring the dead declaration.

--- a/src/persistence/AgentSnapshot.ts
+++ b/src/persistence/AgentSnapshot.ts
@@ -1,6 +1,5 @@
 import type { AgentIdentity } from '../agent/AgentIdentity.js';
 import type { AnimationState } from '../animation/AnimationState.js';
-import type { DomainEvent } from '../events/DomainEvent.js';
 import type { LifeStage } from '../lifecycle/LifeStage.js';
 import type { MemoryRecord } from '../memory/MemoryRecord.js';
 import type { Modifier } from '../modifiers/Modifier.js';
@@ -76,12 +75,6 @@ export interface AgentSnapshot {
 
   /** Consumer-owned extension slot. */
   custom?: Record<string, unknown>;
-
-  /**
-   * Pending events queued on the bus at save time. Restored onto the fresh
-   * bus so in-flight interactions aren't lost across reload.
-   */
-  pendingEvents?: readonly DomainEvent[];
 }
 
 export const CURRENT_SNAPSHOT_VERSION = 2 as const;

--- a/tests/unit/persistence/AgentSnapshot-shape.test.ts
+++ b/tests/unit/persistence/AgentSnapshot-shape.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentModule } from '../../../src/agent/AgentModule.js';
+import { createAgent } from '../../../src/agent/createAgent.js';
+import type { DomainEvent } from '../../../src/events/DomainEvent.js';
+import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
+import { ManualClock } from '../../../src/ports/ManualClock.js';
+
+/**
+ * Contract pin for `AgentSnapshot.pendingEvents`: the field was declared on
+ * the type but never populated by `Agent.snapshot()` nor read by
+ * `Agent.restore()`. This suite locks that absence so a future change cannot
+ * quietly resurrect the field without an accompanying implementation.
+ *
+ * If event-queue persistence is genuinely wanted later, re-introducing a
+ * `pendingEvents` payload must update (or remove) this test — an explicit
+ * signal that the contract is changing.
+ */
+describe('AgentSnapshot shape — pendingEvents', () => {
+  it('snapshot() output does not include a pendingEvents key on a fresh agent', () => {
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      persistence: false,
+    });
+
+    const snap = agent.snapshot();
+    expect(snap).not.toHaveProperty('pendingEvents');
+  });
+
+  it('snapshot() output does not include a pendingEvents key after ticks and facade-published events', async () => {
+    const bus = new InMemoryEventBus();
+    const publisher: AgentModule = {
+      id: 'facade-publisher',
+      reactiveHandlers: [
+        {
+          on: 'Trigger',
+          handle: (_event, facade) => {
+            facade.publishEvent({
+              type: 'FacadeCustom',
+              at: facade.clock.now(),
+            } as DomainEvent);
+          },
+        },
+      ],
+    };
+
+    const agent = createAgent({
+      id: 'pet',
+      species: 'cat',
+      clock: new ManualClock(0),
+      rng: 0,
+      eventBus: bus,
+      modules: [publisher],
+      persistence: false,
+    });
+
+    // Exercise a tick plus in-flight events to rule out any hypothetical
+    // conditional branch populating `pendingEvents`.
+    bus.publish({ type: 'Trigger', at: 0 } as DomainEvent);
+    await agent.tick(0.016);
+    await agent.tick(0.016);
+
+    const snap = agent.snapshot();
+    expect(snap).not.toHaveProperty('pendingEvents');
+  });
+});


### PR DESCRIPTION
## Summary
- Remove `pendingEvents?: readonly DomainEvent[]` from `AgentSnapshot`.
- The field was declared at `src/persistence/AgentSnapshot.ts:84` but never populated by `Agent.snapshot()` nor read by `Agent.restore()`.
- Drops the now-unused `DomainEvent` import from `AgentSnapshot.ts`.
- New regression test `tests/unit/persistence/AgentSnapshot-shape.test.ts` pins the absent key across a fresh-agent snapshot and a post-tick snapshot with facade-published events.

## Why
A dead promise in the public type. Consumers reading `snap.pendingEvents` always got `undefined`; the JSDoc claimed a feature that was never implemented. Keeping it invites future consumers to build around a field that can't deliver.

## Compatibility
- **Wire format:** byte-identical. The field was optional and `snapshot()` never set it, so `JSON.stringify(snapshot)` already produced output without the key.
- **`CURRENT_SNAPSHOT_VERSION`:** unchanged (stays at `2`). No migration needed — on-disk snapshots that somehow contain `pendingEvents` (none should; nothing ever wrote the field) still decode; the typed surface just no longer exposes it.
- **Type surface:** technically breaking. Shipped as **minor** per the pre-1.0 convention for public-type shrinks. Documented in the changeset.
- If event-queue persistence is later wanted, re-introduce with a real implementation (remediation plan Workstream 2 Option B) — out of scope here.

## Test plan
- [x] `npm run verify` green locally (377 tests, including 2 new shape assertions).
- [x] `tests/unit/persistence/AgentSnapshot-shape.test.ts` asserts the field is absent from `snapshot()` output in two configurations.
- [x] Existing snapshot/restore suite still green — no test exercised the dead field.
- [x] Repo-wide grep confirms no code (tests or src) referenced `pendingEvents` outside the deleted declaration.

Addresses remediation plan Workstream 2 (Option A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)