### PR TITLE
fix(config): quiet IDE red marks on vite.config.ts + demo tsconfig

### DIFF
--- a/examples/nurture-pet/tsconfig.json
+++ b/examples/nurture-pet/tsconfig.json
@@ -11,7 +11,6 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "agentonomous": ["../../src/index.ts"],
       "agentonomous/cognition/adapters/mistreevous": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { relative, resolve } from 'node:path';
-import { defineConfig, type Plugin } from 'vite';
+import type { Plugin } from 'vite';
+import { defineConfig } from 'vitest/config';
 import dts from 'vite-plugin-dts';
 
 // Library mode build. Entries:


### PR DESCRIPTION
## Summary

Two small IDE red-marks surfaced post-merge:

- **vite.config.ts** — `test` not typed on `UserConfigExport`. Switched `defineConfig` import to `vitest/config` (keeps `Plugin` from `vite`).
- **examples/nurture-pet/tsconfig.json** — TS 7.0 deprecates `baseUrl: "."`. Dropped it; `paths` entries are already relative to the tsconfig, which is the fallback resolver root under `moduleResolution: Bundler`. No behaviour change.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run verify` green (413 tests + build)
- [x] `cd examples/nurture-pet && npx tsc --noEmit` no longer emits the baseUrl deprecation (pre-existing js-son-agent ambient-module gaps remain — separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)