### PR TITLE
feat(cognition/adapters/tfjs): TfjsLearner closes the Learner seam

### DIFF
--- a/.changeset/tfjs-learner.md
+++ b/.changeset/tfjs-learner.md
@@ -1,0 +1,45 @@
+---
+'agentonomous': minor
+---
+
+Add `TfjsLearner` — the first real `Learner` implementation. Closes
+Stage 8 (score) of the tick pipeline as a working reinforcement seam.
+
+Ships as a sibling of `TfjsReasoner` under the same subpath:
+
+```ts
+import { TfjsReasoner, TfjsLearner } from 'agentonomous/cognition/adapters/tfjs';
+
+const reasoner = await TfjsReasoner.fromJSON(snapshot, { featuresOf, interpret });
+const learner = new TfjsLearner({
+  reasoner,
+  toTrainingPair: (outcome) => {
+    if (outcome.reward === undefined) return null;
+    return { features: projectFeatures(outcome), label: [outcome.reward] };
+  },
+  batchSize: 50,
+  onBatchTrained: ({ finalLoss }) => console.log('batch loss', finalLoss),
+});
+const agent = createAgent({ id, species, reasoner, learner });
+```
+
+Behaviour:
+
+- `score(outcome)` buffers one `LearningOutcome` and returns immediately
+  (no tick-loop blocking).
+- Once the buffer reaches `batchSize`, the learner kicks off a
+  background `reasoner.train(pairs, { epochs, seed })` call.
+- `flush()` trains on whatever the buffer holds right now, waiting on
+  any in-flight background batch first.
+- `bufferCapacity` caps the buffer; oldest entries drop FIFO once
+  exceeded (prevents unbounded memory growth on a long-running agent).
+- `onTrainError` surfaces background-train failures without tearing
+  down the tick pipeline.
+- `dispose()` stops accepting new outcomes.
+
+Determinism contract: no RNG, no `Date.now()`, no `setTimeout` /
+`setInterval`. `trainSeed` must be a stable consumer-supplied value
+(defaults to `1`) — never `Math.random()` — or replays drift.
+
+Addresses `docs/specs/2026-04-24-post-tfjs-improvements.md` §1.1.
+`NoopLearner` stays as the zero-config default; `TfjsLearner` is opt-in.

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
       "name": "dist/cognition/adapters/tfjs/index.js (gzip)",
       "path": "dist/cognition/adapters/tfjs/index.js",
       "gzip": true,
