### PR TITLE
refactor(agent): rename _internalPublish / _internalDie → publishEvent / routeDeath

### DIFF
--- a/.changeset/agent-internal-rename.md
+++ b/.changeset/agent-internal-rename.md
@@ -1,0 +1,29 @@
+---
+'agentonomous': major
+---
+
+Rename the two `@internal` hooks on `Agent` that helper classes under
+`src/agent/internal/` use to drive the tick pipeline:
+
+- `Agent._internalPublish(event)` → `Agent.publishEvent(event)`
+- `Agent._internalDie(cause, reason, at)` → `Agent.routeDeath(cause, reason, at)`
+
+Both methods remain `@internal` (not re-exported from the public
+barrel). The rename drops the leading-underscore convention in favour
+of the TSDoc `@internal` tag + barrel discipline, matches the
+direction of 1.0.3 "narrow the public surface", and aligns with
+`STYLE_GUIDE.md`'s updated naming rules.
+
+**Breaking** only for consumers who reached past the barrel and called
+the underscore-prefixed methods directly. No public / re-exported
+symbol changed. Migration is a one-line sweep:
+
+```ts
+// Before
+agent._internalPublish(event);
+agent._internalDie('explicit', 'from:unit-test', now);
+
+// After
+agent.publishEvent(event);
+agent.routeDeath('explicit', 'from:unit-test', now);
+```

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -91,9 +91,12 @@ Where prettier or eslint already enforces a rule, we say so and move on.
   functions are `camelCase`.
 - **Booleans:** `is` / `has` / `should` / `can` prefix. `isInvokeSkillAction`,
   `hasModifier`, `shouldSave`.
-- **Private / internal:** leading underscore on exported-but-internal
-  symbols (`_internalPublish`, `_internalDie`). Every other private
-  member uses TypeScript's `private` or `protected`.
+- **Private / internal:** `public` methods needed by in-repo tick
+  helpers (e.g. `Agent.publishEvent`, `Agent.routeDeath`) carry the
+  TSDoc `@internal` tag and are not re-exported from the public
+  barrel. Every other private member uses TypeScript's `private` or
+  `protected`. Avoid leading-underscore names — the `@internal` tag
+  and barrel discipline are the contract.
 
 ## Commenting
 

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -279,16 +279,17 @@ export class Agent {
 
   // =========================================================================
   // Internal protocol (exposed for helper classes under src/agent/internal/).
-  // Underscore prefix signals "internal"; consumers should not call these.
+  // Marked @internal — not re-exported from the public barrel; consumers go
+  // through `AgentFacade` / `createAgent` instead.
   // =========================================================================
 
-  /** @internal publish an event onto the bus and into the tick's emitted list. */
-  _internalPublish(event: DomainEvent): void {
+  /** @internal Publish an event onto the bus and into the tick's emitted list. */
+  publishEvent(event: DomainEvent): void {
     this.publish(event);
   }
 
-  /** @internal route the death path — used by NeedsTicker when health hits 0. */
-  _internalDie(
+  /** @internal Route the death path — used by `NeedsTicker` when health hits 0. */
+  routeDeath(
     cause: 'health-depleted' | 'stage-transition' | 'explicit' | (string & {}),
     reason: string | undefined,
     at: number,
@@ -892,7 +893,7 @@ export class Agent {
       rng: this.rng,
       logger: this.logger,
       publishEvent: (event: DomainEvent) => {
-        this._internalPublish(event);
+        this.publishEvent(event);
       },
       invokeSkill: async (skillId, params) => {
         await this.cognitionPipeline.invokeSkillAction(

--- a/src/agent/internal/AnimationReconciler.ts
+++ b/src/agent/internal/AnimationReconciler.ts
@@ -33,7 +33,7 @@ export class AnimationReconciler {
       ...(transition.reason !== undefined ? { reason: transition.reason } : {}),
       ...(transition.fxHint !== undefined ? { fxHint: transition.fxHint } : {}),
     };
-    agent._internalPublish(event);
+    agent.publishEvent(event);
     return {
       from: transition.from,
       to: transition.to,

--- a/src/agent/internal/CognitionPipeline.ts
+++ b/src/agent/internal/CognitionPipeline.ts
@@ -95,7 +95,7 @@ export class CognitionPipeline {
       }
       if (action.type === 'emit-event' && 'event' in action) {
         const event = (action as { event: DomainEvent }).event;
-        this.agent._internalPublish(event);
+        this.agent.publishEvent(event);
         continue;
       }
       // Unknown action kinds are left for consumer modules to interpret;
@@ -126,7 +126,7 @@ export class CognitionPipeline {
           code: 'stage-blocked',
           message: `Skill '${skillId}' is blocked at stage '${agent.ageModel.stage}'.`,
         };
-        agent._internalPublish(event);
+        agent.publishEvent(event);
         return;
       }
     }
@@ -139,7 +139,7 @@ export class CognitionPipeline {
         code: 'not-registered',
         message: `No skill registered with id '${skillId}'.`,
       };
-      agent._internalPublish(event);
+      agent.publishEvent(event);
       return;
     }
     // Expose the running skill to the animation reconciler. Scoped to this
@@ -166,7 +166,7 @@ export class CognitionPipeline {
         message,
         details: { cause: message },
       };
-      agent._internalPublish(event);
+      agent.publishEvent(event);
       return;
     }
     agent.currentActiveSkillId = previousActive;
@@ -184,7 +184,7 @@ export class CognitionPipeline {
         ...(result.value.fxHint !== undefined ? { fxHint: result.value.fxHint } : {}),
         ...(result.value.details !== undefined ? { details: result.value.details } : {}),
       };
-      agent._internalPublish(event);
+      agent.publishEvent(event);
       agent.learner.score({
         intention: { kind: 'satisfy', type: skillId },
         actions: [{ type: 'invoke-skill', skillId, ...(params !== undefined ? { params } : {}) }],
@@ -200,7 +200,7 @@ export class CognitionPipeline {
         message: result.error.message,
         ...(result.error.details !== undefined ? { details: result.error.details } : {}),
       };
-      agent._internalPublish(event);
+      agent.publishEvent(event);
     }
   }
 
@@ -218,7 +218,7 @@ export class CognitionPipeline {
       removeModifier: (id) => agent.removeModifier(id),
       hasModifier: (id) => agent.modifiers.has(id),
       publishEvent: (event) => {
-        agent._internalPublish(event);
+        agent.publishEvent(event);
       },
       ageSeconds: () => agent.ageModel?.ageSeconds ?? 0,
     };

--- a/src/agent/internal/LifecycleTicker.ts
+++ b/src/agent/internal/LifecycleTicker.ts
@@ -24,7 +24,7 @@ export class LifecycleTicker {
         to: t.to,
         atAgeSeconds: t.atAgeSeconds,
       };
-      this.agent._internalPublish(event);
+      this.agent.publishEvent(event);
     }
     return transitions;
   }

--- a/src/agent/internal/ModifiersTicker.ts
+++ b/src/agent/internal/ModifiersTicker.ts
@@ -24,7 +24,7 @@ export class ModifiersTicker {
           ? { fxHint: removal.modifier.visual.fxHint }
           : {}),
       };
-      this.agent._internalPublish(event);
+      this.agent.publishEvent(event);
     }
     return expired;
   }

