### PR TITLE
feat(examples/nurture-pet): loss-delta toast + Untrain button

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6f19e206-9f41-4d74-83ca-15c93838fba3","pid":7084,"acquiredAt":1777063959475}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6f19e206-9f41-4d74-83ca-15c93838fba3","pid":7084,"acquiredAt":1777063959475}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ examples/**/node_modules
 
 graphify-out
 
+.claude/scheduled_tasks.lock

--- a/examples/nurture-pet/index.html
+++ b/examples/nurture-pet/index.html
@@ -487,6 +487,7 @@
         </select>
         <span class="cognition-status" id="cognition-status" data-mode="heuristic">active</span>
         <button id="train-network" type="button" hidden>Train</button>
+        <button id="untrain-network" type="button" hidden>Untrain</button>
       </div>
       <div class="speed">
         <span class="speed-label">Speed</span>

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -280,6 +280,14 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
   const onUntrainClick = async (): Promise<void> => {
     if (!untrainBtn || disposed) return;
     if (activeModeId !== 'learning') return;
+    // Hard gate: while Train is in flight the Untrain button is also
+    // disabled (see onTrainClick), so a user click can't reach here. If
+    // a programmatic caller or stale click slips past, refuse rather
+    // than interleave — Train's trailing `localStorage.setItem(...)`
+    // would otherwise re-persist trained weights after Untrain wipes
+    // them, and the user would see "Reset to baseline ✓" but a reload
+    // would hydrate the trained model.
+    if (pendingTrain) return;
 
     const originalText = untrainBtn.textContent ?? 'Untrain';
     untrainBtn.disabled = true;
@@ -287,19 +295,6 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
     if (trainBtn) trainBtn.disabled = true;
     const myEpoch = ++changeEpoch;
 
-    // If Train is in flight, wait for it to finish before wiping the
-    // snapshot key. Otherwise the pending `localStorage.setItem(...)` at
-    // the tail of `onTrainClick` would re-persist trained weights after
-    // Untrain has cleared them — the user would see "Reset to baseline ✓"
-    // but a reload would still hydrate the trained model.
-    if (pendingTrain) {
-      try {
-        await pendingTrain;
-      } catch {
-        // Train rejections are already surfaced via the train-click
-        // handler; Untrain just needs the persist step to have settled.
-      }
-    }
     // Clear only the tfjs snapshot key — leave the rest of the agent's
     // persisted state alone (this is not a full reset). A fresh
     // `construct()` then rehydrates from the bundled baseline.
@@ -312,11 +307,9 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
 
     const mode = COGNITION_MODES.find((m) => m.id === 'learning');
     if (!mode) {
-      if (!disposed) {
-        untrainBtn.disabled = false;
-        untrainBtn.textContent = originalText;
-        if (trainBtn) trainBtn.disabled = false;
-      }
+      untrainBtn.disabled = false;
+      untrainBtn.textContent = originalText;
+      if (trainBtn) trainBtn.disabled = false;
       return;
     }
 
@@ -329,6 +322,16 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       const previous = activeReasoner;
       agent.setReasoner(reasoner);
       activeReasoner = reasoner;
+      activeModeId = 'learning';
+      // Re-sync the selector + status span: bumping `changeEpoch` above
+      // discarded any in-flight `onChange` work, so if the user had
+      // selected a non-learning mode and clicked Untrain before that
+      // `construct()` resolved, the dropdown could now show the old
+      // non-learning label while the agent is actually running
+      // learning. Snap both to the installed reasoner's reality.
+      if (select.value !== 'learning') select.value = 'learning';
+      status.dataset.mode = 'learning';
+      setTrainVisibility('learning');
       disposeIfOwned(previous);
       flashStatus(status, 'Reset to baseline ✓', TRAINED_FLASH_MS);
     } catch (err) {

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -12,11 +12,15 @@ const TRAINED_FLASH_MS = 1500;
  * heuristic/bdi/bt loads — any reasoner exposing these methods is
  * treated as trainable.
  */
+type TrainResultLike = {
+  finalLoss?: number;
+  history?: { loss?: readonly number[] };
+};
 type TrainableReasoner = {
   train: (
     pairs: Array<{ features: number[]; label: number[] }>,
     opts?: { epochs?: number; learningRate?: number; seed?: number; shuffle?: boolean },
-  ) => Promise<unknown>;
+  ) => Promise<TrainResultLike>;
   toJSON: () => unknown;
   dispose?: () => void;
 };
