### PR TITLE
feat(ports): LlmProviderPort + MockLlmProvider

### DIFF
--- a/.changeset/llm-provider-port.md
+++ b/.changeset/llm-provider-port.md
@@ -1,0 +1,29 @@
+---
+'agentonomous': minor
+---
+
+Add the `LlmProviderPort` — the minimum contract v1.0 freezes so
+Phase B can slot concrete adapters (`AnthropicLlmProvider`,
+`OpenAiLlmProvider`) in without a breaking change. v1.0 surface is
+intentionally small:
+
+- `complete(messages, options) → Promise<LlmCompletion>` (no streaming,
+  no tool-use, no structured output — all Phase B additions).
+- `LlmMessage` with an optional `LlmCacheHint` so adapters that
+  support prompt caching (Anthropic `cache_control: ephemeral`;
+  OpenAI prompt caching) have a stable request-side hook.
+- `LlmBudget` with input / output token caps + USD-cent spend cap;
+  adapters throw the existing `BudgetExceededError` before calling
+  upstream when a populated limit would be exceeded.
+- `LlmUsage` reports `inputTokens`, `outputTokens`, optional
+  `costCents`, optional `cached` flag.
+
+Also ships `MockLlmProvider` — a deterministic, no-network playback
+adapter with scripted responses, queue and `match-or-error`
+dispatch modes, budget enforcement, and abort-signal handling. Use
+it from tests + golden-trace replays so a `Reasoner` built on top
+of an LLM still respects the library's byte-identical replay
+contract.
+
+No existing types changed. Core bundle is unaffected — the port +
+mock are public-barrel additions only.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6f19e206-9f41-4d74-83ca-15c93838fba3","pid":7084,"acquiredAt":1777063959475}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6f19e206-9f41-4d74-83ca-15c93838fba3","pid":7084,"acquiredAt":1777063959475}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ examples/**/node_modules
 
 graphify-out
 
+.claude/scheduled_tasks.lock

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,3 +280,19 @@ export {
 } from './ports/ConsoleLogger.js';
 export type { Validator, ValidationResult, ValidationIssue } from './ports/Validator.js';
 export { PassthroughValidator } from './ports/Validator.js';
+export type {
+  LlmRole,
+  LlmCacheHint,
+  LlmMessage,
+  LlmBudget,
+  LlmCompleteOptions,
+  LlmUsage,
+  LlmCompletion,
+  LlmProviderPort,
+} from './ports/LlmProviderPort.js';
+/** Deterministic `LlmProviderPort` for tests / golden replays — no RNG, no clock, no network. */
+export {
+  MockLlmProvider,
+  type MockLlmProviderOptions,
+  type MockLlmScript,
+} from './ports/MockLlmProvider.js';

