### PR TITLE
refactor(agent): narrow public surface for the 1.0 freeze

### DIFF
--- a/.changeset/narrow-public-surface.md
+++ b/.changeset/narrow-public-surface.md
@@ -1,0 +1,47 @@
+---
+'agentonomous': major
+---
+
+Narrow the public barrel for the 1.0 freeze. Two changes:
+
+**Removed from `src/index.ts`:**
+
+- `AgentDependencies` type. The direct `new Agent(deps)` constructor is
+  still exported (needed as the `createAgent` return type), but the
+  dependency bag is now internal — consumers go through
+  `createAgent(config)`. Tests inside this repo still reach the
+  interface via a relative `./agent/Agent.js` import.
+
+**Marked `@experimental` (stays public, reshape risk flagged):**
+
+- `AgentModule` interface — reshapes in 1.1 (composable kernel:
+  `requires` / `provides` / `hooks` ordering, `serialize` / `restore`).
+- `ReactiveHandler` interface — same reshape window.
+- `Needs`, `Modifiers`, `AgeModel` class direct constructors — wrapped
+  by per-subsystem modules in 1.1. Consumers should prefer
+  `createAgent({ species: { ... } })` descriptors.
+
+Per the v1 plan §1.0.3, reshaping an `@experimental` symbol is a
+**minor** bump, not major. Adding `@experimental` to an existing
+symbol is likewise a minor bump — no runtime behaviour changed.
+
+Also adds `tests/unit/exports.test.ts`, a CI guard that asserts the
+five-subpath export contract in `package.json` matches the 1.0 freeze
+(core / excalibur / mistreevous / js-son / tfjs) so future renames
+break CI instead of silently shipping.
+
+**Migration:**
+
+```ts
+// Before
+import { Agent, type AgentDependencies } from 'agentonomous';
+const deps: AgentDependencies = { /* … */ };
+const agent = new Agent(deps);
+
+// After
+import { createAgent } from 'agentonomous';
+const agent = createAgent({ id: 'pet', species: /* … */ });
+// Or, if you genuinely need the bag-of-dependencies shape, import
+// from the package's source layout (see STYLE_GUIDE and the v1
+// plan — this is intentionally no longer a public surface).
+```

--- a/src/agent/AgentModule.ts
+++ b/src/agent/AgentModule.ts
@@ -6,6 +6,10 @@ import type { AgentFacade } from './AgentFacade.js';
  * A reactive handler: called for every event that matches its filter.
  * Return value is ignored; any agent state changes must go through the
  * `AgentFacade` verbs.
