### PR TITLE
fix(persistence): 0.9.7 FsSnapshotStore reversible key encoding

### DIFF
--- a/.changeset/fs-snapshot-store-reversible-keys.md
+++ b/.changeset/fs-snapshot-store-reversible-keys.md
@@ -1,0 +1,21 @@
+---
+'agentonomous': patch
+---
+
+Fix: `FsSnapshotStore` now uses reversible percent-encoding for on-disk
+filenames, so distinct logical keys always map to distinct files and
+`list()` correctly decodes filenames back to the original keys.
+
+Previously the store's internal `sanitizeKey` replaced every non-
+`[A-Za-z0-9._-]` character with `_`, so keys like `'user/1'`, `'user_1'`,
+and `'user 1'` all collided to the same `user_1.json` — silent data loss
+on `save()` and an ambiguous round-trip on `list()`. The new
+`encodeKey` / `decodeKey` helpers are exported from the module for
+direct unit testing.
+
+**On-disk format break (Node-side consumers).** Snapshots written under
+the previous `sanitizeKey` layout cannot be read through the new
+encoder. Migrate by listing old files on disk, loading the JSON
+directly, and re-saving under the new scheme; or wipe the snapshot
+directory if stored state is regenerable. No automated migration is
+shipped — pre-1.0, manual handling is acceptable.

