### PR TITLE
docs: audit public surface JSDoc for the 1.0 freeze

### DIFF
--- a/src/agent/AgentFacade.ts
+++ b/src/agent/AgentFacade.ts
@@ -6,16 +6,21 @@ import type { AgentIdentity } from './AgentIdentity.js';
 
 /**
  * Read-only + safe-mutation surface passed to skills, reactive handlers,
- * and modules. Keeps consumers from mutating agent internals in ways that
- * break invariants (e.g., setting need levels directly without going
- * through the `satisfy` verb).
+ * and modules. Prevents consumers from mutating agent internals in ways
+ * that would break invariants (e.g., setting need levels directly
+ * without going through the `satisfy` verb, or emitting events outside
+ * the tick pipeline where they would miss the current `DecisionTrace`).
  *
- * More verbs land in later milestones:
- *   - M3: `satisfyNeed(id, amount)`
- *   - M4: `applyModifier(mod)` / `removeModifier(id)`
- *   - M10: `addMemory(record)`
+ * Reached from three places:
+ *  - a `Skill.execute(params, ctx)` body (via `ctx` — a superset that
+ *    adds `satisfyNeed` / `applyModifier` / `removeModifier` /
+ *    `hasModifier` / `ageSeconds`);
+ *  - a `ReactiveHandler.handle(event, agent)` callback;
+ *  - a module's optional `onInstall(agent)` hook.
  *
- * For M2 it exposes only the immutable read surface + `publishEvent`.
+ * Skill-context verbs beyond this interface are declared on
+ * `SkillContext` so that reactive handlers (which should not
+ * arbitrarily mutate need levels) have a deliberately smaller surface.
  */
 export interface AgentFacade {
   readonly identity: AgentIdentity;

--- a/src/cognition/adapters/tfjs/index.ts
+++ b/src/cognition/adapters/tfjs/index.ts
@@ -1,3 +1,19 @@
+// TensorFlow.js neural-network adapter — import from
+// `agentonomous/cognition/adapters/tfjs` so consumers only pull the
+// `@tensorflow/tfjs-core` + `-layers` peer deps into their bundle when
+// they actually use this reasoner. Ship-side backend packages
+// (`-backend-cpu` / `-backend-wasm` / `-backend-webgl`) are separate
+// optional peers; the consumer picks one and side-effect-imports it
+// before constructing the reasoner.
+//
+// The adapter owns the full model lifecycle: inference (`selectIntention`),
+// seeded training (`train()`), deterministic persistence (`toJSON()` /
+// `fromJSON()`), and disposal (`dispose()`). Under the default CPU
+// backend + a fixed seed it produces byte-identical inference — matching
+// the library's determinism contract. GPU backends (WebGL / WebGPU) are
+// supported for speed but weaken that contract; see the `TfjsReasoner`
+// JSDoc for the full caveat.
+
 export {
   TfjsReasoner,
   TfjsBackendNotRegisteredError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,8 +33,17 @@ export {
 export { type Result, ok, err, isOk, isErr, map, mapErr, andThen, unwrap } from './agent/result.js';
 
 // Events.
+//
+// `DomainEvent` = the shape every event on the bus shares. `EventBusPort`
+// = the publish/subscribe port (consumers can swap in a provider that
+// fans out across windows / web-workers / sim-ecs systems).
+// `InMemoryEventBus` is the default adapter. `InteractionRequestedEvent`
+// is emitted by `agent.interact(verb, params?)` and consumed by the
+// default pet-interaction module; register your own handler on the bus
+// if you route bespoke verbs.
 export type { DomainEvent } from './events/DomainEvent.js';
 export type { EventBusPort } from './events/EventBusPort.js';
+/** Default synchronous pub/sub adapter for a single simulation. */
 export { InMemoryEventBus } from './events/InMemoryEventBus.js';
 export {
   type InteractionRequestedEvent,
@@ -83,7 +92,12 @@ export type { Learner, LearningOutcome } from './cognition/learning/Learner.js';
 /** Learner that ignores outcomes. Default when no learner is wired. */
 export { NoopLearner } from './cognition/learning/NoopLearner.js';
 
-// Tuning constants.
+// Tuning constants — hand-picked defaults that subsystems reach for when
+// a consumer hasn't supplied their own. Exposed so power users can
+// reference the same numbers in custom reasoners / policies / skills.
+// Changes here ripple through the default persona bias, the mood
+// thresholds, and skill effectiveness; tune via species descriptors
+// first and only override these if species tuning isn't enough.
 export {
   MOOD_URGENCY_THRESHOLDS,
   PERSONA_TRAIT_WEIGHTS,
@@ -150,7 +164,15 @@ export type { MoodModel, MoodEvaluationContext } from './mood/MoodModel.js';
 export { DefaultMoodModel } from './mood/DefaultMoodModel.js';
 
 // Control modes (M6).
+//
+// `autonomous` (default) lets cognition drive actions. `remote` hands
+// each tick to a `RemoteController` (multiplayer proxy, LLM controller,
+// or recorded replay). `scripted` consumes a pre-recorded
+// `ScriptedController` queue — the same agent doubles as NPC, bot, or
+// player-proxy without code branching.
+/** Default `RemoteController` backed by an in-memory queue — useful for tests and local proxies. */
 export { InMemoryRemoteController, type RemoteController } from './agent/RemoteController.js';
+/** Default `ScriptedController` that pops `AgentAction` entries from a fixed array in order. */
 export { ArrayScriptedController, type ScriptedController } from './agent/ScriptedController.js';
 
 // Species (M12).


### PR DESCRIPTION
## Summary
- Ships the v1.0.4 item from \`docs/plans/2026-04-19-v1-comprehensive-plan.md\`.
- Adds a concept-line header to the tfjs adapter's \`index.ts\` so all four subpath entries (excalibur / mistreevous / js-son / tfjs) match the same discovery pattern.
- Broadens three barrel section comments (Events, Tuning, Control modes) so identifiers like \`INTERACTION_REQUESTED\` / \`MOOD_URGENCY_THRESHOLDS\` / \`InMemoryRemoteController\` are self-explanatory in IntelliSense without jumping into the source.
- Rewrites \`AgentFacade\` JSDoc — replaces the stale "M2/M3/M4/M10 milestones" roadmap with the three actual call sites and the intentional asymmetry with \`SkillContext\`.

## Test plan
- [x] \`npm run verify\` — 414 tests + build all green.
- [x] No runtime change; no changeset needed.
- [x] \`dist/index.js\` gzip 32.50 kB (unchanged; under the 35 kB budget).

## Notes for review
- This is a docs-only sweep; no exported symbol was added or removed.
- Reminder: the 1.0 release itself is on hold while we keep polishing; these JSDoc updates just make sure the barrel reads clean whenever the publish PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)