-      "limit": "5 KB"
+      "limit": "7 KB"
     }
   ],
   "lint-staged": {

--- a/src/cognition/adapters/tfjs/TfjsLearner.ts
+++ b/src/cognition/adapters/tfjs/TfjsLearner.ts
@@ -1,0 +1,205 @@
+import type { Learner, LearningOutcome } from '../../learning/Learner.js';
+import type { TrainOptions, TrainResult } from './TfjsReasoner.js';
+
+/**
+ * Minimum training surface the learner actually uses. `TfjsReasoner`
+ * satisfies this, but tests can pass a fake without a live tfjs backend.
+ */
+export interface TrainableReasoner<In, Out> {
+  train(pairs: Array<{ features: In; label: Out }>, opts?: TrainOptions): Promise<TrainResult>;
+}
+
+/**
+ * Construction options for `TfjsLearner`.
+ */
+export interface TfjsLearnerOptions<In, Out> {
+  /**
+   * The reasoner whose weights this learner trains. Usually a
+   * `TfjsReasoner`, but any object implementing `train(pairs, opts)` with
+   * the tfjs signature works — useful for tests + alt-backend adapters.
+   */
+  readonly reasoner: TrainableReasoner<In, Out>;
+  /**
+   * Project one `LearningOutcome` into a training pair. Return `null` to
+   * skip the outcome (e.g. when `reward` is `undefined`, or when the
+   * intention / action shape doesn't map to a meaningful feature vector).
+   */
+  readonly toTrainingPair: (outcome: LearningOutcome) => { features: In; label: Out } | null;
+  /**
+   * Train once the buffer accumulates this many eligible outcomes. The
+   * learner pops exactly this many pairs off the head of the buffer per
+   * batch; anything beyond stays for the next batch. Default: `50`.
+   */
+  readonly batchSize?: number;
+  /**
+   * Cap on the in-memory buffer. Oldest entries drop FIFO after this.
+   * Default: `batchSize * 4` — enough slack to absorb a short burst of
+   * outcomes while one batch is already training. Set to `Infinity` to
+   * disable the cap (not recommended for long-running agents).
+   */
+  readonly bufferCapacity?: number;
+  /**
+   * Epochs passed through to `reasoner.train()`. Default: `20`.
+   */
+  readonly epochs?: number;
+  /**
+   * Deterministic shuffle seed passed through to `reasoner.train()`.
+   * Default: `1`. In a multi-agent simulation you want this to be a
+   * stable per-learner value — never `Date.now()` or `Math.random()`,
+   * or replays drift.
+   */
+  readonly trainSeed?: number;
+  /**
+   * Fires after each batch completes training. Receives the
+   * `TrainResult` the reasoner returned. Useful for sparkline / toast
+   * wiring in demos.
+   */
+  readonly onBatchTrained?: (result: TrainResult) => void;
+  /**
+   * Fires when an error bubbles out of a background train triggered by
+   * `score()`. The error is swallowed by the learner itself so a single
+   * failed batch doesn't tear down the tick pipeline; the hook lets
+   * consumers log or surface it. Synchronous calls made via `flush()`
+   * still reject normally.
+   */
+  readonly onTrainError?: (error: unknown) => void;
+}
+
+/**
+ * Closes Stage 8 (score) of the tick pipeline by turning `Learner` into
+ * a real reinforcement seam: buffer `LearningOutcome`s, batch-train a
+ * `TfjsReasoner` (or any `TrainableReasoner`-shaped object) every N
+ * outcomes, and stay out of the tick loop's critical path by running
+ * training asynchronously in the background.
+ *
+ * This is the "real" implementation that `NoopLearner`'s JSDoc pointed
+ * at — the port was exposed in Phase A so the tick pipeline had a stable
+ * Stage 8 seam; `TfjsLearner` is what consumers plug in when they want
+ * the agent to actually learn.
+ *
+ * Determinism contract:
+ * - `score()` never touches the agent's RNG stream. The buffer is a
+ *   plain array; training draws its shuffle seed from `trainSeed` (a
+ *   stable consumer-supplied value).
+ * - `score()` never calls `Date.now()` or `setTimeout` / `setInterval`.
+ *   Background training kicks off via a Promise chain; there is no
+ *   wall-clock scheduler.
+ * - Under a fixed `SeededRng` + `ManualClock`, the sequence of
+ *   `LearningOutcome`s handed to `score()` is itself deterministic, so
+ *   the batch boundaries, training pairs, and resulting weight updates
+ *   are all reproducible.
+ *
+ * Typical wiring from `createAgent`:
+ *
+ * ```ts
+ * const reasoner = await TfjsReasoner.fromJSON(snapshot, { featuresOf, interpret });
+ * const learner = new TfjsLearner({
+ *   reasoner,
+ *   toTrainingPair: (o) => {
+ *     if (o.reward === undefined) return null;
+ *     return { features: projectOutcomeFeatures(o), label: [o.reward] };
+ *   },
+ *   batchSize: 50,
+ *   onBatchTrained: (r) => console.log('batch loss', r.finalLoss),
+ * });
+ * const agent = createAgent({ id, species, reasoner, learner });
+ * ```
+ *
+ * Call `flush()` at end-of-episode / save-game boundaries to drain the
+ * buffer even if it hasn't hit `batchSize`.
+ */
+export class TfjsLearner<In = unknown, Out = unknown> implements Learner {
+  private readonly buffer: Array<{ features: In; label: Out }> = [];
+  private inflight: Promise<TrainResult | null> | null = null;
+  private disposed = false;
+
+  constructor(private readonly opts: TfjsLearnerOptions<In, Out>) {}
+
+  /**
+   * Stage-8 hook. Projects the outcome into a training pair (consumer-
+   * supplied) and buffers it. Kicks off a background training run once
+   * the buffer reaches `batchSize`.
+   */
+  score(outcome: LearningOutcome): void {
+    if (this.disposed) return;
+    const pair = this.opts.toTrainingPair(outcome);
+    if (pair === null) return;
+    this.buffer.push(pair);
+    const cap = this.capacity();
+    while (this.buffer.length > cap) this.buffer.shift();
+    if (this.buffer.length >= this.batchSize() && this.inflight === null) {
+      void this.trainBackground();
+    }
+  }
+
+  /**
+   * Force a training batch on whatever the buffer currently holds, even
+   * if it hasn't hit `batchSize`. Waits on any already-inflight batch
+   * first so the in-flight run's outcome isn't lost. Returns `null` when
+   * the buffer is empty.
+   */
+  async flush(): Promise<TrainResult | null> {
+    if (this.disposed) return null;
+    if (this.inflight !== null) await this.inflight;
+    if (this.buffer.length === 0) return null;
+    return this.runTrain();
+  }
+
+  /**
+   * True if a background batch is currently training. Useful for demos
+   * that want to flag the reasoner as "busy" in the UI.
+   */
+  isTraining(): boolean {
+    return this.inflight !== null;
+  }
+
+  /**
+   * Current buffered-outcome count. Observable for demos / tests.
+   */
+  bufferedCount(): number {
+    return this.buffer.length;
+  }
+
+  /**
+   * Drop the buffer and mark the learner inert. Any in-flight background
+   * training is left to complete on its own (cancelling a `model.fit`
+   * mid-batch is not safe) — but `score()` calls after `dispose()`
+   * no-op, so no new batches start.
+   */
+  dispose(): void {
+    this.disposed = true;
+    this.buffer.length = 0;
+  }
+
+  private batchSize(): number {
+    return this.opts.batchSize ?? 50;
+  }
+
+  private capacity(): number {
+    return this.opts.bufferCapacity ?? this.batchSize() * 4;
+  }
+
+  private async trainBackground(): Promise<void> {
+    const promise = this.runTrain().catch((err: unknown) => {
+      this.opts.onTrainError?.(err);
+      return null;
+    });
+    this.inflight = promise;
+    try {
+      await promise;
+    } finally {
+      this.inflight = null;
+    }
+  }
+
+  private async runTrain(): Promise<TrainResult | null> {
+    if (this.buffer.length === 0) return null;
+    const batch = this.buffer.splice(0, this.batchSize());
+    const result = await this.opts.reasoner.train(batch, {
+      epochs: this.opts.epochs ?? 20,
+      seed: this.opts.trainSeed ?? 1,
+    });
+    this.opts.onBatchTrained?.(result);
+    return result;
+  }
+}

--- a/src/cognition/adapters/tfjs/TfjsLearner.ts
+++ b/src/cognition/adapters/tfjs/TfjsLearner.ts
@@ -127,9 +127,7 @@ export class TfjsLearner<In = unknown, Out = unknown> implements Learner {
     this.buffer.push(pair);
     const cap = this.capacity();
     while (this.buffer.length > cap) this.buffer.shift();
-    if (this.buffer.length >= this.batchSize() && this.inflight === null) {
-      void this.trainBackground();
-    }
+    this.maybeScheduleTrain();
   }
 
   /**
@@ -172,11 +170,30 @@ export class TfjsLearner<In = unknown, Out = unknown> implements Learner {
   }
 
   private batchSize(): number {
-    return this.opts.batchSize ?? 50;
+    // Clamp to ≥ 1 so a caller-supplied `batchSize: 0` or a negative
+    // value doesn't turn `score()` into a no-op or `runTrain` into an
+    // infinite-zero-slice loop.
+    return Math.max(1, this.opts.batchSize ?? 50);
   }
 
   private capacity(): number {
-    return this.opts.bufferCapacity ?? this.batchSize() * 4;
+    // Clamp to ≥ 0 so a negative `bufferCapacity` (or a negative
+    // derived default) can't turn the buffer-trim loop into a hang —
+    // `buffer.length > cap` would stay true at 0 when `cap` is negative.
+    return Math.max(0, this.opts.bufferCapacity ?? this.batchSize() * 4);
+  }
+
+  /**
+   * Start a background train if the buffer has enough pairs and no
+   * training is currently running. Called both from `score()` and from
+   * the tail of a previous `trainBackground()` run so consecutive full
+   * batches drain without the caller having to invoke `flush()`.
+   */
+  private maybeScheduleTrain(): void {
+    if (this.disposed) return;
+    if (this.inflight !== null) return;
+    if (this.buffer.length < this.batchSize()) return;
+    void this.trainBackground();
   }
 
   private async trainBackground(): Promise<void> {
@@ -189,6 +206,8 @@ export class TfjsLearner<In = unknown, Out = unknown> implements Learner {
       await promise;
     } finally {
       this.inflight = null;
+      // Drain any batches that queued up while this one was training.
+      this.maybeScheduleTrain();
     }
   }
 

--- a/src/cognition/adapters/tfjs/TfjsLearner.ts
+++ b/src/cognition/adapters/tfjs/TfjsLearner.ts
@@ -138,13 +138,21 @@ export class TfjsLearner<In = unknown, Out = unknown> implements Learner {
    */
   async flush(): Promise<TrainResult | null> {
     if (this.disposed) return null;
-    if (this.inflight !== null) await this.inflight;
+    // Loop in case an earlier in-flight batch's drain-tail kicked off
+    // another `trainBackground()` while we were awaiting it. Each
+    // iteration must re-check `inflight`; otherwise `flush()` could
+    // start `runTrain()` in parallel with that newly-scheduled
+    // background batch — overlapping `model.fit` calls on the same
+    // reasoner are a nondeterminism / backend-error footgun.
+    while (this.inflight !== null) {
+      await this.inflight;
+      if (this.disposed) return null;
+    }
     if (this.buffer.length === 0) return null;
     // Mark as in-flight for the duration of the forced train so a
-    // concurrent `score()` can't fire `trainBackground()` in parallel
-    // on the same reasoner — overlapping `model.fit` calls are a
-    // nondeterminism / backend-error footgun. `isTraining()` also
-    // reports true here, matching the auto-batch path.
+    // concurrent `score()` can't fire `trainBackground()` either.
+    // `isTraining()` also reports true here, matching the auto-batch
+    // path.
     const promise = this.runTrain();
     this.inflight = promise.then(
       () => null,
@@ -198,10 +206,16 @@ export class TfjsLearner<In = unknown, Out = unknown> implements Learner {
   }
 
   private capacity(): number {
-    // Same NaN-safety as `batchSize()` + clamp to ≥ 0 so a negative
-    // `bufferCapacity` (or a negative derived default) can't turn the
-    // buffer-trim loop into a hang at `buffer.length > cap === -n`.
+    // Three-way coercion:
+    //  - `Infinity` is the documented escape hatch for "no cap" — keep
+    //    it as-is so the trim loop's `length > Infinity` is always
+    //    false and nothing ever drops.
+    //  - Any other non-finite value (NaN / -Infinity) falls back to
+    //    the derived default.
+    //  - Finite values are truncated and clamped to ≥ 0 so a negative
+    //    cap can't turn `length > -n` into a hang.
     const raw = this.opts.bufferCapacity;
+    if (raw === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
     const n =
       typeof raw === 'number' && Number.isFinite(raw) ? Math.trunc(raw) : this.batchSize() * 4;
     return Math.max(0, n);

--- a/src/cognition/adapters/tfjs/TfjsLearner.ts
+++ b/src/cognition/adapters/tfjs/TfjsLearner.ts
@@ -140,7 +140,24 @@ export class TfjsLearner<In = unknown, Out = unknown> implements Learner {
     if (this.disposed) return null;
     if (this.inflight !== null) await this.inflight;
     if (this.buffer.length === 0) return null;
-    return this.runTrain();
+    // Mark as in-flight for the duration of the forced train so a
+    // concurrent `score()` can't fire `trainBackground()` in parallel
+    // on the same reasoner — overlapping `model.fit` calls are a
+    // nondeterminism / backend-error footgun. `isTraining()` also
+    // reports true here, matching the auto-batch path.
+    const promise = this.runTrain();
+    this.inflight = promise.then(
+      () => null,
+      () => null,
+    );
+    try {
+      return await promise;
+    } finally {
+      this.inflight = null;
+      // Same drain-tail as `trainBackground`: if more pairs queued up
+      // during this flush, schedule the next batch automatically.
+      this.maybeScheduleTrain();
+    }
   }
 
   /**
@@ -170,17 +187,24 @@ export class TfjsLearner<In = unknown, Out = unknown> implements Learner {
   }
 
   private batchSize(): number {
-    // Clamp to ≥ 1 so a caller-supplied `batchSize: 0` or a negative
-    // value doesn't turn `score()` into a no-op or `runTrain` into an
-    // infinite-zero-slice loop.
-    return Math.max(1, this.opts.batchSize ?? 50);
+    // Normalise the caller-supplied value before clamping: `Math.max`
+    // propagates NaN (a common `Number(envVar)` result), and a NaN
+    // batch size would turn the `<` guard in `maybeScheduleTrain`
+    // into a no-op and make `splice(0, NaN)` remove zero items — the
+    // learner would loop forever scheduling empty batches.
+    const raw = this.opts.batchSize;
+    const n = typeof raw === 'number' && Number.isFinite(raw) ? raw : 50;
+    return Math.max(1, Math.trunc(n));
   }
 
   private capacity(): number {
-    // Clamp to ≥ 0 so a negative `bufferCapacity` (or a negative
-    // derived default) can't turn the buffer-trim loop into a hang —
-    // `buffer.length > cap` would stay true at 0 when `cap` is negative.
-    return Math.max(0, this.opts.bufferCapacity ?? this.batchSize() * 4);
+    // Same NaN-safety as `batchSize()` + clamp to ≥ 0 so a negative
+    // `bufferCapacity` (or a negative derived default) can't turn the
+    // buffer-trim loop into a hang at `buffer.length > cap === -n`.
+    const raw = this.opts.bufferCapacity;
+    const n =
+      typeof raw === 'number' && Number.isFinite(raw) ? Math.trunc(raw) : this.batchSize() * 4;
+    return Math.max(0, n);
   }
 
   /**

--- a/src/cognition/adapters/tfjs/index.ts
+++ b/src/cognition/adapters/tfjs/index.ts
@@ -7,3 +7,4 @@ export {
   type TrainResult,
 } from './TfjsReasoner.js';
 export { type TfjsSnapshot } from './TfjsSnapshot.js';
+export { TfjsLearner, type TfjsLearnerOptions, type TrainableReasoner } from './TfjsLearner.js';

--- a/tests/unit/cognition/adapters/TfjsLearner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsLearner.test.ts
@@ -263,6 +263,67 @@ describe('TfjsLearner', () => {
     expect(fake.calls[0]?.pairs).toHaveLength(1);
   });
 
+  it('sanitises NaN batchSize / bufferCapacity to defaults', async () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: Number.NaN,
+      bufferCapacity: Number.NaN,
+    });
+    // Default batchSize=50, so one pair should buffer rather than
+    // triggering an empty-batch training loop.
+    learner.score(outcome(0.1));
+    expect(learner.bufferedCount()).toBe(1);
+    expect(fake.calls).toHaveLength(0);
+
+    // flush() trains the single pair — and crucially doesn't hang.
+    await learner.flush();
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]?.pairs).toHaveLength(1);
+  });
+
+  it('flush() marks isTraining() true while training and blocks concurrent batches', async () => {
+    let resolveGate!: () => void;
+    const gate = new Promise<void>((r) => {
+      resolveGate = r;
+    });
+    const slowFake: {
+      calls: number;
+      train: (
+        pairs: ReadonlyArray<{ features: number[]; label: number[] }>,
+      ) => Promise<TrainResult>;
+    } = {
+      calls: 0,
+      train(pairs) {
+        slowFake.calls++;
+        return gate.then(() => ({ finalLoss: 1 / pairs.length, history: { loss: [0.5] } }));
+      },
+    };
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: slowFake,
+      toTrainingPair: project,
+      batchSize: 10,
+    });
+
+    // Two pairs below the batchSize so auto-train never kicks in.
+    learner.score(outcome(0.1));
+    learner.score(outcome(0.2));
+
+    const flushPromise = learner.flush();
+    // Immediately after flush() starts, isTraining() must report true
+    // and a concurrent burst that fills the buffer must NOT kick off a
+    // second background train in parallel.
+    expect(learner.isTraining()).toBe(true);
+    for (let i = 0; i < 15; i++) learner.score(outcome(i / 100));
+    expect(slowFake.calls).toBe(1);
+
+    resolveGate();
+    await flushPromise;
+    // The drain-tail then picks up the queued batches.
+    expect(slowFake.calls).toBeGreaterThan(1);
+  });
+
   it('dispose() stops accepting new outcomes', () => {
     const fake = makeFakeReasoner();
     const learner = new TfjsLearner<number[], number[]>({

--- a/tests/unit/cognition/adapters/TfjsLearner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsLearner.test.ts
@@ -180,6 +180,89 @@ describe('TfjsLearner', () => {
     expect(learner.isTraining()).toBe(false);
   });
 
+  it('drains queued batches after an in-flight train completes', async () => {
+    let resolveFirst!: () => void;
+    const firstBlocked = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+    let callCount = 0;
+    const slowFake: {
+      calls: Array<{ pairs: Array<{ features: number[]; label: number[] }> }>;
+      train: (
+        pairs: ReadonlyArray<{ features: number[]; label: number[] }>,
+      ) => Promise<TrainResult>;
+    } = {
+      calls: [],
+      train(pairs) {
+        const index = callCount++;
+        slowFake.calls.push({
+          pairs: pairs.map((p) => ({ features: [...p.features], label: [...p.label] })),
+        });
+        const gate = index === 0 ? firstBlocked : Promise.resolve();
+        return gate.then(() => ({ finalLoss: 1 / pairs.length, history: { loss: [1, 0.5] } }));
+      },
+    };
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: slowFake,
+      toTrainingPair: project,
+      batchSize: 2,
+    });
+
+    // Fill the first batch; it starts training but stalls on firstBlocked.
+    learner.score(outcome(0.1));
+    learner.score(outcome(0.2));
+    expect(learner.isTraining()).toBe(true);
+
+    // Queue a second full batch while the first is still training.
+    learner.score(outcome(0.3));
+    learner.score(outcome(0.4));
+    expect(slowFake.calls).toHaveLength(1);
+
+    // Release the first batch; the tail should auto-schedule the second.
+    resolveFirst();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(slowFake.calls).toHaveLength(2);
+    expect(learner.bufferedCount()).toBe(0);
+  });
+
+  it('clamps non-positive bufferCapacity so the trim loop cannot hang', () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 10, // high enough that we never auto-train in this test
+      bufferCapacity: -3,
+    });
+
+    // Before the clamp, `buffer.length > -3` stays true at length 0, so
+    // `while (buffer.length > cap) buffer.shift()` spins forever.
+    // After the clamp, cap is Math.max(0, -3) = 0, so each pushed pair
+    // is immediately shifted back out and `score()` returns.
+    learner.score(outcome(0.1));
+    learner.score(outcome(0.2));
+
+    expect(learner.bufferedCount()).toBe(0);
+    expect(fake.calls).toHaveLength(0);
+  });
+
+  it('clamps non-positive batchSize so runTrain cannot loop on zero-slice batches', async () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 0,
+    });
+
+    learner.score(outcome(0.1));
+    // Clamped to 1 → the single outcome triggers a batch immediately.
+    await learner.flush();
+
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]?.pairs).toHaveLength(1);
+  });
+
   it('dispose() stops accepting new outcomes', () => {
     const fake = makeFakeReasoner();
     const learner = new TfjsLearner<number[], number[]>({

--- a/tests/unit/cognition/adapters/TfjsLearner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsLearner.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TfjsLearner } from '../../../../src/cognition/adapters/tfjs/TfjsLearner.js';
+import type {
+  TrainOptions,
+  TrainResult,
+} from '../../../../src/cognition/adapters/tfjs/TfjsReasoner.js';
+import type { LearningOutcome } from '../../../../src/cognition/learning/Learner.js';
+
+/**
+ * Fake `TrainableReasoner` that records every `train()` invocation
+ * without touching tfjs. The training result is deterministic so the
+ * learner's batching / flushing logic can be asserted without pulling a
+ * backend in.
+ */
+function makeFakeReasoner(): {
+  train: (
+    pairs: ReadonlyArray<{ features: number[]; label: number[] }>,
+    opts?: TrainOptions,
+  ) => Promise<TrainResult>;
+  calls: Array<{ pairs: Array<{ features: number[]; label: number[] }>; opts: TrainOptions }>;
+} {
+  const calls: Array<{
+    pairs: Array<{ features: number[]; label: number[] }>;
+    opts: TrainOptions;
+  }> = [];
+  return {
+    calls,
+    train(pairs, opts = {}): Promise<TrainResult> {
+      calls.push({
+        pairs: pairs.map((p) => ({ features: [...p.features], label: [...p.label] })),
+        opts: { ...opts },
+      });
+      const n = pairs.length;
+      return Promise.resolve({
+        finalLoss: n === 0 ? 0 : 1 / n,
+        history: { loss: [1, 0.5, 1 / Math.max(n, 1)] },
+      });
+    },
+  };
+}
+
+function outcome(reward: number | undefined): LearningOutcome {
+  return {
+    intention: { kind: 'satisfy', type: 'satisfy-need:hunger' },
+    actions: [],
+    ...(reward !== undefined ? { reward } : {}),
+  };
+}
+
+describe('TfjsLearner', () => {
+  const project = (o: LearningOutcome): { features: number[]; label: number[] } | null => {
+    if (o.reward === undefined) return null;
+    return { features: [o.reward], label: [o.reward] };
+  };
+
+  it('buffers outcomes without calling train() below batchSize', () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 3,
+    });
+    learner.score(outcome(0.1));
+    learner.score(outcome(0.2));
+    expect(learner.bufferedCount()).toBe(2);
+    expect(fake.calls).toHaveLength(0);
+  });
+
+  it('fires a background train exactly once when the buffer hits batchSize', async () => {
+    const fake = makeFakeReasoner();
+    const onBatchTrained = vi.fn();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 3,
+      onBatchTrained,
+    });
+    learner.score(outcome(0.1));
+    learner.score(outcome(0.2));
+    learner.score(outcome(0.3));
+    // Train is scheduled; wait for it to settle.
+    await learner.flush();
+
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]?.pairs).toHaveLength(3);
+    expect(learner.bufferedCount()).toBe(0);
+    expect(onBatchTrained).toHaveBeenCalledOnce();
+    const batchResult = onBatchTrained.mock.calls[0]?.[0] as TrainResult | undefined;
+    expect(typeof batchResult?.finalLoss).toBe('number');
+  });
+
+  it('skips outcomes whose projection returns null', () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 2,
+    });
+    learner.score(outcome(undefined));
+    learner.score(outcome(0.5));
+    expect(learner.bufferedCount()).toBe(1);
+    expect(fake.calls).toHaveLength(0);
+  });
+
+  it('forwards trainSeed + epochs to the reasoner', async () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 2,
+      epochs: 12,
+      trainSeed: 42,
+    });
+    learner.score(outcome(0.1));
+    learner.score(outcome(0.2));
+    await learner.flush();
+
+    expect(fake.calls[0]?.opts).toEqual({ epochs: 12, seed: 42 });
+  });
+
+  it('drops oldest buffered outcomes when bufferCapacity is exceeded', () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 10, // never auto-trains in this test
+      bufferCapacity: 3,
+    });
+    for (let i = 0; i < 5; i++) learner.score(outcome(i / 10));
+
+    expect(learner.bufferedCount()).toBe(3);
+  });
+
+  it('flush() trains the partial buffer immediately', async () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 10,
+    });
+    learner.score(outcome(0.1));
+    learner.score(outcome(0.2));
+
+    const result = await learner.flush();
+    expect(result).not.toBeNull();
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]?.pairs).toHaveLength(2);
+    expect(learner.bufferedCount()).toBe(0);
+  });
+
+  it('flush() returns null when the buffer is empty', async () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 5,
+    });
+    await expect(learner.flush()).resolves.toBeNull();
+  });
+
+  it('surfaces training errors via onTrainError (background) without throwing from score()', async () => {
+    const errFake = {
+      train(): Promise<TrainResult> {
+        return Promise.reject(new Error('boom'));
+      },
+    };
+    const onTrainError = vi.fn();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: errFake,
+      toTrainingPair: project,
+      batchSize: 1,
+      onTrainError,
+    });
+    learner.score(outcome(0.1));
+    // Drain the microtask queue the background train scheduled.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onTrainError).toHaveBeenCalledOnce();
+    expect((onTrainError.mock.calls[0]?.[0] as Error)?.message).toBe('boom');
+    expect(learner.isTraining()).toBe(false);
+  });
+
+  it('dispose() stops accepting new outcomes', () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 1,
+    });
+    learner.dispose();
+    learner.score(outcome(0.1));
+    expect(learner.bufferedCount()).toBe(0);
+    expect(fake.calls).toHaveLength(0);
+  });
+
+  it('is deterministic: identical outcome sequences produce identical train() calls', async () => {
+    const runOnce = async (): Promise<
+      Array<{ pairs: Array<{ features: number[]; label: number[] }>; opts: TrainOptions }>
+    > => {
+      const fake = makeFakeReasoner();
+      const learner = new TfjsLearner<number[], number[]>({
+        reasoner: fake,
+        toTrainingPair: project,
+        batchSize: 2,
+        epochs: 7,
+        trainSeed: 9,
+      });
+      for (const r of [0.1, 0.2, 0.3, 0.4]) learner.score(outcome(r));
+      await learner.flush();
+      return fake.calls;
+    };
+
+    const runA = await runOnce();
+    const runB = await runOnce();
+    expect(runA).toEqual(runB);
+  });
+});