--- a/src/persistence/FsSnapshotStore.ts
+++ b/src/persistence/FsSnapshotStore.ts
@@ -56,7 +56,7 @@ export class FsSnapshotStore implements SnapshotStorePort {
   async list(): Promise<readonly string[]> {
     await this.ensureDir();
     const entries = await this.fs.readdir(this.directory);
-    return entries.filter((e) => e.endsWith('.json')).map((e) => e.slice(0, -5));
+    return entries.filter((e) => e.endsWith('.json')).map((e) => decodeKey(e.slice(0, -5)));
   }
 
   async delete(key: string): Promise<void> {
@@ -74,10 +74,47 @@ export class FsSnapshotStore implements SnapshotStorePort {
   }
 
   private pathFor(key: string): string {
-    return `${this.directory}${this.sep}${sanitizeKey(key)}.json`;
+    return `${this.directory}${this.sep}${encodeKey(key)}.json`;
   }
 }
 
-function sanitizeKey(key: string): string {
-  return key.replace(/[^a-zA-Z0-9._-]/g, '_');
+/**
+ * Encode a logical snapshot key into a filesystem-safe filename component.
+ *
+ * Reversible percent-encoding: every character outside `[A-Za-z0-9._-]`,
+ * plus `%` itself, becomes `%XX` — uppercase hex of the UTF-8 byte(s).
+ * Keeps the output alphabet strictly `/[A-Za-z0-9._\-%]+/` so `decodeKey`
+ * is a clean inverse.
+ *
+ * Worst case is 3× expansion (every char → `%XX` for one-byte code
+ * points, up to 9× for four-byte UTF-8). Callers needing strict path-
+ * length safety should bound logical keys at the call site.
+ */
+export function encodeKey(key: string): string {
+  let out = '';
+  for (const char of key) {
+    if (/^[A-Za-z0-9._-]$/.test(char)) {
+      out += char;
+    } else {
+      // encodeURIComponent emits multi-byte UTF-8 as chained %XX — exactly
+      // the byte-wise escaping we want. It leaves `! ' ( ) * ~` unreserved
+      // though, so sweep those into %XX too to keep the output alphabet
+      // narrow enough for decodeKey to treat every %XX uniformly.
+      let escaped = encodeURIComponent(char);
+      escaped = escaped.replace(
+        /[!'()*~]/g,
+        (c) => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')}`,
+      );
+      out += escaped;
+    }
+  }
+  return out;
+}
+
+/**
+ * Decode a filename (sans `.json` suffix) back into its logical snapshot
+ * key. Inverse of `encodeKey`.
+ */
+export function decodeKey(encoded: string): string {
+  return decodeURIComponent(encoded);
 }

--- a/tests/unit/persistence/FsSnapshotStore.test.ts
+++ b/tests/unit/persistence/FsSnapshotStore.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentSnapshot } from '../../../src/persistence/AgentSnapshot.js';
+import {
+  decodeKey,
+  encodeKey,
+  FsSnapshotStore,
+  type FsAdapter,
+} from '../../../src/persistence/FsSnapshotStore.js';
+
+/** Build a minimal snapshot carrying the logical key on `identity.id`. */
+function snap(id: string): AgentSnapshot {
+  return {
+    schemaVersion: 2,
+    snapshotAt: 0,
+    identity: { id, name: id, version: '0.0.0', role: 'npc', species: 'cat' },
+  };
+}
+
+/**
+ * In-memory `FsAdapter` stub. Files are stored under their full path; the
+ * stub resolves `readdir(dir)` by prefix-matching those paths, which mirrors
+ * real filesystem semantics closely enough for the store's purposes.
+ */
+class MemFs implements FsAdapter {
+  readonly files = new Map<string, string>();
+  readFile(path: string, _encoding: 'utf8'): Promise<string> {
+    const v = this.files.get(path);
+    if (v === undefined) return Promise.reject(new Error('ENOENT'));
+    return Promise.resolve(v);
+  }
+  writeFile(path: string, data: string, _encoding: 'utf8'): Promise<void> {
+    this.files.set(path, data);
+    return Promise.resolve();
+  }
+  mkdir(_path: string, _opts: { recursive: true }): Promise<void> {
+    return Promise.resolve();
+  }
+  readdir(dir: string): Promise<string[]> {
+    const prefix = `${dir}/`;
+    return Promise.resolve(
+      [...this.files.keys()].filter((p) => p.startsWith(prefix)).map((p) => p.slice(prefix.length)),
+    );
+  }
+  unlink(path: string): Promise<void> {
+    this.files.delete(path);
+    return Promise.resolve();
+  }
+  access(path: string): Promise<void> {
+    return this.files.has(path) ? Promise.resolve() : Promise.reject(new Error('ENOENT'));
+  }
+}
+
+describe('encodeKey / decodeKey', () => {
+  it('round-trips the safe alphabet unchanged', () => {
+    const keys = ['abc', 'ABC', '123', 'foo.bar', 'foo_bar', 'foo-bar'];
+    for (const k of keys) {
+      expect(encodeKey(k)).toBe(k);
+      expect(decodeKey(encodeKey(k))).toBe(k);
+    }
+  });
+
+  it('escapes path separators, spaces, and common symbols', () => {
+    expect(encodeKey('user/1')).toBe('user%2F1');
+    expect(encodeKey('user 1')).toBe('user%201');
+    expect(encodeKey('user:1')).toBe('user%3A1');
+    expect(encodeKey('user@example.com')).toBe('user%40example.com');
+  });
+
+  it('escapes the percent character itself for round-trip safety', () => {
+    expect(encodeKey('50% off')).toBe('50%25%20off');
+    expect(decodeKey(encodeKey('50% off'))).toBe('50% off');
+  });
+
+  it('escapes multi-byte unicode via UTF-8 byte-wise %XX sequences', () => {
+    expect(encodeKey('café')).toBe('caf%C3%A9');
+    expect(decodeKey('caf%C3%A9')).toBe('café');
+  });
+
+  it('escapes the spec-unreserved chars that encodeURIComponent leaves alone', () => {
+    // encodeURIComponent leaves ! ' ( ) * ~ unreserved; our encoder must not.
+    expect(encodeKey('a!b')).toBe('a%21b');
+    expect(encodeKey("a'b")).toBe('a%27b');
+    expect(encodeKey('a(b)')).toBe('a%28b%29');
+    expect(encodeKey('a*b')).toBe('a%2Ab');
+    expect(encodeKey('a~b')).toBe('a%7Eb');
+  });
+
+  it('previously-colliding keys now map to distinct filenames', () => {
+    // Pre-fix, sanitizeKey mapped all three to `user_1`.
+    expect(encodeKey('user/1')).not.toBe(encodeKey('user_1'));
+    expect(encodeKey('user 1')).not.toBe(encodeKey('user_1'));
+    expect(encodeKey('user/1')).not.toBe(encodeKey('user 1'));
+  });
+});
+
+describe('FsSnapshotStore', () => {
+  it('save / load round-trips a logical key with symbols', async () => {
+    const fs = new MemFs();
+    const store = new FsSnapshotStore({ directory: '/var/snaps', fs });
+    const key = 'user@ex.com/nurturing 1';
+    await store.save(key, snap(key));
+    const loaded = await store.load(key);
+    expect(loaded?.identity.id).toBe(key);
+  });
+
+  it('list() decodes encoded filenames back to logical keys', async () => {
+    const fs = new MemFs();
+    const store = new FsSnapshotStore({ directory: '/var/snaps', fs });
+    await store.save('user/1', snap('user/1'));
+    await store.save('user_1', snap('user_1'));
+    await store.save('café', snap('café'));
+
+    const keys = await store.list();
+    expect(new Set(keys)).toEqual(new Set(['user/1', 'user_1', 'café']));
+  });
+
+  it('previously-colliding keys do not overwrite each other', async () => {
+    const fs = new MemFs();
+    const store = new FsSnapshotStore({ directory: '/var/snaps', fs });
+    await store.save('user/1', snap('via-slash'));
+    await store.save('user_1', snap('via-underscore'));
+    await store.save('user 1', snap('via-space'));
+
+    expect((await store.load('user/1'))?.identity.id).toBe('via-slash');
+    expect((await store.load('user_1'))?.identity.id).toBe('via-underscore');
+    expect((await store.load('user 1'))?.identity.id).toBe('via-space');
+  });
+
+  it('delete() removes the encoded filename and keeps siblings intact', async () => {
+    const fs = new MemFs();
+    const store = new FsSnapshotStore({ directory: '/var/snaps', fs });
+    await store.save('user/1', snap('user/1'));
+    await store.save('user_1', snap('user_1'));
+
+    await store.delete('user/1');
+    expect(await store.load('user/1')).toBeNull();
+    expect((await store.load('user_1'))?.identity.id).toBe('user_1');
+  });
+
+  it('delete() is idempotent on missing keys', async () => {
+    const fs = new MemFs();
+    const store = new FsSnapshotStore({ directory: '/var/snaps', fs });
+    await expect(store.delete('never-saved')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `FsSnapshotStore.sanitizeKey`'s lossy `/[^A-Za-z0-9._-]/g → '_'` substitution with exported `encodeKey` / `decodeKey` helpers using reversible percent-encoding (UTF-8 byte-wise `%XX`).
- `pathFor()` encodes; `list()` decodes — logical keys survive the round trip.
- Distinct logical keys (`'user/1'`, `'user_1'`, `'user 1'`) now map to distinct files.
- First dedicated test file for the store: `tests/unit/persistence/FsSnapshotStore.test.ts` — 11 tests covering encoder round-trip, collision avoidance, UTF-8 (`café`), the spec-unreserved characters `encodeURIComponent` leaves alone, and end-to-end save/load/list/delete integration via an in-memory `FsAdapter` stub.

## Why
The old `sanitizeKey` was a silent data-loss bug: any two keys differing only by non-safe characters collided to the same filename. `save('user/1', ...)` followed by `save('user_1', ...)` silently overwrote the first. `list()` returned the sanitized filename stem, not the original logical key, so callers couldn't even discover what they'd saved.

## Compatibility
**Breaking on-disk format for Node-side consumers with existing snapshots.** Files written under the previous layout cannot be read through the new encoder. Pre-1.0 library — this is an acceptable break. Migration options documented in the changeset:
- Read old files directly from disk (`fs.readFile('<key>.json')`) and `save()` them through the new scheme, or
- Wipe the snapshot directory if the state is regenerable.

No automated migration helper ships with this PR — the dual-read path would complicate `load()` / `list()` for a narrow audience and is out of scope.

## Encoding choice (percent over base64url)
Kept filenames human-inspectable in a directory listing. Worst-case expansion is 3× for single-byte code points (documented in the `encodeKey` JSDoc). `encodeURIComponent` does the heavy lifting; we additionally escape `!'()*~` (spec-unreserved but not in our safe set) so the output alphabet stays strictly `/[A-Za-z0-9._\-%]+/` and `decodeKey` is a clean inverse.

## Test plan
- [x] `npm run verify` green locally (388 tests, including 11 new).
- [x] Encoder round-trips safe alphabet, symbols, spaces, `%`, UTF-8, `!'()*~`.
- [x] Previously-colliding keys now produce distinct filenames.
- [x] Save/load/list/delete round trip via in-memory `FsAdapter`; delete is idempotent and leaves siblings intact.

Addresses remediation plan Workstream 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)