--- a/src/agent/internal/MoodReconciler.ts
+++ b/src/agent/internal/MoodReconciler.ts
@@ -31,7 +31,7 @@ export class MoodReconciler {
       to: next.category,
       valence: next.valence,
     };
-    agent._internalPublish(event);
+    agent.publishEvent(event);
     return { from: previous?.category, to: next.category, valence: next.valence };
   }
 }

--- a/src/agent/internal/NeedsTicker.ts
+++ b/src/agent/internal/NeedsTicker.ts
@@ -31,7 +31,7 @@ export class NeedsTicker {
           needId: delta.needId,
           level: delta.after,
         };
-        agent._internalPublish(event);
+        agent.publishEvent(event);
       } else if (delta.crossedSafe) {
         const event: NeedSafeEvent = {
           type: NEED_SAFE,
@@ -40,14 +40,14 @@ export class NeedsTicker {
           needId: delta.needId,
           level: delta.after,
         };
-        agent._internalPublish(event);
+        agent.publishEvent(event);
       }
       if (delta.needId === 'health' && delta.after <= 0) {
         healthDepleted = true;
       }
     }
     if (healthDepleted && !agent.halted) {
-      agent._internalDie('health-depleted', undefined, at);
+      agent.routeDeath('health-depleted', undefined, at);
     }
     return deltas;
   }

--- a/tests/unit/agent/Agent-facade-publish.test.ts
+++ b/tests/unit/agent/Agent-facade-publish.test.ts
@@ -9,7 +9,7 @@ import { ManualClock } from '../../../src/ports/ManualClock.js';
 /**
  * Regression coverage for `AgentFacade.publishEvent`. The facade must publish
  * through the same internal path used by skill contexts and kernel-originated
- * events — i.e. `_internalPublish` — so facade-emitted events (a) land on the
+ * events — i.e. `Agent.publishEvent` — so facade-emitted events (a) land on the
  * current tick's `DecisionTrace.emitted` list and (b) are observed by the
  * autosave event-trigger tracker. Both invariants regressed when the facade
  * was wired straight to `eventBus.publish()`.
@@ -44,7 +44,7 @@ describe('AgentFacade.publishEvent', () => {
 
     // Seed a Trigger onto the bus so Stage 1 dispatches the reactive handler
     // mid-tick. The handler then publishes FacadeCustom via the facade — the
-    // code path the fix unifies with `_internalPublish`.
+    // code path the fix unifies with `Agent.publishEvent`.
     bus.publish({ type: 'Trigger', at: 0 } as DomainEvent);
 
     const trace = await agent.tick(0.016);


### PR DESCRIPTION
## Summary
- Drops the leading-underscore convention on \`Agent\`'s two \`@internal\` hooks used by the in-repo tick helpers, in favour of the \`@internal\` TSDoc tag + barrel discipline.
- \`Agent._internalPublish(event)\` → \`Agent.publishEvent(event)\`.
- \`Agent._internalDie(cause, reason, at)\` → \`Agent.routeDeath(cause, reason, at)\`.
- Sweeps all 13 call sites across \`src/agent/internal/*Ticker.ts\` + \`*Reconciler.ts\` + \`CognitionPipeline.ts\` + the facade proxy in \`Agent.facade()\`.
- Rewrites the \`STYLE_GUIDE.md\` naming rule so it matches the new convention.
- Closes the v1 plan item \`1.0.1\` (docs updated separately in PR #64).

## Test plan
- [x] \`npm run verify\` — format + lint + typecheck + 410 tests + build all green.
- [x] No \`_internalPublish\` / \`_internalDie\` refs left under \`src/\` or \`tests/\` (\`rg\`).
- [x] Core bundle \`dist/index.js\` gzip size unchanged at 32.50 kB (under the 35 kB budget).
- [x] Major-bump changeset committed (\`.changeset/agent-internal-rename.md\`).

## Notes for review
- Both methods remain \`@internal\`; this is a rename, not a surface-widening.
- Breaking only for consumers who reached past the barrel — the migration is a one-line sweep documented in the changeset.
- Pre-work for 1.0.3 "narrow the public surface" (next PR in the v1 train).

🤖 Generated with [Claude Code](https://claude.com/claude-code)