@@ -113,10 +117,17 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
   }
 
   const trainBtn = document.getElementById('train-network') as HTMLButtonElement | null;
+  const untrainBtn = document.getElementById('untrain-network') as HTMLButtonElement | null;
   const setTrainVisibility = (modeId: CognitionModeSpec['id']): void => {
-    if (!trainBtn) return;
-    if (modeId === 'learning') trainBtn.removeAttribute('hidden');
-    else trainBtn.setAttribute('hidden', '');
+    const show = modeId === 'learning';
+    if (trainBtn) {
+      if (show) trainBtn.removeAttribute('hidden');
+      else trainBtn.setAttribute('hidden', '');
+    }
+    if (untrainBtn) {
+      if (show) untrainBtn.removeAttribute('hidden');
+      else untrainBtn.setAttribute('hidden', '');
+    }
   };
 
   let disposed = false;
@@ -224,7 +235,7 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
         const urgency = 1 - min;
         return { features, label: [urgency] };
       });
-      await reasoner.train!(pairs, {
+      const result = await reasoner.train!(pairs, {
         epochs: TRAIN_EPOCHS,
         learningRate: 0.1,
         seed: Math.floor(trainRng() * 0x7fff_ffff),
@@ -238,7 +249,7 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       } catch {
         // localStorage unavailable — training still succeeds for this session.
       }
-      flashStatus(status, 'Trained ✓', TRAINED_FLASH_MS);
+      flashStatus(status, formatTrainedToast(result), TRAINED_FLASH_MS);
     };
 
     trainingReasoner = reasonerHandle;
@@ -259,6 +270,57 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
     void onTrainClick();
   };
   if (trainBtn) trainBtn.addEventListener('click', onTrainClickWrapped);
+
+  const onUntrainClick = async (): Promise<void> => {
+    if (!untrainBtn || disposed) return;
+    if (activeModeId !== 'learning') return;
+    // Clear only the tfjs snapshot key — leave the rest of the agent's
+    // persisted state alone (this is not a full reset). A fresh
+    // `construct()` then rehydrates from the bundled baseline.
+    try {
+      globalThis.localStorage?.removeItem(`agentonomous/${agent.identity.id}/tfjs-network`);
+    } catch {
+      // localStorage unavailable — the next construct() falls back to
+      // the bundled baseline anyway.
+    }
+
+    const mode = COGNITION_MODES.find((m) => m.id === 'learning');
+    if (!mode) return;
+
+    const originalText = untrainBtn.textContent ?? 'Untrain';
+    untrainBtn.disabled = true;
+    untrainBtn.textContent = 'Resetting…';
+    if (trainBtn) trainBtn.disabled = true;
+    const myEpoch = ++changeEpoch;
+
+    try {
+      const reasoner = await mode.construct();
+      if (disposed || myEpoch !== changeEpoch) {
+        disposeIfOwned(reasoner);
+        return;
+      }
+      const previous = activeReasoner;
+      agent.setReasoner(reasoner);
+      activeReasoner = reasoner;
+      disposeIfOwned(previous);
+      flashStatus(status, 'Reset to baseline ✓', TRAINED_FLASH_MS);
+    } catch (err) {
+      if (disposed || myEpoch !== changeEpoch) return;
+      // eslint-disable-next-line no-console -- user-visible diagnostic.
+      console.error('cognitionSwitcher: untrain failed', err);
+      flashStatus(status, 'Untrain failed', TRAINED_FLASH_MS);
+    } finally {
+      if (!disposed) {
+        untrainBtn.disabled = false;
+        untrainBtn.textContent = originalText;
+        if (trainBtn) trainBtn.disabled = false;
+      }
+    }
+  };
+  const onUntrainClickWrapped = (): void => {
+    void onUntrainClick();
+  };
+  if (untrainBtn) untrainBtn.addEventListener('click', onUntrainClickWrapped);
 
   void Promise.all(
     COGNITION_MODES.map(async (mode: CognitionModeSpec) => {
@@ -282,10 +344,31 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       disposed = true;
       select.removeEventListener('change', onChangeWrapped);
       if (trainBtn) trainBtn.removeEventListener('click', onTrainClickWrapped);
+      if (untrainBtn) untrainBtn.removeEventListener('click', onUntrainClickWrapped);
       disposeIfOwned(activeReasoner);
       activeReasoner = null;
     },
   };
+}
+
+/**
+ * Render the post-train toast. Prefers the loss delta ("0.42 → 0.08")
+ * when both the initial-epoch loss and the final loss are reported; falls
+ * back to a bare checkmark if the training result is sparse.
+ */
+function formatTrainedToast(result: TrainResultLike): string {
+  const history = result.history?.loss;
+  const initialLoss = history && history.length > 0 ? history[0] : undefined;
+  const finalLoss = result.finalLoss ?? (history ? history[history.length - 1] : undefined);
+  if (
+    typeof initialLoss === 'number' &&
+    Number.isFinite(initialLoss) &&
+    typeof finalLoss === 'number' &&
+    Number.isFinite(finalLoss)
+  ) {
+    return `Trained ✓ — loss ${initialLoss.toFixed(2)} → ${finalLoss.toFixed(2)}`;
+  }
+  return 'Trained ✓';
 }
 
 /**

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -278,22 +278,38 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
   if (trainBtn) trainBtn.addEventListener('click', onTrainClickWrapped);
 
   const onUntrainClick = async (): Promise<void> => {
-    if (!untrainBtn || disposed) return;
+    // Hard gate first, all preconditions on a single line so a reader
+    // can see at a glance that Untrain is BLOCKED while Train is in
+    // flight. The Train handler also disables the Untrain button when
+    // it starts, but a programmatic caller or stale click could still
+    // reach here — refuse rather than interleave, or Train's trailing
+    // `localStorage.setItem(...)` would re-persist trained weights
+    // after Untrain wipes them.
+    if (!untrainBtn || disposed || pendingTrain !== null) return;
     if (activeModeId !== 'learning') return;
-    // Hard gate: while Train is in flight the Untrain button is also
-    // disabled (see onTrainClick), so a user click can't reach here. If
-    // a programmatic caller or stale click slips past, refuse rather
-    // than interleave — Train's trailing `localStorage.setItem(...)`
-    // would otherwise re-persist trained weights after Untrain wipes
-    // them, and the user would see "Reset to baseline ✓" but a reload
-    // would hydrate the trained model.
-    if (pendingTrain) return;
 
     const originalText = untrainBtn.textContent ?? 'Untrain';
     untrainBtn.disabled = true;
     untrainBtn.textContent = 'Resetting…';
     if (trainBtn) trainBtn.disabled = true;
     const myEpoch = ++changeEpoch;
+
+    // Optimistically snap the selector / status / train-button
+    // visibility to `'learning'` right now. Bumping `changeEpoch`
+    // discarded any in-flight `onChange` work — including a non-
+    // learning mode selection the user may have clicked just before
+    // Untrain — so the UI would otherwise keep showing that cancelled
+    // mode's label while the agent is running learning.
+    if (select.value !== 'learning') select.value = 'learning';
+    status.dataset.mode = 'learning';
+    setTrainVisibility('learning');
+    // `flashStatus` captures `status.textContent` at call time as the
+    // value to restore after the timeout. If a Train toast (`"Trained
+    // ✓ …"`) is still on-screen when Untrain fires, it would be
+    // restored after our own toast times out — making the status claim
+    // the model is trained even after a successful reset. Snap back to
+    // the canonical "active" text now so flashStatus captures that.
+    status.textContent = 'active';
 
     // Clear only the tfjs snapshot key — leave the rest of the agent's
     // persisted state alone (this is not a full reset). A fresh
@@ -323,15 +339,6 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       agent.setReasoner(reasoner);
       activeReasoner = reasoner;
       activeModeId = 'learning';
-      // Re-sync the selector + status span: bumping `changeEpoch` above
-      // discarded any in-flight `onChange` work, so if the user had
-      // selected a non-learning mode and clicked Untrain before that
-      // `construct()` resolved, the dropdown could now show the old
-      // non-learning label while the agent is actually running
-      // learning. Snap both to the installed reasoner's reality.
-      if (select.value !== 'learning') select.value = 'learning';
-      status.dataset.mode = 'learning';
-      setTrainVisibility('learning');
       disposeIfOwned(previous);
       flashStatus(status, 'Reset to baseline ✓', TRAINED_FLASH_MS);
     } catch (err) {

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -274,6 +274,26 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
   const onUntrainClick = async (): Promise<void> => {
     if (!untrainBtn || disposed) return;
     if (activeModeId !== 'learning') return;
+
+    const originalText = untrainBtn.textContent ?? 'Untrain';
+    untrainBtn.disabled = true;
+    untrainBtn.textContent = 'Resetting…';
+    if (trainBtn) trainBtn.disabled = true;
+    const myEpoch = ++changeEpoch;
+
+    // If Train is in flight, wait for it to finish before wiping the
+    // snapshot key. Otherwise the pending `localStorage.setItem(...)` at
+    // the tail of `onTrainClick` would re-persist trained weights after
+    // Untrain has cleared them — the user would see "Reset to baseline ✓"
+    // but a reload would still hydrate the trained model.
+    if (pendingTrain) {
+      try {
+        await pendingTrain;
+      } catch {
+        // Train rejections are already surfaced via the train-click
+        // handler; Untrain just needs the persist step to have settled.
+      }
+    }
     // Clear only the tfjs snapshot key — leave the rest of the agent's
     // persisted state alone (this is not a full reset). A fresh
     // `construct()` then rehydrates from the bundled baseline.
@@ -285,13 +305,14 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
     }
 
     const mode = COGNITION_MODES.find((m) => m.id === 'learning');
-    if (!mode) return;
-
-    const originalText = untrainBtn.textContent ?? 'Untrain';
-    untrainBtn.disabled = true;
-    untrainBtn.textContent = 'Resetting…';
-    if (trainBtn) trainBtn.disabled = true;
-    const myEpoch = ++changeEpoch;
+    if (!mode) {
+      if (!disposed) {
+        untrainBtn.disabled = false;
+        untrainBtn.textContent = originalText;
+        if (trainBtn) trainBtn.disabled = false;
+      }
+      return;
+    }
 
     try {
       const reasoner = await mode.construct();

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -222,12 +222,16 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
     trainBtn.textContent = 'Training…';
     // Lock Untrain out of the UI for the duration of the train so the
     // two handlers can't race on the `localStorage.setItem(...)` tail
-    // below. (Untrain also awaits `pendingTrain` as a belt-and-
-    // suspenders guard for programmatic callers.)
+    // below.
     if (untrainBtn) untrainBtn.disabled = true;
-    await new Promise<void>((r) => setTimeout(r, 0));
 
     const run = async (): Promise<void> => {
+      // Yield once so the browser paints the "Training…" label before
+      // the synchronous `model.fit` bookkeeping inside the reasoner
+      // begins. The yield now lives INSIDE `run`, after
+      // `pendingTrain` is set — so Untrain's `pendingTrain !== null`
+      // gate can't be bypassed during this microtask window.
+      await new Promise<void>((r) => setTimeout(r, 0));
       if (disposed) return;
       const pairs = Array.from({ length: TRAIN_PAIR_COUNT }, () => {
         const features: number[] = [];
@@ -257,6 +261,9 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       flashStatus(status, formatTrainedToast(result), TRAINED_FLASH_MS);
     };
 
+    // Mark training as in-flight BEFORE any yield so Untrain's
+    // `pendingTrain !== null` guard catches the race window between
+    // the click and the first microtask tick.
     trainingReasoner = reasonerHandle;
     const promise = run();
     pendingTrain = promise.catch(() => undefined);

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -220,6 +220,11 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
     const originalText = trainBtn.textContent ?? 'Train';
     trainBtn.disabled = true;
     trainBtn.textContent = 'Training…';
+    // Lock Untrain out of the UI for the duration of the train so the
+    // two handlers can't race on the `localStorage.setItem(...)` tail
+    // below. (Untrain also awaits `pendingTrain` as a belt-and-
+    // suspenders guard for programmatic callers.)
+    if (untrainBtn) untrainBtn.disabled = true;
     await new Promise<void>((r) => setTimeout(r, 0));
 
     const run = async (): Promise<void> => {
@@ -264,6 +269,7 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       }
       trainBtn.disabled = false;
       trainBtn.textContent = originalText;
+      if (untrainBtn) untrainBtn.disabled = false;
     }
   };
   const onTrainClickWrapped = (): void => {
@@ -331,11 +337,12 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       console.error('cognitionSwitcher: untrain failed', err);
       flashStatus(status, 'Untrain failed', TRAINED_FLASH_MS);
     } finally {
-      if (!disposed) {
-        untrainBtn.disabled = false;
-        untrainBtn.textContent = originalText;
-        if (trainBtn) trainBtn.disabled = false;
-      }
+      // Always restore button state so a `dispose()` that races with an
+      // in-flight Untrain doesn't leave the DOM stuck on "Resetting…"
+      // for the next mount (DOM elements outlive the closure).
+      untrainBtn.disabled = false;
+      untrainBtn.textContent = originalText;
+      if (trainBtn) trainBtn.disabled = false;
     }
   };
   const onUntrainClickWrapped = (): void => {

--- a/tests/examples/learningMode.train.test.ts
+++ b/tests/examples/learningMode.train.test.ts
@@ -50,6 +50,7 @@ function renderRoot(): HTMLElement {
     '<select id="cognition-mode-select"></select>' +
     '<span id="cognition-status" data-mode="heuristic">active</span>' +
     '<button id="train-network" type="button" hidden>Train</button>' +
+    '<button id="untrain-network" type="button" hidden>Untrain</button>' +
     '</div>' +
     '<button id="reset-button" type="button">Reset</button>';
   return document.querySelector<HTMLElement>('#cognition-switcher')!;
@@ -159,6 +160,50 @@ describe('Train button visibility', () => {
     await selectMode('bt');
     const btn = doc.getElementById('train-network')!;
     expect(btn.hasAttribute('hidden')).toBe(true);
+  });
+});
+
+describe('Untrain button', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('shares visibility with the Train button across mode switches', async () => {
+    const { document: doc, selectMode } = await mountDemo();
+    const untrain = doc.getElementById('untrain-network')!;
+    expect(untrain.hasAttribute('hidden')).toBe(true);
+
+    await selectMode('learning');
+    expect(untrain.hasAttribute('hidden')).toBe(false);
+
+    await selectMode('heuristic');
+    expect(untrain.hasAttribute('hidden')).toBe(true);
+  });
+
+  it('clears the persisted tfjs snapshot and swaps in a fresh reasoner', async () => {
+    const agentId = 'test-pet';
+    localStorage.setItem(
+      `agentonomous/${agentId}/tfjs-network`,
+      JSON.stringify({ version: 1, topology: {}, weights: '', weightsShapes: [] }),
+    );
+
+    const { document: doc, selectMode, fakeAgent } = await mountDemo({ agentId });
+    await selectMode('learning');
+    const initialSetCount = fakeAgent.setReasoner.mock.calls.length;
+    const untrainBtn = doc.getElementById('untrain-network') as HTMLButtonElement;
+
+    untrainBtn.click();
+    await waitForTrainingFlush(untrainBtn);
+
+    expect(localStorage.getItem(`agentonomous/${agentId}/tfjs-network`)).toBeNull();
+    expect(fakeAgent.setReasoner.mock.calls.length).toBeGreaterThan(initialSetCount);
+    expect(untrainBtn.textContent).toBe('Untrain');
+    expect(untrainBtn.disabled).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
Closes \`docs/specs/2026-04-24-post-tfjs-improvements.md\` §2.3 and §2.5.

- **§2.3 — loss-delta toast.** After Train completes, the status flash reads "Trained ✓ — loss 0.42 → 0.08" by threading \`TfjsReasoner.train()\`'s \`history.loss\` + \`finalLoss\` back to the formatter. Falls back to the bare "Trained ✓" when training returns a sparse result.
- **§2.5 — Untrain button.** Sits next to Train in the HUD, visible only in Learning mode. Clears \`agentonomous/<agentId>/tfjs-network\` from localStorage, re-runs the learning-mode \`construct()\` to rehydrate from the bundled baseline, and disposes the outgoing reasoner. Deliberately narrower than the existing Reset button (which wipes the whole agent).

Demo-only PR — no library change, no changeset.

## Test plan
- [x] \`npm run verify\` — 412 vitest tests (2 new) + build green.
- [x] \`index.js\` / subpath gzip budgets unchanged.
- [x] Reuses the existing \`disposeIfOwned\` + \`changeEpoch\` guards so a user swapping modes mid-reset doesn't end up with a stale reasoner or leaked tensors.
- [ ] Manual: open demo, switch to Learning, click Train (toast reports loss delta), click Untrain (status flashes "Reset to baseline ✓", train button works again afterwards).

## Notes for review
- Untrain does **not** call \`location.reload()\` — that's the Reset button's job. Untrain is a narrower undo of the training step only.
- The Train/Untrain pair ignores its own error paths gracefully: localStorage unavailable, \`construct()\` rejecting mid-reset, or the user swapping modes while either handler is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)