+ *
+ * @experimental — shape may change in 1.1 when the composable kernel
+ * lands (see `docs/plans/2026-04-19-v1-comprehensive-plan.md#11--composable-kernel`).
+ * Additions to this interface are minor bumps, not major.
  */
 export interface ReactiveHandler {
   /**
@@ -22,8 +26,11 @@ export interface ReactiveHandler {
  * skills, tools, reactive handlers, and event schemas into one installable
  * unit instead of wiring each individually.
  *
- * `Skill` / `Tool` land in M7; this interface already names the slots so
- * later milestones just add concrete implementations.
+ * @experimental — this interface reshapes in 1.1 (composable kernel:
+ * `requires` / `provides` / `hooks` ordering, `serialize` / `restore`).
+ * Additions are minor bumps. Prefer passing a list of `AgentModule`s
+ * through `createAgent({ modules: [...] })` over reaching for the
+ * underlying class directly.
  */
 export interface AgentModule {
   id: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,17 @@ export type { AgentInput, AgentOutput } from './agent/types.js';
 export type { ControlMode } from './agent/ControlMode.js';
 
 // Agent core.
-export { Agent, type AgentDependencies } from './agent/Agent.js';
+//
+// `Agent` is exported because `createAgent` returns one; the direct
+// constructor + `AgentDependencies` are intentionally NOT re-exported —
+// consumers go through `createAgent(config)`. Tests can still reach the
+// raw class via a relative `./agent/Agent.js` import if they need full
+// control over every slot (see `src/agent/Agent.ts` JSDoc).
+//
+// `AgentModule` + `ReactiveHandler` are tagged `@experimental` — the
+// shape reshapes in 1.1 (composable kernel). Treat additions to either
+// as minor bumps, not major.
+export { Agent } from './agent/Agent.js';
 export { createAgent, type CreateAgentConfig } from './agent/createAgent.js';
 export type { AgentFacade } from './agent/AgentFacade.js';
 export type { AgentModule, ReactiveHandler } from './agent/AgentModule.js';

--- a/src/lifecycle/AgeModel.ts
+++ b/src/lifecycle/AgeModel.ts
@@ -27,6 +27,12 @@ export interface AgeModelOptions {
  * stage thresholds (for instance after restoring from a snapshot saved hours
  * ago), every crossed transition is reported in order so downstream emitters
  * can fire all intermediate `LifeStageChanged` events.
+ *
+ * @experimental — the direct constructor is wrapped by a `lifecycle`
+ * module in the 1.1 composable kernel. Prefer
+ * `createAgent({ species: { lifecycle: defineLifecycle(...) } })` over
+ * `new AgeModel(...)`; reach for the class only when you need full
+ * control over the slot (tests and tick-helper extraction do).
  */
 export class AgeModel {
   readonly bornAt: number;

--- a/src/modifiers/Modifiers.ts
+++ b/src/modifiers/Modifiers.ts
@@ -17,6 +17,12 @@ export interface ModifierRemoval {
  * Mood (M5), Skills (M7), and the Reasoner (M7). Stores modifiers by
  * internal key (id + incrementing ordinal) to support `stack` entries
  * that share an id.
+ *
+ * @experimental — the direct constructor is wrapped by a `modifiers`
+ * module in the 1.1 composable kernel. Prefer applying modifiers via
+ * the agent (`facade.applyModifier(...)` / `SkillContext.applyModifier`)
+ * or declaring them on a species descriptor; reach for `new
+ * Modifiers()` only when you need full control over the slot.
  */
 export class Modifiers {
   private readonly entries: { key: string; mod: Modifier }[] = [];

--- a/src/needs/Needs.ts
+++ b/src/needs/Needs.ts
@@ -9,6 +9,11 @@ export type DecayMultiplierFn = (needId: string) => number;
 /**
  * Collection of `Need` values on an agent. Owns decay, urgency, satisfaction,
  * and snapshot/restore for its own slice of state.
+ *
+ * @experimental — the direct constructor is wrapped by a `needs` module
+ * in the 1.1 composable kernel. Prefer `createAgent({ species: { needs:
+ * [...] } })` over `new Needs(...)`; reach for the class only if you
+ * need full control over the slot.
  */
 export class Needs {
   private readonly needs = new Map<string, Need>();

--- a/tests/unit/exports.test.ts
+++ b/tests/unit/exports.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import pkgJson from '../../package.json' with { type: 'json' };
+
+/**
+ * Guards the public subpath-export map against accidental renames. If an
+ * adapter directory moves, `package.json#exports` falls out of sync, or
+ * a consumer-visible entry is dropped, this test fails in CI before the
+ * change lands on `develop`.
+ *
+ * The expected list is the 1.0 contract per
+ * `docs/plans/2026-04-19-v1-comprehensive-plan.md#103--narrow-the-public-surface`.
+ */
+const EXPECTED_SUBPATH_KEYS = [
+  '.',
+  './integrations/excalibur',
+  './cognition/adapters/mistreevous',
+  './cognition/adapters/js-son',
+  './cognition/adapters/tfjs',
+  './package.json',
+] as const;
+
+describe('package.json#exports', () => {
+  it('lists exactly the 1.0 subpath contract', () => {
+    const exports = (pkgJson as { exports: Record<string, unknown> }).exports;
+    const actual = Object.keys(exports).sort();
+    const expected = [...EXPECTED_SUBPATH_KEYS].sort();
+    expect(actual).toEqual(expected);
+  });
+
+  it('each non-metadata subpath advertises both import + types', () => {
+    const exports = (pkgJson as { exports: Record<string, unknown> }).exports;
+    for (const key of EXPECTED_SUBPATH_KEYS) {
+      if (key === './package.json') continue;
+      const entry = exports[key];
+      expect(entry, `subpath ${key} missing from exports map`).toBeTypeOf('object');
+      const e = entry as Record<string, unknown>;
+      expect(typeof e.import, `subpath ${key} missing 'import' field`).toBe('string');
+      expect(typeof e.types, `subpath ${key} missing 'types' field`).toBe('string');
+    }
+  });
+});
+
+describe('public barrel (src/index.ts)', () => {
+  it('does not re-export AgentDependencies (consumers go through createAgent)', async () => {
+    const mod = (await import('../../src/index.js')) as Record<string, unknown>;
+    expect(mod.AgentDependencies).toBeUndefined();
+  });
+
+  it('still exports createAgent + Agent + the determinism ports', async () => {
+    const mod = (await import('../../src/index.js')) as Record<string, unknown>;
+    expect(typeof mod.createAgent).toBe('function');
+    expect(typeof mod.Agent).toBe('function');
+    expect(typeof mod.SeededRng).toBe('function');
+    expect(typeof mod.ManualClock).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- Ships the v1.0.3 item from \`docs/plans/2026-04-19-v1-comprehensive-plan.md\`.
- Removes \`AgentDependencies\` from the public barrel. Consumers go through \`createAgent\`; tests still reach the raw interface via relative imports.
- Tags \`AgentModule\` + \`ReactiveHandler\` + \`Needs\` + \`Modifiers\` + \`AgeModel\` as \`@experimental\` — documented reshape risk for 1.1's composable-kernel work.
- Adds \`tests/unit/exports.test.ts\`: asserts the five-subpath export contract in \`package.json\` and that \`AgentDependencies\` is no longer on the barrel.

## Test plan
- [x] \`npm run verify\` — 414 tests (4 new) + build all green.
- [x] \`dist/index.js\` gzip 32.82 kB (under the 35 kB budget).
- [x] Export resolution test imports \`package.json\` and asserts exactly: \`.\`, \`./integrations/excalibur\`, \`./cognition/adapters/mistreevous\`, \`./cognition/adapters/js-son\`, \`./cognition/adapters/tfjs\`, \`./package.json\` — any drift breaks CI.

## Notes for review
- \`@experimental\` is a JSDoc tag only — TypeScript has no built-in awareness. Typedoc renders it as a callout. Semver contract: reshaping an \`@experimental\` symbol is a minor bump, not major.
- Reminder from the project lead: the 1.0 release itself is on hold while we polish the library + demo further. The major-bump changesets (this PR + PR #65 rename) accumulate until the eventual publish.
- No source-file deletions; this PR is purely a barrel narrowing + TSDoc sweep + new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)