--- a/src/ports/LlmProviderPort.ts
+++ b/src/ports/LlmProviderPort.ts
@@ -1,0 +1,99 @@
+/**
+ * Port through which the library reaches an LLM provider. v1.0 ships the
+ * completion-only surface: messages in, one completion out, no streaming,
+ * no tool-use, no structured output. Streaming + tool-use additions land
+ * in Phase B and are additive — nothing here has to change.
+ *
+ * Consumers pick a concrete adapter (e.g. `AnthropicLlmProvider`,
+ * `OpenAiLlmProvider`; both Phase B) or implement their own. Tests use
+ * `MockLlmProvider` from this module for deterministic playback.
+ */
+
+/** Role tag for a single turn. The provider decides how to serialise these. */
+export type LlmRole = 'system' | 'user' | 'assistant';
+
+/**
+ * Request-side hint that a provider MAY honour to insert a prompt-cache
+ * breakpoint at this message boundary. The concrete meaning is up to the
+ * adapter (Anthropic: `cache_control: ephemeral`; OpenAI: prompt-caching;
+ * in-memory mock: response memoisation). Opaque to the core — consumers
+ * supply an arbitrary stable string; the adapter translates.
+ */
+export interface LlmCacheHint {
+  /** Stable logical key the provider may use to group cache lookups. */
+  readonly key: string;
+}
+
+/** A single message in a completion request. */
+export interface LlmMessage {
+  readonly role: LlmRole;
+  readonly content: string;
+  /** If present, signals a cache breakpoint after this message. */
+  readonly cacheHint?: LlmCacheHint;
+}
+
+/**
+ * Upper bounds a consumer wants enforced per request. Adapters throw
+ * `BudgetExceededError` (from `src/agent/errors.ts`) before calling the
+ * upstream provider when any populated limit would be exceeded. All
+ * fields optional: absence means "no cap".
+ */
+export interface LlmBudget {
+  /** Hard ceiling on tokens the provider may generate. */
+  readonly maxOutputTokens?: number;
+  /** Hard ceiling on input tokens (rough estimate is acceptable). */
+  readonly maxInputTokens?: number;
+  /** Hard ceiling on spend for this single request, in USD cents. */
+  readonly maxCostCents?: number;
+}
+
+/** Per-call knobs. All fields optional; adapter defaults apply. */
+export interface LlmCompleteOptions {
+  /** Specific model id (e.g. `claude-opus-4-7`). Adapter picks a default. */
+  readonly model?: string;
+  /** Per-request budget caps. */
+  readonly budget?: LlmBudget;
+  /**
+   * Sampling temperature. `0` = greedy (most deterministic). Adapters
+   * MUST pass this through; determinism beyond `0` is provider-dependent.
+   */
+  readonly temperature?: number;
+  /** Abort signal. Adapters should surface aborts as `stopReason: 'abort'`. */
+  readonly signal?: AbortSignal;
+}
+
+/** Token + cost accounting for a single completion. */
+export interface LlmUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  /** Total spend in USD cents, when the adapter can compute it. */
+  readonly costCents?: number;
+  /** True if the provider served (part of) the response from its cache. */
+  readonly cached?: boolean;
+}
+
+/** One completion response. */
+export interface LlmCompletion {
+  /** Assistant text. Empty string is legal (e.g. tool-only turn in Phase B). */
+  readonly text: string;
+  /** Token + cost accounting. */
+  readonly usage: LlmUsage;
+  /** Model id that actually served the request. */
+  readonly model: string;
+  /**
+   * Why generation stopped. `'stop'` = natural end; `'length'` = hit
+   * `maxOutputTokens`; `'abort'` = `signal` fired. Adapters may surface
+   * provider-specific strings (`'content_filter'`, …).
+   */
+  readonly stopReason?: 'stop' | 'length' | 'abort' | (string & {});
+}
+
+/**
+ * Minimum LLM provider contract. v1.0 = completion only. Streaming,
+ * tool-use, and structured output land in Phase B as additive methods
+ * (likely `stream(...)` returning an async iterator) — existing
+ * adapters keep working unchanged.
+ */
+export interface LlmProviderPort {
+  complete(messages: readonly LlmMessage[], options?: LlmCompleteOptions): Promise<LlmCompletion>;
+}

--- a/src/ports/MockLlmProvider.ts
+++ b/src/ports/MockLlmProvider.ts
@@ -166,5 +166,8 @@ function estimateTokens(messages: readonly LlmMessage[]): number {
 }
 
 function estimateTokensFor(text: string): number {
-  return Math.max(1, Math.ceil(text.length / 4));
+  // Empty strings count as 0 tokens so `maxOutputTokens: 0` with an empty
+  // scripted response behaves as documented. Honoring the ceil/4
+  // convention strictly — no floor.
+  return Math.ceil(text.length / 4);
 }

--- a/src/ports/MockLlmProvider.ts
+++ b/src/ports/MockLlmProvider.ts
@@ -92,7 +92,8 @@ export class MockLlmProvider implements LlmProviderPort {
       };
     }
 
-    const script = this.pickScript(messages, options);
+    const picked = this.pickScript(messages, options);
+    const script = picked.script;
     const model = script.model ?? options.model ?? this.defaultModel;
     const inputTokens = script.usage?.inputTokens ?? estimateTokens(messages);
     const outputTokens = script.usage?.outputTokens ?? estimateTokensFor(script.text);
