### PR TITLE
fix(examples/nurture-pet): include js-son ambient shim in demo tsconfig

### DIFF
--- a/examples/nurture-pet/tsconfig.json
+++ b/examples/nurture-pet/tsconfig.json
@@ -20,5 +20,5 @@
       "agentonomous/cognition/adapters/tfjs": ["../../src/cognition/adapters/tfjs/index.ts"]
     }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "../../src/cognition/adapters/js-son/js-son-agent.d.ts"]
 }


### PR DESCRIPTION
## Summary
- Extends `examples/nurture-pet/tsconfig.json` `include` to pull in the adapter's ambient shim (`../../src/cognition/adapters/js-son/js-son-agent.d.ts`), so the demo's local `tsc --noEmit` sees the `declare module 'js-son-agent'` block when it reaches the adapter source via `paths`.
- Closes `docs/specs/2026-04-24-post-tfjs-improvements.md` §3A.1 — pre-existing gap logged during the tfjs post-migration review.

## Test plan
- [x] `cd examples/nurture-pet && npx tsc --noEmit` — no errors (was 4× TS7016 on `js-son-agent`).
- [x] `npm run verify` — green (410 tests).
- [x] No runtime change — tsconfig `include` only affects type-check scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)