### PR TITLE
fix(persistence): FsSnapshotStore.list() tolerates undecodable filenames

### DIFF
--- a/.changeset/fs-snapshot-store-list-decode-errors.md
+++ b/.changeset/fs-snapshot-store-list-decode-errors.md
@@ -1,0 +1,15 @@
+---
+'agentonomous': patch
+---
+
+Fix: `FsSnapshotStore.list()` no longer rejects when the snapshot
+directory contains a `.json` filename the encoder wouldn't have produced
+(e.g. a foreign file with a literal `%` outside a valid `%XX` sequence).
+
+Previously the call to `decodeURIComponent` via `decodeKey` could throw
+`URIError`, propagating out of `list()` and failing the whole call. Now
+`list()` catches per-entry decode errors and skips the offending file —
+such names can't round-trip through key-based `load()` anyway, so
+surfacing them would just hand callers an unusable key.
+
+Follow-up to #57 addressing a reviewer-flagged edge case.

--- a/src/persistence/FsSnapshotStore.ts
+++ b/src/persistence/FsSnapshotStore.ts
@@ -56,7 +56,19 @@ export class FsSnapshotStore implements SnapshotStorePort {
   async list(): Promise<readonly string[]> {
     await this.ensureDir();
     const entries = await this.fs.readdir(this.directory);
-    return entries.filter((e) => e.endsWith('.json')).map((e) => decodeKey(e.slice(0, -5)));
+    const out: string[] = [];
+    for (const e of entries) {
+      if (!e.endsWith('.json')) continue;
+      try {
+        out.push(decodeKey(e.slice(0, -5)));
+      } catch {
+        // Malformed `%XX` sequence — a file the encoder wouldn't have
+        // produced (foreign tooling, manual drop-in). Skip it; the store
+        // can't round-trip it through key-based `load()` anyway, so
+        // surfacing it would just hand callers an unusable key.
+      }
+    }
+    return out;
   }
 
   async delete(key: string): Promise<void> {

--- a/tests/unit/persistence/FsSnapshotStore.test.ts
+++ b/tests/unit/persistence/FsSnapshotStore.test.ts
@@ -142,4 +142,19 @@ describe('FsSnapshotStore', () => {
     const store = new FsSnapshotStore({ directory: '/var/snaps', fs });
     await expect(store.delete('never-saved')).resolves.toBeUndefined();
   });
+
+  it('list() skips files whose names the encoder would never produce', async () => {
+    // Foreign `.json` files in a shared snapshot directory must not cause
+    // list() to reject — `decodeURIComponent` throws URIError on malformed
+    // `%XX` sequences; the store drops those entries and returns the
+    // decodable subset.
+    const fs = new MemFs();
+    const store = new FsSnapshotStore({ directory: '/var/snaps', fs });
+    await store.save('good-key', snap('good-key'));
+    // Drop a file the encoder would never emit (bare `%ZZ`).
+    fs.files.set('/var/snaps/bad%ZZ.json', '{}');
+
+    const keys = await store.list();
+    expect(keys).toEqual(['good-key']);
+  });
 });


### PR DESCRIPTION
## Summary
- Catch per-entry decode errors in `FsSnapshotStore.list()` so a foreign `.json` file with a malformed `%XX` sequence can't reject the whole call.
- New regression test pins the skip-on-malformed behavior via the in-memory `FsAdapter` stub.
- Patch changeset.

## Why
Post-#57, `list()` ran `decodeKey` (wrapping `decodeURIComponent`) over every `.json` basename. `decodeURIComponent` throws `URIError` on malformed `%XX` sequences — so a single file the encoder wouldn't have produced (e.g. `bad%ZZ.json` from foreign tooling or a manual drop-in into a shared snapshot directory) would fail the whole `list()` call. The pre-#57 implementation never decoded at all, so this is a regression introduced by the encoder switch.

Skipping undecodable names is the right contract: such filenames can't round-trip through key-based `load()` anyway, so surfacing them would just hand callers an unusable key. A shared directory with foreign files now stays usable — consumers see the decodable subset.

## Test plan
- [x] `npm test -- FsSnapshotStore` — 12 tests green, including the new skip-on-malformed case.
- [x] Full suite green (389 tests).

Follow-up to #57. Addresses Codex review P2 feedback: https://github.com/Luis85/agentonomous/pull/57#discussion_r3132913383

🤖 Generated with [Claude Code](https://claude.com/claude-code)