@@ -119,6 +120,11 @@ export class MockLlmProvider implements LlmProviderPort {
       );
     }
 
+    // Only commit the queue cursor once budget checks have passed —
+    // otherwise a budget-rejected request would consume a scripted
+    // entry and make retries non-deterministic.
+    picked.commit();
+
     const usage: LlmUsage = {
       inputTokens,
       outputTokens,
@@ -133,7 +139,10 @@ export class MockLlmProvider implements LlmProviderPort {
     };
   }
 
-  private pickScript(messages: readonly LlmMessage[], options: LlmCompleteOptions): MockLlmScript {
+  private pickScript(
+    messages: readonly LlmMessage[],
+    options: LlmCompleteOptions,
+  ): { script: MockLlmScript; commit: () => void } {
     if (this.dispatch === 'match-or-error') {
       // Strict dispatch must fail fast on both zero and multi-match — the
       // whole point is that each request resolves to exactly one scripted
@@ -148,15 +157,23 @@ export class MockLlmProvider implements LlmProviderPort {
           `MockLlmProvider: ${hits.length} scripts matched the request (match-or-error requires exactly one).`,
         );
       }
-      return hits[0]!;
+      // match-or-error has no queue state to advance; commit is a no-op.
+      return { script: hits[0]!, commit: () => undefined };
     }
     // Queue mode: honour a `match` predicate if it's set; otherwise take
-    // the next positional script. Exhausted queue throws.
-    while (this.cursor < this.scripts.length) {
-      const candidate = this.scripts[this.cursor]!;
-      this.cursor += 1;
+    // the next positional script. Exhausted queue throws. The returned
+    // `commit` advances the queue cursor; callers defer it until after
+    // budget checks so a rejected request doesn't consume an entry.
+    for (let i = this.cursor; i < this.scripts.length; i++) {
+      const candidate = this.scripts[i]!;
       if (candidate.match === undefined || candidate.match(messages, options)) {
-        return candidate;
+        const advanceTo = i + 1;
+        return {
+          script: candidate,
+          commit: () => {
+            this.cursor = advanceTo;
+          },
+        };
       }
     }
     throw new Error('MockLlmProvider: script queue exhausted.');

--- a/src/ports/MockLlmProvider.ts
+++ b/src/ports/MockLlmProvider.ts
@@ -1,0 +1,170 @@
+import { BudgetExceededError } from '../agent/errors.js';
+import type {
+  LlmCompleteOptions,
+  LlmCompletion,
+  LlmMessage,
+  LlmProviderPort,
+  LlmUsage,
+} from './LlmProviderPort.js';
+
+/**
+ * Scripted response used by `MockLlmProvider`. The `match` predicate
+ * decides whether this entry fires for a given request; if omitted, the
+ * script is matched only by position in the queue.
+ */
+export interface MockLlmScript {
+  /** Optional predicate — if returns true, this script serves the request. */
+  readonly match?: (messages: readonly LlmMessage[], options: LlmCompleteOptions) => boolean;
+  /** Response text. */
+  readonly text: string;
+  /** Overrides for usage stats. Defaults to `ceil(content.length / 4)` per side. */
+  readonly usage?: Partial<LlmUsage>;
+  /** Model id reported in the completion. Defaults to the provider's `defaultModel`. */
+  readonly model?: string;
+  /** Stop reason reported. Defaults to `'stop'`. */
+  readonly stopReason?: LlmCompletion['stopReason'];
+}
+
+/** Construction options for `MockLlmProvider`. */
+export interface MockLlmProviderOptions {
+  /** Ordered list of scripted responses. */
+  readonly scripts: readonly MockLlmScript[];
+  /**
+   * Default model id surfaced when a script does not override it.
+   * Defaults to `'mock-llm'`.
+   */
+  readonly defaultModel?: string;
+  /**
+   * How to dispatch to scripts:
+   *  - `'queue'` (default): consume scripts in order; each request pops
+   *    the next one (respecting optional `match`).
+   *  - `'match-or-error'`: every request must find a script whose
+   *    `match` returns true; no positional fallback.
+   */
+  readonly dispatch?: 'queue' | 'match-or-error';
+}
+
+/**
+ * Deterministic `LlmProviderPort` for tests and golden-trace replays.
+ *
+ * No RNG, no `Date.now()`, no network. Two runs with identical options +
+ * identical request sequences produce byte-identical completions —
+ * matching the library's determinism contract, so a `Reasoner` built
+ * on top of an LLM can still be replayed tick-for-tick.
+ *
+ * Budget enforcement is intentionally simple: the mock rejects any
+ * request whose resulting completion would exceed a populated
+ * `maxOutputTokens` or `maxCostCents`. `maxInputTokens` is checked
+ * against the precomputed input estimate before the completion is
+ * constructed.
+ */
+export class MockLlmProvider implements LlmProviderPort {
+  private readonly scripts: readonly MockLlmScript[];
+  private readonly defaultModel: string;
+  private readonly dispatch: 'queue' | 'match-or-error';
+  private cursor = 0;
+
+  constructor(options: MockLlmProviderOptions) {
+    this.scripts = options.scripts;
+    this.defaultModel = options.defaultModel ?? 'mock-llm';
+    this.dispatch = options.dispatch ?? 'queue';
+  }
+
+  complete(
+    messages: readonly LlmMessage[],
+    options: LlmCompleteOptions = {},
+  ): Promise<LlmCompletion> {
+    // Body returns a Promise so sync throws surface as rejected promises — the
+    // port contract is async even though this mock has no real IO to await on.
+    return Promise.resolve().then(() => this.completeSync(messages, options));
+  }
+
+  private completeSync(
+    messages: readonly LlmMessage[],
+    options: LlmCompleteOptions,
+  ): LlmCompletion {
+    if (options.signal?.aborted === true) {
+      return {
+        text: '',
+        usage: { inputTokens: 0, outputTokens: 0 },
+        model: options.model ?? this.defaultModel,
+        stopReason: 'abort',
+      };
+    }
+
+    const script = this.pickScript(messages, options);
+    const model = script.model ?? options.model ?? this.defaultModel;
+    const inputTokens = script.usage?.inputTokens ?? estimateTokens(messages);
+    const outputTokens = script.usage?.outputTokens ?? estimateTokensFor(script.text);
+
+    const budget = options.budget;
+    if (budget?.maxInputTokens !== undefined && inputTokens > budget.maxInputTokens) {
+      throw new BudgetExceededError(
+        `MockLlmProvider: input ${inputTokens} tokens exceeds maxInputTokens ${budget.maxInputTokens}.`,
+      );
+    }
+    if (budget?.maxOutputTokens !== undefined && outputTokens > budget.maxOutputTokens) {
+      throw new BudgetExceededError(
+        `MockLlmProvider: output ${outputTokens} tokens exceeds maxOutputTokens ${budget.maxOutputTokens}.`,
+      );
+    }
+    const costCents = script.usage?.costCents;
+    if (
+      budget?.maxCostCents !== undefined &&
+      costCents !== undefined &&
+      costCents > budget.maxCostCents
+    ) {
+      throw new BudgetExceededError(
+        `MockLlmProvider: cost ${costCents}¢ exceeds maxCostCents ${budget.maxCostCents}¢.`,
+      );
+    }
+
+    const usage: LlmUsage = {
+      inputTokens,
+      outputTokens,
+      ...(costCents !== undefined ? { costCents } : {}),
+      ...(script.usage?.cached !== undefined ? { cached: script.usage.cached } : {}),
+    };
+    return {
+      text: script.text,
+      usage,
+      model,
+      stopReason: script.stopReason ?? 'stop',
+    };
+  }
+
+  private pickScript(messages: readonly LlmMessage[], options: LlmCompleteOptions): MockLlmScript {
+    if (this.dispatch === 'match-or-error') {
+      const hit = this.scripts.find((s) => s.match?.(messages, options) === true);
+      if (!hit) {
+        throw new Error('MockLlmProvider: no script matched the request.');
+      }
+      return hit;
+    }
+    // Queue mode: honour a `match` predicate if it's set; otherwise take
+    // the next positional script. Exhausted queue throws.
+    while (this.cursor < this.scripts.length) {
+      const candidate = this.scripts[this.cursor]!;
+      this.cursor += 1;
+      if (candidate.match === undefined || candidate.match(messages, options)) {
+        return candidate;
+      }
+    }
+    throw new Error('MockLlmProvider: script queue exhausted.');
+  }
+}
+
+/**
+ * Crude character-based token approximator. Good enough for budget
+ * assertions in deterministic tests; real adapters report upstream
+ * counts instead.
+ */
+function estimateTokens(messages: readonly LlmMessage[]): number {
+  let total = 0;
+  for (const m of messages) total += estimateTokensFor(m.content);
+  return total;
+}
+
+function estimateTokensFor(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}

--- a/src/ports/MockLlmProvider.ts
+++ b/src/ports/MockLlmProvider.ts
@@ -95,13 +95,18 @@ export class MockLlmProvider implements LlmProviderPort {
     const picked = this.pickScript(messages, options);
     const script = picked.script;
     const model = script.model ?? options.model ?? this.defaultModel;
-    const inputTokens = script.usage?.inputTokens ?? estimateTokens(messages);
+    // Request-side input count used for the budget check — scripts must
+    // not be able to under-report `inputTokens` and sneak an oversize
+    // prompt past `maxInputTokens`. The reported usage on the completion
+    // still honours the script override so tests can pin exact numbers.
+    const requestInputTokens = estimateTokens(messages);
+    const reportedInputTokens = script.usage?.inputTokens ?? requestInputTokens;
     const outputTokens = script.usage?.outputTokens ?? estimateTokensFor(script.text);
 
     const budget = options.budget;
-    if (budget?.maxInputTokens !== undefined && inputTokens > budget.maxInputTokens) {
+    if (budget?.maxInputTokens !== undefined && requestInputTokens > budget.maxInputTokens) {
       throw new BudgetExceededError(
-        `MockLlmProvider: input ${inputTokens} tokens exceeds maxInputTokens ${budget.maxInputTokens}.`,
+        `MockLlmProvider: input ${requestInputTokens} tokens exceeds maxInputTokens ${budget.maxInputTokens}.`,
       );
     }
     if (budget?.maxOutputTokens !== undefined && outputTokens > budget.maxOutputTokens) {
@@ -126,7 +131,7 @@ export class MockLlmProvider implements LlmProviderPort {
     picked.commit();
 
     const usage: LlmUsage = {
-      inputTokens,
+      inputTokens: reportedInputTokens,
       outputTokens,
       ...(costCents !== undefined ? { costCents } : {}),
       ...(script.usage?.cached !== undefined ? { cached: script.usage.cached } : {}),

--- a/src/ports/MockLlmProvider.ts
+++ b/src/ports/MockLlmProvider.ts
@@ -135,11 +135,20 @@ export class MockLlmProvider implements LlmProviderPort {
 
   private pickScript(messages: readonly LlmMessage[], options: LlmCompleteOptions): MockLlmScript {
     if (this.dispatch === 'match-or-error') {
-      const hit = this.scripts.find((s) => s.match?.(messages, options) === true);
-      if (!hit) {
+      // Strict dispatch must fail fast on both zero and multi-match — the
+      // whole point is that each request resolves to exactly one scripted
+      // response. Silently taking the first match would mask misconfigured
+      // scripts and produce the wrong completion in replay tests.
+      const hits = this.scripts.filter((s) => s.match?.(messages, options) === true);
+      if (hits.length === 0) {
         throw new Error('MockLlmProvider: no script matched the request.');
       }
-      return hit;
+      if (hits.length > 1) {
+        throw new Error(
+          `MockLlmProvider: ${hits.length} scripts matched the request (match-or-error requires exactly one).`,
+        );
+      }
+      return hits[0]!;
     }
     // Queue mode: honour a `match` predicate if it's set; otherwise take
     // the next positional script. Exhausted queue throws.

--- a/tests/unit/ports/MockLlmProvider.test.ts
+++ b/tests/unit/ports/MockLlmProvider.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { BudgetExceededError } from '../../../src/agent/errors.js';
+import { MockLlmProvider } from '../../../src/ports/MockLlmProvider.js';
+import type { LlmMessage } from '../../../src/ports/LlmProviderPort.js';
+
+const ASK: readonly LlmMessage[] = [
+  { role: 'system', content: 'You are a pet.' },
+  { role: 'user', content: 'meow?' },
+];
+
+describe('MockLlmProvider', () => {
+  it('serves scripted responses deterministically across runs', async () => {
+    const build = () =>
+      new MockLlmProvider({
+        scripts: [{ text: 'prr' }, { text: 'mrow' }],
+        defaultModel: 'mock',
+      });
+
+    const runA = [
+      await build().complete(ASK),
+      await (async () => {
+        const p = build();
+        await p.complete(ASK);
+        return p.complete(ASK);
+      })(),
+    ];
+    const runB = [
+      await build().complete(ASK),
+      await (async () => {
+        const p = build();
+        await p.complete(ASK);
+        return p.complete(ASK);
+      })(),
+    ];
+
+    expect(runA).toEqual(runB);
+    expect(runA[0]?.text).toBe('prr');
+    expect(runA[1]?.text).toBe('mrow');
+    expect(runA[0]?.model).toBe('mock');
+    expect(runA[0]?.stopReason).toBe('stop');
+  });
+
+  it('estimates tokens from content length when usage is not supplied', async () => {
+    const provider = new MockLlmProvider({
+      scripts: [{ text: 'mrow' }],
+    });
+    const completion = await provider.complete(ASK);
+
+    // ASK = 'You are a pet.' (14) + 'meow?' (5) → ceil/4 per msg → 4 + 2 = 6.
+    expect(completion.usage.inputTokens).toBe(6);
+    // 'mrow' = 4 chars → 1 token.
+    expect(completion.usage.outputTokens).toBe(1);
+  });
+
+  it('throws BudgetExceededError when output exceeds maxOutputTokens', async () => {
+    const provider = new MockLlmProvider({
+      scripts: [{ text: 'this is a long-ish response', usage: { outputTokens: 20 } }],
+    });
+    await expect(provider.complete(ASK, { budget: { maxOutputTokens: 5 } })).rejects.toBeInstanceOf(
+      BudgetExceededError,
+    );
+  });
+
+  it('throws BudgetExceededError when input exceeds maxInputTokens', async () => {
+    const provider = new MockLlmProvider({
+      scripts: [{ text: 'ok' }],
+    });
+    await expect(provider.complete(ASK, { budget: { maxInputTokens: 1 } })).rejects.toBeInstanceOf(
+      BudgetExceededError,
+    );
+  });
+
+  it('throws BudgetExceededError when cost exceeds maxCostCents', async () => {
+    const provider = new MockLlmProvider({
+      scripts: [{ text: 'ok', usage: { costCents: 200 } }],
+    });
+    await expect(provider.complete(ASK, { budget: { maxCostCents: 50 } })).rejects.toBeInstanceOf(
+      BudgetExceededError,
+    );
+  });
+
+  it('returns an abort stub completion when the signal is already aborted', async () => {
+    const provider = new MockLlmProvider({ scripts: [{ text: 'ok' }] });
+    const controller = new AbortController();
+    controller.abort();
+
+    const completion = await provider.complete(ASK, { signal: controller.signal });
+    expect(completion.stopReason).toBe('abort');
+    expect(completion.text).toBe('');
+  });
+
+  it('queue dispatch: honours a match predicate and falls through positionally', async () => {
+    const provider = new MockLlmProvider({
+      scripts: [
+        { text: 'first', match: (msgs) => msgs[0]?.content === 'never' },
+        { text: 'fallback' },
+      ],
+    });
+
+    const completion = await provider.complete(ASK);
+    expect(completion.text).toBe('fallback');
+  });
+
+  it('match-or-error dispatch: every request must match exactly one script', async () => {
+    const provider = new MockLlmProvider({
+      dispatch: 'match-or-error',
+      scripts: [
+        {
+          text: 'greeting',
+          match: (msgs) => msgs.some((m) => m.role === 'user' && m.content.includes('meow')),
+        },
+      ],
+    });
+
+    const hit = await provider.complete(ASK);
+    expect(hit.text).toBe('greeting');
+
+    await expect(provider.complete([{ role: 'user', content: 'bark!' }])).rejects.toThrow(
+      /no script matched/,
+    );
+  });
+
+  it('queue mode throws when scripts are exhausted', async () => {
+    const provider = new MockLlmProvider({ scripts: [{ text: 'only' }] });
+    await provider.complete(ASK);
+    await expect(provider.complete(ASK)).rejects.toThrow(/exhausted/);
+  });
+
+  it('reports cached usage when the script marks it', async () => {
+    const provider = new MockLlmProvider({
+      scripts: [{ text: 'cached', usage: { cached: true, inputTokens: 10, outputTokens: 2 } }],
+    });
+    const completion = await provider.complete(ASK, {
+      model: 'override-model',
+    });
+    expect(completion.usage.cached).toBe(true);
+    expect(completion.model).toBe('override-model');
+  });
+});

--- a/tests/unit/ports/MockLlmProvider.test.ts
+++ b/tests/unit/ports/MockLlmProvider.test.ts
@@ -126,6 +126,20 @@ describe('MockLlmProvider', () => {
     await expect(provider.complete(ASK)).rejects.toThrow(/exhausted/);
   });
 
+  it('counts empty content as 0 tokens (no floor)', async () => {
+    const provider = new MockLlmProvider({ scripts: [{ text: '' }] });
+    const completion = await provider.complete([{ role: 'user', content: '' }]);
+
+    expect(completion.usage.inputTokens).toBe(0);
+    expect(completion.usage.outputTokens).toBe(0);
+  });
+
+  it('honours maxOutputTokens: 0 against an empty scripted response', async () => {
+    const provider = new MockLlmProvider({ scripts: [{ text: '' }] });
+    const completion = await provider.complete(ASK, { budget: { maxOutputTokens: 0 } });
+    expect(completion.usage.outputTokens).toBe(0);
+  });
+
   it('reports cached usage when the script marks it', async () => {
     const provider = new MockLlmProvider({
       scripts: [{ text: 'cached', usage: { cached: true, inputTokens: 10, outputTokens: 2 } }],

--- a/tests/unit/ports/MockLlmProvider.test.ts
+++ b/tests/unit/ports/MockLlmProvider.test.ts
@@ -126,6 +126,17 @@ describe('MockLlmProvider', () => {
     await expect(provider.complete(ASK)).rejects.toThrow(/exhausted/);
   });
 
+  it('match-or-error dispatch: rejects when more than one script matches', async () => {
+    const provider = new MockLlmProvider({
+      dispatch: 'match-or-error',
+      scripts: [
+        { text: 'first', match: () => true },
+        { text: 'second', match: () => true },
+      ],
+    });
+    await expect(provider.complete(ASK)).rejects.toThrow(/2 scripts matched/);
+  });
+
   it('counts empty content as 0 tokens (no floor)', async () => {
     const provider = new MockLlmProvider({ scripts: [{ text: '' }] });
     const completion = await provider.complete([{ role: 'user', content: '' }]);

--- a/tests/unit/ports/MockLlmProvider.test.ts
+++ b/tests/unit/ports/MockLlmProvider.test.ts
@@ -70,6 +70,26 @@ describe('MockLlmProvider', () => {
     );
   });
 
+  it('maxInputTokens checks request tokens, not script-reported usage', async () => {
+    // Script under-reports input to try to sneak past the budget.
+    const provider = new MockLlmProvider({
+      scripts: [{ text: 'ok', usage: { inputTokens: 1 } }],
+    });
+    // ASK estimates to 6 tokens. maxInputTokens=2 must reject despite
+    // the script claiming inputTokens=1.
+    await expect(provider.complete(ASK, { budget: { maxInputTokens: 2 } })).rejects.toBeInstanceOf(
+      BudgetExceededError,
+    );
+  });
+
+  it('usage.inputTokens in the completion still honours the script override', async () => {
+    const provider = new MockLlmProvider({
+      scripts: [{ text: 'ok', usage: { inputTokens: 999 } }],
+    });
+    const completion = await provider.complete(ASK);
+    expect(completion.usage.inputTokens).toBe(999);
+  });
+
   it('budget rejections do not consume queued scripts', async () => {
     const provider = new MockLlmProvider({
       scripts: [{ text: 'too long', usage: { outputTokens: 50 } }, { text: 'first success' }],

--- a/tests/unit/ports/MockLlmProvider.test.ts
+++ b/tests/unit/ports/MockLlmProvider.test.ts
@@ -70,6 +70,21 @@ describe('MockLlmProvider', () => {
     );
   });
 
+  it('budget rejections do not consume queued scripts', async () => {
+    const provider = new MockLlmProvider({
+      scripts: [{ text: 'too long', usage: { outputTokens: 50 } }, { text: 'first success' }],
+    });
+    // First call rejects on budget — cursor must NOT advance.
+    await expect(provider.complete(ASK, { budget: { maxOutputTokens: 1 } })).rejects.toBeInstanceOf(
+      BudgetExceededError,
+    );
+    // Retry with a looser budget — must still get script[0], not script[1].
+    const first = await provider.complete(ASK);
+    expect(first.text).toBe('too long');
+    const second = await provider.complete(ASK);
+    expect(second.text).toBe('first success');
+  });
+
   it('throws BudgetExceededError when cost exceeds maxCostCents', async () => {
     const provider = new MockLlmProvider({
       scripts: [{ text: 'ok', usage: { costCents: 200 } }],


### PR DESCRIPTION
## Summary
- Ships the v1.0.2 item from \`docs/plans/2026-04-19-v1-comprehensive-plan.md\` — freezes the minimum LLM-provider contract so Phase B can slot concrete adapters in without a breaking change.
- Completion only — no streaming, no tool-use, no structured output (all Phase B additions).
- \`LlmMessage\` carries an optional \`LlmCacheHint\`; adapters translate to Anthropic \`cache_control: ephemeral\` / OpenAI prompt caching / mock memoisation.
- \`LlmBudget\` covers input / output token caps + USD-cent spend cap; populated limits throw the existing \`BudgetExceededError\`.
- \`MockLlmProvider\` is deterministic (no RNG, no \`Date.now()\`, no network) — two runs with the same option + request sequence produce byte-identical completions, so a \`Reasoner\` built on top respects the library's replay contract.
- \`MockLlmProvider\` dispatches in either \`'queue'\` (default) or \`'match-or-error'\` mode; scripted responses can override usage stats, model, or stop reason; abort-signal handling surfaces \`stopReason: 'abort'\`.

## Test plan
- [x] \`npm run verify\` — format + lint + typecheck + 420 tests (11 new) + build all green.
- [x] 11 new unit tests in \`tests/unit/ports/MockLlmProvider.test.ts\` cover: deterministic replay, per-message token estimation, three budget rejections, abort-signal stub, queue match fallback, queue exhaustion, match-or-error strictness, cached-usage flag.
- [x] \`dist/index.js\` gzip 33.58 kB (vs 32.50 kB before) — under the 35 kB budget; flagged in the PR description per the v1-plan risk row.
- [x] No core tick-pipeline change; this is a pure port + mock addition.

## Notes for review
- Async method body wraps the sync work in \`Promise.resolve().then(...)\` so \`throw new BudgetExceededError(...)\` surfaces as a rejected promise while \`eslint @typescript-eslint/require-await\` stays happy.
- Cache hint is intentionally opaque — just a string key. Provider adapters translate.
- Budget enforcement uses the script's pre-computed \`usage.outputTokens\` (if set) or the crude \`ceil(chars/4)\` estimator, not a real tokenizer. Real adapters should report upstream counts instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)