--- a/tests/unit/cognition/adapters/TfjsLearner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsLearner.test.ts
@@ -324,6 +324,64 @@ describe('TfjsLearner', () => {
     expect(slowFake.calls).toBeGreaterThan(1);
   });
 
+  it('honours bufferCapacity: Infinity (no cap, never drops outcomes)', () => {
+    const fake = makeFakeReasoner();
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: fake,
+      toTrainingPair: project,
+      batchSize: 1000, // never auto-trains in this test
+      bufferCapacity: Number.POSITIVE_INFINITY,
+    });
+    for (let i = 0; i < 250; i++) learner.score(outcome(i / 1000));
+    expect(learner.bufferedCount()).toBe(250);
+  });
+
+  it('flush() re-checks inflight to avoid overlap with a drain-tail batch', async () => {
+    const gates: Array<() => void> = [];
+    let callCount = 0;
+    const slowFake: {
+      calls: number;
+      train: (
+        pairs: ReadonlyArray<{ features: number[]; label: number[] }>,
+      ) => Promise<TrainResult>;
+    } = {
+      calls: 0,
+      train(pairs) {
+        slowFake.calls++;
+        const index = callCount++;
+        return new Promise<void>((resolve) => {
+          gates[index] = resolve;
+        }).then(() => ({ finalLoss: 1 / pairs.length, history: { loss: [0.5] } }));
+      },
+    };
+    const learner = new TfjsLearner<number[], number[]>({
+      reasoner: slowFake,
+      toTrainingPair: project,
+      batchSize: 2,
+    });
+
+    // Two full batches buffered; first auto-train starts, second waits.
+    for (let i = 0; i < 4; i++) learner.score(outcome(i / 100));
+    expect(slowFake.calls).toBe(1);
+
+    // Issue flush() while batch #1 is still gated.
+    const flushPromise = learner.flush();
+
+    // Release batch #1 → drain-tail kicks off batch #2.
+    gates[0]!();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(slowFake.calls).toBe(2);
+
+    // Release batch #2; flush() must NOT have started a parallel
+    // runTrain after re-checking inflight; with the buffer drained it
+    // should resolve null.
+    gates[1]!();
+    const result = await flushPromise;
+    expect(result).toBeNull();
+    expect(slowFake.calls).toBe(2);
+  });
+
   it('dispose() stops accepting new outcomes', () => {
     const fake = makeFakeReasoner();
     const learner = new TfjsLearner<number[], number[]>({


### PR DESCRIPTION
## Summary
Closes \`docs/specs/2026-04-24-post-tfjs-improvements.md\` §1.1 — the first real \`Learner\` implementation. Turns Stage 8 (score) of the tick pipeline into a working reinforcement seam; \`NoopLearner\` stays the zero-config default, \`TfjsLearner\` is opt-in.

- \`TfjsLearner\` buffers \`LearningOutcome\`s and batches \`reasoner.train(pairs, { epochs, seed })\` calls every \`batchSize\` outcomes. Background training runs off the tick loop via a Promise chain; \`score()\` never blocks.
- \`TrainableReasoner<In, Out>\` is a minimum-surface view of the reasoner so tests can substitute a fake without spinning up tfjs.
- \`flush()\` force-trains the partial buffer (waits on any in-flight batch first); \`dispose()\` stops new outcomes without cancelling in-flight training (tfjs \`model.fit\` can't be cancelled mid-batch); \`isTraining()\` + \`bufferedCount()\` are observable for demos.
- Determinism: no RNG, no \`Date.now()\`, no \`setTimeout\`. \`trainSeed\` (default \`1\`) is a stable consumer-supplied value.

## Test plan
- [x] \`npm run verify\` — 422 tests (10 new) + build green.
- [x] \`npm run size\` — all five bundles under budget; \`tfjs\` limit raised from 5 kB to 7 kB (size went gzip 4.17 → 5.72 kB — room for §1.2 multi-output softmax next).
- [x] Deterministic-replay test in the suite: running the same outcome sequence twice produces byte-identical \`train()\` call arrays.

## Notes for review
- Consumer projects the reward / action / details tuple into a \`{ features, label }\` pair via \`toTrainingPair\`; returning \`null\` skips the outcome. Keeps the existing \`LearningOutcome.reward?: number\` schema — no \`LearningOutcome\` widening needed.
- \`onTrainError\` lets consumers surface background-train failures without a single failed batch tearing down the tick pipeline. Errors from explicit \`flush()\` calls still reject normally.
- \`dispose()\` deliberately leaves in-flight \`model.fit\` running. The demo's cognition switcher has a similar pattern (\`trainingReasoner\` guard) so this matches shipped behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)