### PR TITLE
fix(persistence): split localStorage keyspace so index cannot collide with data

### DIFF
--- a/.changeset/localstorage-store-keyspace-collision.md
+++ b/.changeset/localstorage-store-keyspace-collision.md
@@ -1,0 +1,31 @@
+---
+'agentonomous': minor
+---
+
+Fix: `LocalStorageSnapshotStore` no longer lets a user-supplied key collide
+with its own index metadata.
+
+Previously both snapshot payloads and the index list were stored under
+`{prefix}{key}`, so saving under `key === '__agentonomous/index__'`
+silently overwrote the index — `list()` then returned garbage and the
+snapshot became unreachable.
+
+The store now splits the keyspace into disjoint sub-namespaces:
+
+- `{prefix}__agentonomous/data/{encodeURIComponent(userKey)}` — payloads.
+- `{prefix}__agentonomous/meta/index` — the O(1) key list.
+
+User-supplied keys are `encodeURIComponent`-encoded before the storage
+write, so strings that look like meta paths can never escape the data
+subspace. The index payload still contains raw (decoded) user keys — no
+consumer-visible shape change.
+
+Existing entries written under the pre-split layout are migrated once on
+construction: legacy `{prefix}{userKey}` payloads are rewritten under the
+new data path, and the legacy `{prefix}__agentonomous/index__` entry is
+rewritten under the new meta path. No consumer action required.
+
+Public `StorageLike` interface is unchanged. Migration uses a runtime
+capability probe for iteration (`length` + `key(index)`); backends that
+don't expose iteration skip migration silently — in-memory stubs
+typically have no legacy data anyway.

--- a/.changeset/localstorage-store-keyspace-collision.md
+++ b/.changeset/localstorage-store-keyspace-collision.md
@@ -2,11 +2,11 @@
 'agentonomous': minor
 ---
 
-Fix: `LocalStorageSnapshotStore` no longer lets a user-supplied key collide
-with its own index metadata.
+Fix: `LocalStorageSnapshotStore` no longer lets a user-supplied key
+collide with its own index metadata.
 
-Previously both snapshot payloads and the index list were stored under
-`{prefix}{key}`, so saving under `key === '__agentonomous/index__'`
+Previously both snapshot payloads and the index list were stored
+under `{prefix}{key}`, so saving under `key === '__agentonomous/index__'`
 silently overwrote the index — `list()` then returned garbage and the
 snapshot became unreachable.
 
@@ -15,17 +15,18 @@ The store now splits the keyspace into disjoint sub-namespaces:
 - `{prefix}__agentonomous/data/{encodeURIComponent(userKey)}` — payloads.
 - `{prefix}__agentonomous/meta/index` — the O(1) key list.
 
-User-supplied keys are `encodeURIComponent`-encoded before the storage
-write, so strings that look like meta paths can never escape the data
-subspace. The index payload still contains raw (decoded) user keys — no
-consumer-visible shape change.
+`encodeURIComponent`-encoded user keys can never escape the data
+subspace, so any string a consumer supplies is safe.
 
-Existing entries written under the pre-split layout are migrated once on
-construction: legacy `{prefix}{userKey}` payloads are rewritten under the
-new data path, and the legacy `{prefix}__agentonomous/index__` entry is
-rewritten under the new meta path. No consumer action required.
+**Storage shape has changed.** This is pre-1.0; no migration path is
+provided for stores created by earlier pre-release builds. Consumers
+upgrading from a pre-release version should clear their
+`__agentonomous/` namespace before loading.
 
-Public `StorageLike` interface is unchanged. Migration uses a runtime
-capability probe for iteration (`length` + `key(index)`); backends that
-don't expose iteration skip migration silently — in-memory stubs
-typically have no legacy data anyway.
+Also adds input validation:
+
+- Empty prefix is rejected at construction — an empty namespace would
+  collide with unrelated storage keys.
+- Keys that are not well-formed UTF-16 (lone surrogates) produce a
+  store-specific error from `save` / `load` / `delete` instead of a
+  bare `URIError` from `encodeURIComponent`.

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ dist
 coverage
 docs
 node_modules
+graphify-out
 *.min.js
 pnpm-lock.yaml
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
       "name": "dist/index.js (gzip)",
       "path": "dist/index.js",
       "gzip": true,
-      "limit": "50 KB"
+      "limit": "35 KB"
     },
     {
       "name": "dist/integrations/excalibur/index.js (gzip)",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
       "name": "dist/index.js (gzip)",
       "path": "dist/index.js",
       "gzip": true,
-      "limit": "35 KB"
+      "limit": "50 KB"
     },
     {
       "name": "dist/integrations/excalibur/index.js (gzip)",

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -21,6 +21,14 @@ const DATA_PREFIX = '__agentonomous/data/';
  */
 const LEGACY_INDEX_SUFFIX = '__agentonomous/index__';
 
+/**
+ * Sentinel written once at the end of `migrateLegacyKeys` so subsequent
+ * constructions short-circuit. Guarantees re-entrance safety without
+ * having to disambiguate v1-user-key shapes that happen to match the
+ * new `data/` layout.
+ */
+const META_MIGRATED_KEY = '__agentonomous/meta/migrated';
+
 /** Minimal storage contract; browser `Storage` satisfies this. */
 export interface StorageLike {
   getItem(key: string): string | null;
@@ -173,11 +181,22 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
    * - **Orphan scan.** Runs only when the backend exposes `length` +
    *   `key(index)`. Picks up entries whose registration in the legacy
    *   index was lost (the original v1 collision bug where saving under
-   *   `__agentonomous/index__` wiped the index). The filter on the
-   *   new-layout subpaths keeps the scan re-entrant — on subsequent
-   *   constructions it finds only post-split entries and short-circuits.
+   *   `__agentonomous/index__` wiped the index).
+   *
+   * Re-entrance: a `META_MIGRATED_KEY` sentinel written at the end
+   * short-circuits subsequent constructions. The sentinel is what
+   * distinguishes "v1 user key shaped like the new data/ subpath"
+   * (migrate) from "new-layout entry this code wrote last run" (leave
+   * alone) — without it the scan would have to guess, and any guess
+   * loses data in one direction or the other.
    */
   private migrateLegacyKeys(): void {
+    // Re-entrance guard: once migration has run, the sentinel is set.
+    // Further constructions must not scan — the storage now contains
+    // new-layout entries written by this code that would be
+    // indistinguishable from v1 user keys of the same shape.
+    if (this.storage.getItem(this.prefix + META_MIGRATED_KEY) !== null) return;
+
     const legacyKeys = new Set<string>();
     const legacyIndexRaw = this.storage.getItem(this.prefix + LEGACY_INDEX_SUFFIX);
 
@@ -210,14 +229,18 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
         if (storageKey === null || !storageKey.startsWith(this.prefix)) continue;
         const suffix = storageKey.slice(this.prefix.length);
         if (suffix === LEGACY_INDEX_SUFFIX) continue;
-        // Skip new-layout subpaths so subsequent constructions don't
-        // re-process entries this code wrote on a prior run.
-        if (suffix.startsWith(DATA_PREFIX) || suffix.startsWith('__agentonomous/meta/')) continue;
+        // Skip our own metadata namespace (index / migrated marker) —
+        // not user data, never legacy. Note: do NOT filter out
+        // `__agentonomous/data/...` here. Those strings were valid v1
+        // user keys, and a pathological v1 store with the legacy index
+        // missing would leave them orphaned if we excluded them. The
+        // META_MIGRATED_KEY sentinel (checked at function entry) is
+        // what prevents re-processing the new-layout entries this
+        // code writes on a prior construction.
+        if (suffix.startsWith('__agentonomous/meta/')) continue;
         legacyKeys.add(suffix);
       }
     }
-
-    if (legacyKeys.size === 0 && legacyIndexRaw === null) return;
 
     for (const userKey of legacyKeys) {
       const raw = this.storage.getItem(this.prefix + userKey);
@@ -233,7 +256,15 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
     const migratedIndex = new Set<string>(legacyKeys);
     const existingIndex = this.readIndex();
     for (const entry of existingIndex) migratedIndex.add(entry);
-    this.writeIndex([...migratedIndex]);
+    if (migratedIndex.size > 0) {
+      this.writeIndex([...migratedIndex]);
+    }
+
+    // Always set the re-entrance sentinel — even on a fresh install
+    // with no legacy data — so subsequent constructions short-circuit
+    // the scan before it can misinterpret v2 `data/` entries as v1
+    // user keys.
+    this.storage.setItem(this.prefix + META_MIGRATED_KEY, '1');
   }
 }
 

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -158,7 +158,22 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   private migrateLegacyKeys(): void {
     if (!isIterableStorage(this.storage)) return;
 
-    const legacyKeys: string[] = [];
+    // Two sources of "what counts as a legacy user key":
+    //
+    // 1. Scan: any `{prefix}{suffix}` entry whose suffix is NOT under the
+    //    new-layout `data/` or `meta/` subpaths. Picks up orphans the
+    //    legacy index may have lost (the original v1 collision bug).
+    //    Filter on the new-layout subpaths makes migration re-entrant —
+    //    on subsequent constructions the scan finds only post-split
+    //    entries and short-circuits.
+    //
+    // 2. Legacy index: user keys that v1 explicitly registered. This is
+    //    authoritative — a user who saved under a key that LOOKS like a
+    //    new-layout subpath (e.g. `__agentonomous/data/foo`) would be
+    //    skipped by the scan filter, so we union the index in so those
+    //    keys still migrate. Without this, such snapshots become
+    //    unreachable after upgrade.
+    const legacyKeys = new Set<string>();
     let legacyIndexRaw: string | null = null;
 
     for (let i = 0; i < this.storage.length; i++) {
@@ -170,32 +185,38 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
         continue;
       }
       if (suffix.startsWith(DATA_PREFIX) || suffix.startsWith('__agentonomous/meta/')) continue;
-      legacyKeys.push(suffix);
+      legacyKeys.add(suffix);
     }
 
-    if (legacyKeys.length === 0 && legacyIndexRaw === null) return;
-
-    for (const userKey of legacyKeys) {
-      const raw = this.storage.getItem(this.prefix + userKey);
-      if (raw !== null) this.storage.setItem(this.dataKey(userKey), raw);
-      this.storage.removeItem(this.prefix + userKey);
-    }
-
-    const migratedIndex = new Set<string>(legacyKeys);
     if (legacyIndexRaw !== null) {
       try {
         const parsed: unknown = JSON.parse(legacyIndexRaw);
         if (Array.isArray(parsed)) {
           for (const entry of parsed) {
-            if (typeof entry === 'string') migratedIndex.add(entry);
+            if (typeof entry === 'string') legacyKeys.add(entry);
           }
         }
       } catch {
-        // Corrupted legacy index — fall through; we still have legacyKeys.
+        // Corrupted legacy index — fall through with whatever the scan
+        // found. Best-effort recovery; can't synthesize keys we don't
+        // know about.
       }
+    }
+
+    if (legacyKeys.size === 0 && legacyIndexRaw === null) return;
+
+    for (const userKey of legacyKeys) {
+      const raw = this.storage.getItem(this.prefix + userKey);
+      if (raw !== null) {
+        this.storage.setItem(this.dataKey(userKey), raw);
+        this.storage.removeItem(this.prefix + userKey);
+      }
+    }
+    if (legacyIndexRaw !== null) {
       this.storage.removeItem(this.prefix + LEGACY_INDEX_SUFFIX);
     }
 
+    const migratedIndex = new Set<string>(legacyKeys);
     const existingIndex = this.readIndex();
     for (const entry of existingIndex) migratedIndex.add(entry);
     this.writeIndex([...migratedIndex]);

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -74,7 +74,18 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   private readonly storage: StorageLike;
 
   constructor(opts: LocalStorageSnapshotStoreOptions = {}) {
-    this.prefix = opts.prefix ?? 'agentonomous/';
+    const prefix = opts.prefix ?? 'agentonomous/';
+    // An empty prefix would make the migration scan match every storage
+    // key (`startsWith('')` is always true), which could rewrite and
+    // remove unrelated application data on first construction after
+    // upgrade. Reject it at the boundary rather than letting it silently
+    // corrupt other data.
+    if (prefix === '') {
+      throw new Error(
+        'LocalStorageSnapshotStore: `prefix` must not be empty — an empty namespace would cause migration to match and rewrite unrelated storage keys.',
+      );
+    }
+    this.prefix = prefix;
     const resolved = opts.storage ?? resolveBrowserStorage();
     if (!resolved) {
       throw new Error(
@@ -151,42 +162,24 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
    * - `{prefix}{userKey}` → `{prefix}__agentonomous/data/{encodeURIComponent(userKey)}`
    * - `{prefix}__agentonomous/index__` → `{prefix}__agentonomous/meta/index`
    *
-   * Skipped silently when the storage backend does not expose iteration
-   * (`length` + `key(index)`) — minimal test stubs have no legacy data
-   * anyway, so there is nothing to migrate.
+   * Two discovery paths so the public `StorageLike` contract (which
+   * requires only getItem/setItem/removeItem) remains supported:
+   *
+   * - **Legacy index lookup.** Always runs. Reads the known legacy
+   *   path directly via `getItem` — no iteration required — and
+   *   migrates every user key it lists. Covers persistent custom
+   *   adapters that don't expose iteration but still hold legacy data.
+   *
+   * - **Orphan scan.** Runs only when the backend exposes `length` +
+   *   `key(index)`. Picks up entries whose registration in the legacy
+   *   index was lost (the original v1 collision bug where saving under
+   *   `__agentonomous/index__` wiped the index). The filter on the
+   *   new-layout subpaths keeps the scan re-entrant — on subsequent
+   *   constructions it finds only post-split entries and short-circuits.
    */
   private migrateLegacyKeys(): void {
-    if (!isIterableStorage(this.storage)) return;
-
-    // Two sources of "what counts as a legacy user key":
-    //
-    // 1. Scan: any `{prefix}{suffix}` entry whose suffix is NOT under the
-    //    new-layout `data/` or `meta/` subpaths. Picks up orphans the
-    //    legacy index may have lost (the original v1 collision bug).
-    //    Filter on the new-layout subpaths makes migration re-entrant —
-    //    on subsequent constructions the scan finds only post-split
-    //    entries and short-circuits.
-    //
-    // 2. Legacy index: user keys that v1 explicitly registered. This is
-    //    authoritative — a user who saved under a key that LOOKS like a
-    //    new-layout subpath (e.g. `__agentonomous/data/foo`) would be
-    //    skipped by the scan filter, so we union the index in so those
-    //    keys still migrate. Without this, such snapshots become
-    //    unreachable after upgrade.
     const legacyKeys = new Set<string>();
-    let legacyIndexRaw: string | null = null;
-
-    for (let i = 0; i < this.storage.length; i++) {
-      const storageKey = this.storage.key(i);
-      if (storageKey === null || !storageKey.startsWith(this.prefix)) continue;
-      const suffix = storageKey.slice(this.prefix.length);
-      if (suffix === LEGACY_INDEX_SUFFIX) {
-        legacyIndexRaw = this.storage.getItem(storageKey);
-        continue;
-      }
-      if (suffix.startsWith(DATA_PREFIX) || suffix.startsWith('__agentonomous/meta/')) continue;
-      legacyKeys.add(suffix);
-    }
+    const legacyIndexRaw = this.storage.getItem(this.prefix + LEGACY_INDEX_SUFFIX);
 
     if (legacyIndexRaw !== null) {
       try {
@@ -197,9 +190,21 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
           }
         }
       } catch {
-        // Corrupted legacy index — fall through with whatever the scan
-        // found. Best-effort recovery; can't synthesize keys we don't
-        // know about.
+        // Corrupted legacy index — fall through with whatever the
+        // orphan scan (if available) finds. Best-effort recovery.
+      }
+    }
+
+    if (isIterableStorage(this.storage)) {
+      for (let i = 0; i < this.storage.length; i++) {
+        const storageKey = this.storage.key(i);
+        if (storageKey === null || !storageKey.startsWith(this.prefix)) continue;
+        const suffix = storageKey.slice(this.prefix.length);
+        if (suffix === LEGACY_INDEX_SUFFIX) continue;
+        // Skip new-layout subpaths so subsequent constructions don't
+        // re-process entries this code wrote on a prior run.
+        if (suffix.startsWith(DATA_PREFIX) || suffix.startsWith('__agentonomous/meta/')) continue;
+        legacyKeys.add(suffix);
       }
     }
 

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -323,23 +323,19 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
     //
     //   - Iterable backend: the orphan scan observed every key under
     //     the prefix, so nothing recoverable was missed.
-    //   - Fresh install (no legacy index at all): there is no v1 data
-    //     to worry about.
-    //   - Parseable legacy index + every listed key migrated OR was
-    //     already gone: we handled what v1 said existed. An index
-    //     that pointed at entries with raw === null still requires
-    //     migrated.length === legacyKeys.size to finalize — if none
-    //     moved, prefer to keep artifacts intact for a retry.
+    //   - Non-iterable backend with a parseable legacy index AND every
+    //     listed key migrated (or was already gone): the index told us
+    //     exactly what v1 wrote, and we handled all of it.
     //
-    // Anything else (non-iterable + unparseable index, or non-iterable
-    // with a non-empty index where nothing moved) leaves the legacy
-    // artifacts intact so a later construction on a better-wired
-    // backend can still recover.
+    // Anything else — including non-iterable with NO legacy index (we
+    // can't distinguish "genuinely fresh" from "pathological v1 that
+    // lost its index to the original collision bug") — leaves the
+    // legacy artifacts intact and does NOT stamp the marker. A later
+    // construction on an iterable backend, or after the index is
+    // restored, can still recover orphaned payloads.
     const iterable = isIterableStorage(this.storage);
     const safeToFinalize =
-      iterable ||
-      legacyIndexRaw === null ||
-      (legacyIndexParseable && migrated.length === legacyKeys.size);
+      iterable || (legacyIndexParseable && migrated.length === legacyKeys.size);
 
     if (!safeToFinalize) {
       return;

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -123,6 +123,14 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
     }
     this.storage.setItem(encoded, JSON.stringify(snapshot));
     this.appendIndex(key);
+    // Lazily stamp the re-entrance sentinel on the first write. The
+    // constructor deliberately skips this for empty stores so
+    // read-only / quota-exceeded backends can still construct a load-
+    // only store. Once the consumer does write, we have to record
+    // that the store is in v2 shape — otherwise a subsequent
+    // construction would scan the new-layout entries we just wrote
+    // and mis-migrate them as v1 user keys.
+    this.ensureMigrationMarker();
     return Promise.resolve();
   }
 
@@ -175,6 +183,15 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
 
   private indexKey(): string {
     return this.prefix + META_INDEX_KEY;
+  }
+
+  private ensureMigrationMarker(): void {
+    // Idempotent: read first so a backend that rejects duplicate
+    // writes doesn't re-stamp on every save.
+    if (this.storage.getItem(this.prefix + META_MIGRATED_KEY) === MIGRATED_MARKER_VALUE) {
+      return;
+    }
+    this.storage.setItem(this.prefix + META_MIGRATED_KEY, MIGRATED_MARKER_VALUE);
   }
 
   private appendIndex(key: string): void {

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -1,13 +1,46 @@
 import type { AgentSnapshot } from './AgentSnapshot.js';
 import type { SnapshotStorePort } from './SnapshotStorePort.js';
 
-const INDEX_KEY = '__agentonomous/index__';
+/**
+ * Internal sub-namespace for the index metadata. Split from data so a
+ * user-supplied key can never collide with the index itself.
+ */
+const META_INDEX_KEY = '__agentonomous/meta/index';
+
+/**
+ * Internal sub-namespace for snapshot payloads. All user-supplied keys
+ * live under this prefix and are `encodeURIComponent`-encoded so strings
+ * that look like meta paths (e.g. `__agentonomous/meta/index`) can't
+ * escape the data subspace.
+ */
+const DATA_PREFIX = '__agentonomous/data/';
+
+/**
+ * Pre-split legacy layout that v1 shipped — kept here so `migrateLegacyKeys`
+ * can rewrite entries from it on first construction.
+ */
+const LEGACY_INDEX_SUFFIX = '__agentonomous/index__';
 
 /** Minimal storage contract; browser `Storage` satisfies this. */
 export interface StorageLike {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
   removeItem(key: string): void;
+}
+
+/**
+ * Optional capability: iteration over storage keys. Real `Storage`
+ * satisfies this; minimal in-memory test stubs may not. Used only for
+ * one-shot legacy migration on construction.
+ */
+interface IterableStorage extends StorageLike {
+  readonly length: number;
+  key(index: number): string | null;
+}
+
+function isIterableStorage(s: StorageLike): s is IterableStorage {
+  const cast = s as Partial<IterableStorage>;
+  return typeof cast.length === 'number' && typeof cast.key === 'function';
 }
 
 export interface LocalStorageSnapshotStoreOptions {
@@ -23,7 +56,18 @@ export interface LocalStorageSnapshotStoreOptions {
 /**
  * Snapshot store backed by a `Storage`-like object (typically
  * `window.localStorage`). Serializes via `JSON.stringify` / `JSON.parse`.
- * Keeps a `prefix/__agentonomous/index__` list so `list()` is O(1).
+ *
+ * Keyspace layout (internal; consumers should not depend on it):
+ *
+ * - `{prefix}__agentonomous/data/{encodeURIComponent(userKey)}` — payloads.
+ * - `{prefix}__agentonomous/meta/index` — the O(1) key list backing `list()`.
+ *
+ * This split means a user-supplied key that literally equals the legacy
+ * index path (`__agentonomous/index__`) can't overwrite the index; the
+ * encoded path `data/%5F%5F...` is disjoint from `meta/index`.
+ *
+ * Entries written under the legacy (pre-split) layout are migrated once
+ * on construction — see `migrateLegacyKeys`.
  */
 export class LocalStorageSnapshotStore implements SnapshotStorePort {
   private readonly prefix: string;
@@ -38,16 +82,17 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       );
     }
     this.storage = resolved;
+    this.migrateLegacyKeys();
   }
 
   save(key: string, snapshot: AgentSnapshot): Promise<void> {
-    this.storage.setItem(this.prefix + key, JSON.stringify(snapshot));
+    this.storage.setItem(this.dataKey(key), JSON.stringify(snapshot));
     this.appendIndex(key);
     return Promise.resolve();
   }
 
   load(key: string): Promise<AgentSnapshot | null> {
-    const raw = this.storage.getItem(this.prefix + key);
+    const raw = this.storage.getItem(this.dataKey(key));
     if (raw === null) return Promise.resolve(null);
     try {
       return Promise.resolve(JSON.parse(raw) as AgentSnapshot);
@@ -61,9 +106,17 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   }
 
   delete(key: string): Promise<void> {
-    this.storage.removeItem(this.prefix + key);
+    this.storage.removeItem(this.dataKey(key));
     this.removeFromIndex(key);
     return Promise.resolve();
+  }
+
+  private dataKey(key: string): string {
+    return this.prefix + DATA_PREFIX + encodeURIComponent(key);
+  }
+
+  private indexKey(): string {
+    return this.prefix + META_INDEX_KEY;
   }
 
   private appendIndex(key: string): void {
@@ -78,7 +131,7 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   }
 
   private readIndex(): readonly string[] {
-    const raw = this.storage.getItem(this.prefix + INDEX_KEY);
+    const raw = this.storage.getItem(this.indexKey());
     if (!raw) return [];
     try {
       const parsed: unknown = JSON.parse(raw);
@@ -89,7 +142,63 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   }
 
   private writeIndex(keys: readonly string[]): void {
-    this.storage.setItem(this.prefix + INDEX_KEY, JSON.stringify(keys));
+    this.storage.setItem(this.indexKey(), JSON.stringify(keys));
+  }
+
+  /**
+   * One-shot migration from the pre-split layout:
+   *
+   * - `{prefix}{userKey}` → `{prefix}__agentonomous/data/{encodeURIComponent(userKey)}`
+   * - `{prefix}__agentonomous/index__` → `{prefix}__agentonomous/meta/index`
+   *
+   * Skipped silently when the storage backend does not expose iteration
+   * (`length` + `key(index)`) — minimal test stubs have no legacy data
+   * anyway, so there is nothing to migrate.
+   */
+  private migrateLegacyKeys(): void {
+    if (!isIterableStorage(this.storage)) return;
+
+    const legacyKeys: string[] = [];
+    let legacyIndexRaw: string | null = null;
+
+    for (let i = 0; i < this.storage.length; i++) {
+      const storageKey = this.storage.key(i);
+      if (storageKey === null || !storageKey.startsWith(this.prefix)) continue;
+      const suffix = storageKey.slice(this.prefix.length);
+      if (suffix === LEGACY_INDEX_SUFFIX) {
+        legacyIndexRaw = this.storage.getItem(storageKey);
+        continue;
+      }
+      if (suffix.startsWith(DATA_PREFIX) || suffix.startsWith('__agentonomous/meta/')) continue;
+      legacyKeys.push(suffix);
+    }
+
+    if (legacyKeys.length === 0 && legacyIndexRaw === null) return;
+
+    for (const userKey of legacyKeys) {
+      const raw = this.storage.getItem(this.prefix + userKey);
+      if (raw !== null) this.storage.setItem(this.dataKey(userKey), raw);
+      this.storage.removeItem(this.prefix + userKey);
+    }
+
+    const migratedIndex = new Set<string>(legacyKeys);
+    if (legacyIndexRaw !== null) {
+      try {
+        const parsed: unknown = JSON.parse(legacyIndexRaw);
+        if (Array.isArray(parsed)) {
+          for (const entry of parsed) {
+            if (typeof entry === 'string') migratedIndex.add(entry);
+          }
+        }
+      } catch {
+        // Corrupted legacy index — fall through; we still have legacyKeys.
+      }
+      this.storage.removeItem(this.prefix + LEGACY_INDEX_SUFFIX);
+    }
+
+    const existingIndex = this.readIndex();
+    for (const entry of existingIndex) migratedIndex.add(entry);
+    this.writeIndex([...migratedIndex]);
   }
 }
 

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -296,7 +296,13 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       }
     }
 
-    const migrated: string[] = [];
+    // Phase 1: PLAN the migration without mutating storage. Collect
+    // every discoverable user key's payload into `plan`. If we decide
+    // to abort in phase 2, storage stays untouched — so a prior
+    // non-iterable pass that couldn't finalize never leaves orphan
+    // `data/*` entries that a subsequent iterable pass would
+    // mistake for v1 user keys (Codex P1, 2026-04-24).
+    const plan: Array<{ userKey: string; encoded: string; raw: string }> = [];
     for (const userKey of legacyKeys) {
       const raw = this.storage.getItem(this.prefix + userKey);
       if (raw === null) continue;
@@ -304,57 +310,56 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       try {
         encoded = this.dataKey(userKey);
       } catch {
-        // Malformed UTF-16 key (lone surrogate) — can't round-trip
-        // through encodeURIComponent. Skip so migration doesn't crash
-        // store initialization for the other, well-formed entries. The
-        // payload stays at the legacy path; the consumer sees it
-        // missing from `list()` but storage isn't mutated.
+        // Malformed UTF-16 key (lone surrogate) — skip without
+        // aborting the whole migration. Other well-formed entries
+        // still migrate.
         continue;
       }
-      this.storage.setItem(encoded, raw);
-      this.storage.removeItem(this.prefix + userKey);
-      migrated.push(userKey);
+      plan.push({ userKey, encoded, raw });
     }
-    // Decide whether we can safely finalize (clear legacy artifacts +
-    // stamp the re-entrance sentinel). Finalization is destructive —
-    // once the marker is set, future constructions short-circuit and
-    // lose any chance to recover still-orphaned v1 data. Allow it only
-    // when the discovery path is trustworthy:
+
+    // Phase 2: decide whether to finalize. Conditions:
     //
     //   - Iterable backend: the orphan scan observed every key under
-    //     the prefix, so nothing recoverable was missed.
-    //   - Non-iterable backend with a parseable legacy index AND every
-    //     listed key migrated (or was already gone): the index told us
-    //     exactly what v1 wrote, and we handled all of it.
+    //     the prefix; nothing recoverable was missed.
+    //   - Non-iterable backend + parseable legacy index: the index
+    //     is v1's source of truth for what was written. Stale/ghost
+    //     entries (raw === null) are tolerated — v1 deletes should
+    //     have updated the index so ghosts are rare and don't
+    //     indicate lost data.
     //
-    // Anything else — including non-iterable with NO legacy index (we
-    // can't distinguish "genuinely fresh" from "pathological v1 that
-    // lost its index to the original collision bug") — leaves the
-    // legacy artifacts intact and does NOT stamp the marker. A later
-    // construction on an iterable backend, or after the index is
-    // restored, can still recover orphaned payloads.
+    // Anything else (non-iterable + no index; non-iterable + unparseable
+    // index) leaves the legacy artifacts intact. A later construction
+    // on an iterable backend, or after the index is restored, can
+    // still recover orphans.
     const iterable = isIterableStorage(this.storage);
-    const safeToFinalize =
-      iterable || (legacyIndexParseable && migrated.length === legacyKeys.size);
+    const safeToFinalize = iterable || legacyIndexParseable;
 
     if (!safeToFinalize) {
       return;
+    }
+
+    // Phase 3: commit the plan. Every write here is part of a path
+    // that ends with the finalized marker — no half-finished state
+    // can outlive the constructor.
+    for (const { userKey, encoded, raw } of plan) {
+      this.storage.setItem(encoded, raw);
+      this.storage.removeItem(this.prefix + userKey);
     }
 
     if (legacyIndexRaw !== null) {
       this.storage.removeItem(this.prefix + LEGACY_INDEX_SUFFIX);
     }
 
-    const migratedIndex = new Set<string>(migrated);
+    const migratedIndex = new Set<string>(plan.map((p) => p.userKey));
     const existingIndex = this.readIndex();
     for (const entry of existingIndex) migratedIndex.add(entry);
     if (migratedIndex.size > 0) {
       this.writeIndex([...migratedIndex]);
     }
 
-    // Re-entrance sentinel — even on a fresh install with no legacy
-    // data — so subsequent constructions short-circuit the scan
-    // before it can misinterpret v2 `data/` entries as v1 user keys.
+    // Re-entrance sentinel. Subsequent constructions short-circuit
+    // here via `rawAtMarker === MIGRATED_MARKER_VALUE` at the top.
     this.storage.setItem(this.prefix + META_MIGRATED_KEY, MIGRATED_MARKER_VALUE);
   }
 }

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -15,50 +15,11 @@ const META_INDEX_KEY = '__agentonomous/meta/index';
  */
 const DATA_PREFIX = '__agentonomous/data/';
 
-/**
- * Pre-split legacy layout that v1 shipped — kept here so `migrateLegacyKeys`
- * can rewrite entries from it on first construction.
- */
-const LEGACY_INDEX_SUFFIX = '__agentonomous/index__';
-
-/**
- * Sentinel path written at the end of `migrateLegacyKeys` so subsequent
- * constructions short-circuit. Guarantees re-entrance safety without
- * having to disambiguate v1-user-key shapes that happen to match the
- * new `data/` layout.
- */
-const META_MIGRATED_KEY = '__agentonomous/meta/migrated';
-
-/**
- * Sentinel VALUE written at `META_MIGRATED_KEY`. Check the value (not
- * just presence) so a v1 user who happened to save under the exact
- * sentinel path is still migrated — the value at their path is a JSON
- * snapshot, which can never equal this string, so they fall through
- * into the migration branch instead of being mistaken for an
- * already-migrated store.
- */
-const MIGRATED_MARKER_VALUE = '__agentonomous_v2_migrated__';
-
 /** Minimal storage contract; browser `Storage` satisfies this. */
 export interface StorageLike {
   getItem(key: string): string | null;
   setItem(key: string, value: string): void;
   removeItem(key: string): void;
-}
-
-/**
- * Optional capability: iteration over storage keys. Real `Storage`
- * satisfies this; minimal in-memory test stubs may not. Used only for
- * one-shot legacy migration on construction.
- */
-interface IterableStorage extends StorageLike {
-  readonly length: number;
-  key(index: number): string | null;
-}
-
-function isIterableStorage(s: StorageLike): s is IterableStorage {
-  const cast = s as Partial<IterableStorage>;
-  return typeof cast.length === 'number' && typeof cast.key === 'function';
 }
 
 export interface LocalStorageSnapshotStoreOptions {
@@ -80,35 +41,24 @@ export interface LocalStorageSnapshotStoreOptions {
  * - `{prefix}__agentonomous/data/{encodeURIComponent(userKey)}` — payloads.
  * - `{prefix}__agentonomous/meta/index` — the O(1) key list backing `list()`.
  *
- * This split means a user-supplied key that literally equals the legacy
- * index path (`__agentonomous/index__`) can't overwrite the index; the
- * encoded path `data/%5F%5F...` is disjoint from `meta/index`.
- *
- * Entries written under the legacy (pre-split) layout are migrated once
- * on construction — see `migrateLegacyKeys`.
+ * Splitting data from metadata means a user-supplied key that would
+ * otherwise collide with the index path (e.g. the string
+ * `__agentonomous/meta/index`) is `encodeURIComponent`-encoded into
+ * the disjoint data subspace and can never overwrite the index.
  */
 export class LocalStorageSnapshotStore implements SnapshotStorePort {
   private readonly prefix: string;
   private readonly storage: StorageLike;
-  /**
-   * True when `migrateLegacyKeys` returned without being able to safely
-   * finalize — legacy artifacts exist but this backend couldn't
-   * enumerate them. Writes are refused in that state so a later
-   * construction on an iterable backend still has a chance to recover
-   * the legacy payloads.
-   */
-  private migrationAborted = false;
 
   constructor(opts: LocalStorageSnapshotStoreOptions = {}) {
     const prefix = opts.prefix ?? 'agentonomous/';
-    // An empty prefix would make the migration scan match every storage
-    // key (`startsWith('')` is always true), which could rewrite and
-    // remove unrelated application data on first construction after
-    // upgrade. Reject it at the boundary rather than letting it silently
-    // corrupt other data.
+    // An empty prefix would make `startsWith(prefix)` true for every
+    // storage key, so a future scan-style feature could rewrite
+    // unrelated application data. Reject it at the boundary rather
+    // than leaving that footgun open.
     if (prefix === '') {
       throw new Error(
-        'LocalStorageSnapshotStore: `prefix` must not be empty — an empty namespace would cause migration to match and rewrite unrelated storage keys.',
+        'LocalStorageSnapshotStore: `prefix` must not be empty — an empty namespace would collide with unrelated storage keys.',
       );
     }
     this.prefix = prefix;
@@ -119,30 +69,15 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       );
     }
     this.storage = resolved;
-    this.migrateLegacyKeys();
   }
 
   save(key: string, snapshot: AgentSnapshot): Promise<void> {
-    if (this.migrationAborted) {
-      return Promise.reject(
-        new Error(
-          'LocalStorageSnapshotStore: refusing to save — legacy migration could not finalize on this backend; reconstruct on an iterable backend (one exposing `length` + `key(i)`) to recover legacy payloads before writing new data.',
-        ),
-      );
-    }
     let encoded: string;
     try {
       encoded = this.dataKey(key);
     } catch (cause) {
       return Promise.reject(cause as Error);
     }
-    // Stamp the re-entrance sentinel BEFORE the data/index writes. A
-    // partial-failure path (quota exhaustion between the data and
-    // index writes) must never leave new-layout entries on storage
-    // without the marker — that state would trick the next
-    // construction's orphan scan into treating them as v1 user keys.
-    // Idempotent: skipped if the marker is already stamped.
-    this.ensureMigrationMarker();
     this.storage.setItem(encoded, JSON.stringify(snapshot));
     this.appendIndex(key);
     return Promise.resolve();
@@ -169,13 +104,6 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   }
 
   delete(key: string): Promise<void> {
-    if (this.migrationAborted) {
-      return Promise.reject(
-        new Error(
-          'LocalStorageSnapshotStore: refusing to delete — legacy migration could not finalize on this backend; reconstruct on an iterable backend (one exposing `length` + `key(i)`) to recover legacy payloads before mutating data.',
-        ),
-      );
-    }
     let encoded: string;
     try {
       encoded = this.dataKey(key);
@@ -190,8 +118,8 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   private dataKey(key: string): string {
     // `encodeURIComponent` throws `URIError` on lone-surrogate inputs
     // (malformed UTF-16). Re-raise with a message that points the
-    // consumer at the bad key instead of surfacing a bare runtime error
-    // from `save` / `load` / `delete`.
+    // consumer at the bad key instead of surfacing a bare runtime
+    // error from save / load / delete.
     try {
       return this.prefix + DATA_PREFIX + encodeURIComponent(key);
     } catch (cause) {
@@ -204,15 +132,6 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
 
   private indexKey(): string {
     return this.prefix + META_INDEX_KEY;
-  }
-
-  private ensureMigrationMarker(): void {
-    // Idempotent: read first so a backend that rejects duplicate
-    // writes doesn't re-stamp on every save.
-    if (this.storage.getItem(this.prefix + META_MIGRATED_KEY) === MIGRATED_MARKER_VALUE) {
-      return;
-    }
-    this.storage.setItem(this.prefix + META_MIGRATED_KEY, MIGRATED_MARKER_VALUE);
   }
 
   private appendIndex(key: string): void {
@@ -239,180 +158,6 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
 
   private writeIndex(keys: readonly string[]): void {
     this.storage.setItem(this.indexKey(), JSON.stringify(keys));
-  }
-
-  /**
-   * One-shot migration from the pre-split layout:
-   *
-   * - `{prefix}{userKey}` → `{prefix}__agentonomous/data/{encodeURIComponent(userKey)}`
-   * - `{prefix}__agentonomous/index__` → `{prefix}__agentonomous/meta/index`
-   *
-   * Two discovery paths so the public `StorageLike` contract (which
-   * requires only getItem/setItem/removeItem) remains supported:
-   *
-   * - **Legacy index lookup.** Always runs. Reads the known legacy
-   *   path directly via `getItem` — no iteration required — and
-   *   migrates every user key it lists. Covers persistent custom
-   *   adapters that don't expose iteration but still hold legacy data.
-   *
-   * - **Orphan scan.** Runs only when the backend exposes `length` +
-   *   `key(index)`. Picks up entries whose registration in the legacy
-   *   index was lost (the original v1 collision bug where saving under
-   *   `__agentonomous/index__` wiped the index).
-   *
-   * Re-entrance: a `META_MIGRATED_KEY` sentinel written at the end
-   * short-circuits subsequent constructions. The sentinel is what
-   * distinguishes "v1 user key shaped like the new data/ subpath"
-   * (migrate) from "new-layout entry this code wrote last run" (leave
-   * alone) — without it the scan would have to guess, and any guess
-   * loses data in one direction or the other.
-   */
-  private migrateLegacyKeys(): void {
-    // Re-entrance guard: once migration has run, the sentinel value is
-    // written at the marker path. Match on VALUE, not mere presence —
-    // a v1 user who happened to save under the sentinel path would
-    // otherwise be mistaken for an already-migrated store and have
-    // their snapshot left orphaned.
-    const rawAtMarker = this.storage.getItem(this.prefix + META_MIGRATED_KEY);
-    if (rawAtMarker === MIGRATED_MARKER_VALUE) return;
-
-    const legacyKeys = new Set<string>();
-    const legacyIndexRaw = this.storage.getItem(this.prefix + LEGACY_INDEX_SUFFIX);
-    // If the marker path holds something that ISN'T our sentinel value,
-    // it's v1 user data at a colliding path. Treat it as a legacy user
-    // key so the snapshot migrates instead of being overwritten when we
-    // stamp the sentinel at the end of this pass.
-    if (rawAtMarker !== null && rawAtMarker !== MIGRATED_MARKER_VALUE) {
-      legacyKeys.add(META_MIGRATED_KEY);
-    }
-
-    // Track whether we could parse the legacy index into a usable array.
-    // If the index exists but is not parseable AND the backend doesn't
-    // expose iteration, we have no way to enumerate legacy payloads —
-    // abort before touching anything so a later construction (maybe on
-    // an iterable backend) can still recover the data.
-    let legacyIndexParseable = false;
-    if (legacyIndexRaw !== null) {
-      try {
-        const parsed: unknown = JSON.parse(legacyIndexRaw);
-        if (Array.isArray(parsed)) {
-          legacyIndexParseable = true;
-          for (const entry of parsed) {
-            // Defensive: skip the index sentinel itself. A v1 store that
-            // hit the original collision bug (saving under a key of
-            // `__agentonomous/index__`) could leave that string listed
-            // in the index; copying the raw payload at that path — which
-            // is index metadata, not a snapshot — into the new data
-            // namespace would surface garbage as an AgentSnapshot and
-            // break `load()` for that key.
-            if (typeof entry === 'string' && entry !== LEGACY_INDEX_SUFFIX) {
-              legacyKeys.add(entry);
-            }
-          }
-        }
-      } catch {
-        // Corrupted legacy index — fall through; `legacyIndexParseable`
-        // stays false so the non-iterable abort below fires.
-      }
-    }
-
-    if (isIterableStorage(this.storage)) {
-      for (let i = 0; i < this.storage.length; i++) {
-        const storageKey = this.storage.key(i);
-        if (storageKey === null || !storageKey.startsWith(this.prefix)) continue;
-        const suffix = storageKey.slice(this.prefix.length);
-        // The legacy index sentinel path is handled separately above.
-        if (suffix === LEGACY_INDEX_SUFFIX) continue;
-        // Everything else under the prefix is a candidate v1 user key.
-        // Do NOT filter on `__agentonomous/data/...` or
-        // `__agentonomous/meta/...` — both were valid v1 user keys in
-        // the pre-split `{prefix}{key}` layout. The META_MIGRATED_KEY
-        // sentinel (checked at function entry) is what prevents
-        // re-processing the new-layout entries this code writes on a
-        // prior construction.
-        legacyKeys.add(suffix);
-      }
-    }
-
-    // Phase 1: PLAN the migration without mutating storage. Collect
-    // every discoverable user key's payload into `plan`. If we decide
-    // to abort in phase 2, storage stays untouched — so a prior
-    // non-iterable pass that couldn't finalize never leaves orphan
-    // `data/*` entries that a subsequent iterable pass would
-    // mistake for v1 user keys (Codex P1, 2026-04-24).
-    const plan: Array<{ userKey: string; encoded: string; raw: string }> = [];
-    for (const userKey of legacyKeys) {
-      const raw = this.storage.getItem(this.prefix + userKey);
-      if (raw === null) continue;
-      let encoded: string;
-      try {
-        encoded = this.dataKey(userKey);
-      } catch {
-        // Malformed UTF-16 key (lone surrogate) — skip without
-        // aborting the whole migration. Other well-formed entries
-        // still migrate.
-        continue;
-      }
-      plan.push({ userKey, encoded, raw });
-    }
-
-    // Early exit when nothing to migrate AND no legacy index to clean
-    // up — a fresh install on any backend should not perform a
-    // `setItem` for the marker (which could throw on a read-only /
-    // quota-exceeded store and turn a no-op upgrade path into a
-    // startup failure). Subsequent constructions re-enter this
-    // function, find nothing again, and short-circuit at zero cost.
-    // Crucially, this check precedes the `safeToFinalize` gate so
-    // an empty non-iterable store isn't classified as "aborted"
-    // (there's no unresolved legacy data to protect).
-    const hasLegacyArtifacts = plan.length > 0 || legacyIndexRaw !== null;
-    if (!hasLegacyArtifacts) {
-      return;
-    }
-
-    // Phase 2: decide whether to finalize. Conditions:
-    //
-    //   - Iterable backend: the orphan scan observed every key under
-    //     the prefix; nothing recoverable was missed.
-    //   - Non-iterable backend + parseable legacy index: the index
-    //     is v1's source of truth for what was written. Stale/ghost
-    //     entries (raw === null) are tolerated — v1 deletes should
-    //     have updated the index so ghosts are rare and don't
-    //     indicate lost data.
-    //
-    // Anything else (non-iterable + unparseable index) leaves the
-    // legacy artifacts intact AND flags the store as aborted so
-    // `save` / `delete` refuse to mutate — otherwise a write path
-    // would stamp the marker and strand the legacy payloads.
-    const iterable = isIterableStorage(this.storage);
-    const safeToFinalize = iterable || legacyIndexParseable;
-
-    if (!safeToFinalize) {
-      this.migrationAborted = true;
-      return;
-    }
-
-    // Every write here is part of a path that ends with the finalized
-    // marker — no half-finished state can outlive the constructor.
-    for (const { userKey, encoded, raw } of plan) {
-      this.storage.setItem(encoded, raw);
-      this.storage.removeItem(this.prefix + userKey);
-    }
-
-    if (legacyIndexRaw !== null) {
-      this.storage.removeItem(this.prefix + LEGACY_INDEX_SUFFIX);
-    }
-
-    const migratedIndex = new Set<string>(plan.map((p) => p.userKey));
-    const existingIndex = this.readIndex();
-    for (const entry of existingIndex) migratedIndex.add(entry);
-    if (migratedIndex.size > 0) {
-      this.writeIndex([...migratedIndex]);
-    }
-
-    // Re-entrance sentinel. Subsequent constructions short-circuit
-    // here via `rawAtMarker === MIGRATED_MARKER_VALUE` at the top.
-    this.storage.setItem(this.prefix + META_MIGRATED_KEY, MIGRATED_MARKER_VALUE);
   }
 }
 

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -278,32 +278,20 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       }
     }
 
-    // Abort without clearing artifacts when:
-    //   1. Legacy index is present but not parseable as a string array
-    //      (corrupt, or holds a colliding v1 snapshot), AND
-    //   2. The backend does not expose iteration, so we cannot find
-    //      orphans via scan.
-    // Leaving legacy artifacts intact lets a subsequent construction
-    // (different backend wiring, restored index) retry migration.
-    if (!isIterableStorage(this.storage) && legacyIndexRaw !== null && !legacyIndexParseable) {
-      return;
-    }
-
     if (isIterableStorage(this.storage)) {
       for (let i = 0; i < this.storage.length; i++) {
         const storageKey = this.storage.key(i);
         if (storageKey === null || !storageKey.startsWith(this.prefix)) continue;
         const suffix = storageKey.slice(this.prefix.length);
+        // The legacy index sentinel path is handled separately above.
         if (suffix === LEGACY_INDEX_SUFFIX) continue;
-        // Skip our own metadata namespace (index / migrated marker) —
-        // not user data, never legacy. Note: do NOT filter out
-        // `__agentonomous/data/...` here. Those strings were valid v1
-        // user keys, and a pathological v1 store with the legacy index
-        // missing would leave them orphaned if we excluded them. The
-        // META_MIGRATED_KEY sentinel (checked at function entry) is
-        // what prevents re-processing the new-layout entries this
-        // code writes on a prior construction.
-        if (suffix.startsWith('__agentonomous/meta/')) continue;
+        // Everything else under the prefix is a candidate v1 user key.
+        // Do NOT filter on `__agentonomous/data/...` or
+        // `__agentonomous/meta/...` — both were valid v1 user keys in
+        // the pre-split `{prefix}{key}` layout. The META_MIGRATED_KEY
+        // sentinel (checked at function entry) is what prevents
+        // re-processing the new-layout entries this code writes on a
+        // prior construction.
         legacyKeys.add(suffix);
       }
     }
@@ -327,6 +315,36 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       this.storage.removeItem(this.prefix + userKey);
       migrated.push(userKey);
     }
+    // Decide whether we can safely finalize (clear legacy artifacts +
+    // stamp the re-entrance sentinel). Finalization is destructive —
+    // once the marker is set, future constructions short-circuit and
+    // lose any chance to recover still-orphaned v1 data. Allow it only
+    // when the discovery path is trustworthy:
+    //
+    //   - Iterable backend: the orphan scan observed every key under
+    //     the prefix, so nothing recoverable was missed.
+    //   - Fresh install (no legacy index at all): there is no v1 data
+    //     to worry about.
+    //   - Parseable legacy index + every listed key migrated OR was
+    //     already gone: we handled what v1 said existed. An index
+    //     that pointed at entries with raw === null still requires
+    //     migrated.length === legacyKeys.size to finalize — if none
+    //     moved, prefer to keep artifacts intact for a retry.
+    //
+    // Anything else (non-iterable + unparseable index, or non-iterable
+    // with a non-empty index where nothing moved) leaves the legacy
+    // artifacts intact so a later construction on a better-wired
+    // backend can still recover.
+    const iterable = isIterableStorage(this.storage);
+    const safeToFinalize =
+      iterable ||
+      legacyIndexRaw === null ||
+      (legacyIndexParseable && migrated.length === legacyKeys.size);
+
+    if (!safeToFinalize) {
+      return;
+    }
+
     if (legacyIndexRaw !== null) {
       this.storage.removeItem(this.prefix + LEGACY_INDEX_SUFFIX);
     }
@@ -338,10 +356,9 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       this.writeIndex([...migratedIndex]);
     }
 
-    // Always set the re-entrance sentinel — even on a fresh install
-    // with no legacy data — so subsequent constructions short-circuit
-    // the scan before it can misinterpret v2 `data/` entries as v1
-    // user keys.
+    // Re-entrance sentinel — even on a fresh install with no legacy
+    // data — so subsequent constructions short-circuit the scan
+    // before it can misinterpret v2 `data/` entries as v1 user keys.
     this.storage.setItem(this.prefix + META_MIGRATED_KEY, MIGRATED_MARKER_VALUE);
   }
 }

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -22,12 +22,22 @@ const DATA_PREFIX = '__agentonomous/data/';
 const LEGACY_INDEX_SUFFIX = '__agentonomous/index__';
 
 /**
- * Sentinel written once at the end of `migrateLegacyKeys` so subsequent
+ * Sentinel path written at the end of `migrateLegacyKeys` so subsequent
  * constructions short-circuit. Guarantees re-entrance safety without
  * having to disambiguate v1-user-key shapes that happen to match the
  * new `data/` layout.
  */
 const META_MIGRATED_KEY = '__agentonomous/meta/migrated';
+
+/**
+ * Sentinel VALUE written at `META_MIGRATED_KEY`. Check the value (not
+ * just presence) so a v1 user who happened to save under the exact
+ * sentinel path is still migrated — the value at their path is a JSON
+ * snapshot, which can never equal this string, so they fall through
+ * into the migration branch instead of being mistaken for an
+ * already-migrated store.
+ */
+const MIGRATED_MARKER_VALUE = '__agentonomous_v2_migrated__';
 
 /** Minimal storage contract; browser `Storage` satisfies this. */
 export interface StorageLike {
@@ -105,13 +115,25 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   }
 
   save(key: string, snapshot: AgentSnapshot): Promise<void> {
-    this.storage.setItem(this.dataKey(key), JSON.stringify(snapshot));
+    let encoded: string;
+    try {
+      encoded = this.dataKey(key);
+    } catch (cause) {
+      return Promise.reject(cause as Error);
+    }
+    this.storage.setItem(encoded, JSON.stringify(snapshot));
     this.appendIndex(key);
     return Promise.resolve();
   }
 
   load(key: string): Promise<AgentSnapshot | null> {
-    const raw = this.storage.getItem(this.dataKey(key));
+    let encoded: string;
+    try {
+      encoded = this.dataKey(key);
+    } catch (cause) {
+      return Promise.reject(cause as Error);
+    }
+    const raw = this.storage.getItem(encoded);
     if (raw === null) return Promise.resolve(null);
     try {
       return Promise.resolve(JSON.parse(raw) as AgentSnapshot);
@@ -125,13 +147,30 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   }
 
   delete(key: string): Promise<void> {
-    this.storage.removeItem(this.dataKey(key));
+    let encoded: string;
+    try {
+      encoded = this.dataKey(key);
+    } catch (cause) {
+      return Promise.reject(cause as Error);
+    }
+    this.storage.removeItem(encoded);
     this.removeFromIndex(key);
     return Promise.resolve();
   }
 
   private dataKey(key: string): string {
-    return this.prefix + DATA_PREFIX + encodeURIComponent(key);
+    // `encodeURIComponent` throws `URIError` on lone-surrogate inputs
+    // (malformed UTF-16). Re-raise with a message that points the
+    // consumer at the bad key instead of surfacing a bare runtime error
+    // from `save` / `load` / `delete`.
+    try {
+      return this.prefix + DATA_PREFIX + encodeURIComponent(key);
+    } catch (cause) {
+      throw new Error(
+        `LocalStorageSnapshotStore: snapshot key '${key}' is not a well-formed UTF-16 string (${String(cause)}).`,
+        { cause },
+      );
+    }
   }
 
   private indexKey(): string {
@@ -191,14 +230,23 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
    * loses data in one direction or the other.
    */
   private migrateLegacyKeys(): void {
-    // Re-entrance guard: once migration has run, the sentinel is set.
-    // Further constructions must not scan — the storage now contains
-    // new-layout entries written by this code that would be
-    // indistinguishable from v1 user keys of the same shape.
-    if (this.storage.getItem(this.prefix + META_MIGRATED_KEY) !== null) return;
+    // Re-entrance guard: once migration has run, the sentinel value is
+    // written at the marker path. Match on VALUE, not mere presence —
+    // a v1 user who happened to save under the sentinel path would
+    // otherwise be mistaken for an already-migrated store and have
+    // their snapshot left orphaned.
+    const rawAtMarker = this.storage.getItem(this.prefix + META_MIGRATED_KEY);
+    if (rawAtMarker === MIGRATED_MARKER_VALUE) return;
 
     const legacyKeys = new Set<string>();
     const legacyIndexRaw = this.storage.getItem(this.prefix + LEGACY_INDEX_SUFFIX);
+    // If the marker path holds something that ISN'T our sentinel value,
+    // it's v1 user data at a colliding path. Treat it as a legacy user
+    // key so the snapshot migrates instead of being overwritten when we
+    // stamp the sentinel at the end of this pass.
+    if (rawAtMarker !== null && rawAtMarker !== MIGRATED_MARKER_VALUE) {
+      legacyKeys.add(META_MIGRATED_KEY);
+    }
 
     if (legacyIndexRaw !== null) {
       try {
@@ -242,18 +290,30 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       }
     }
 
+    const migrated: string[] = [];
     for (const userKey of legacyKeys) {
       const raw = this.storage.getItem(this.prefix + userKey);
-      if (raw !== null) {
-        this.storage.setItem(this.dataKey(userKey), raw);
-        this.storage.removeItem(this.prefix + userKey);
+      if (raw === null) continue;
+      let encoded: string;
+      try {
+        encoded = this.dataKey(userKey);
+      } catch {
+        // Malformed UTF-16 key (lone surrogate) — can't round-trip
+        // through encodeURIComponent. Skip so migration doesn't crash
+        // store initialization for the other, well-formed entries. The
+        // payload stays at the legacy path; the consumer sees it
+        // missing from `list()` but storage isn't mutated.
+        continue;
       }
+      this.storage.setItem(encoded, raw);
+      this.storage.removeItem(this.prefix + userKey);
+      migrated.push(userKey);
     }
     if (legacyIndexRaw !== null) {
       this.storage.removeItem(this.prefix + LEGACY_INDEX_SUFFIX);
     }
 
-    const migratedIndex = new Set<string>(legacyKeys);
+    const migratedIndex = new Set<string>(migrated);
     const existingIndex = this.readIndex();
     for (const entry of existingIndex) migratedIndex.add(entry);
     if (migratedIndex.size > 0) {
@@ -264,7 +324,7 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
     // with no legacy data — so subsequent constructions short-circuit
     // the scan before it can misinterpret v2 `data/` entries as v1
     // user keys.
-    this.storage.setItem(this.prefix + META_MIGRATED_KEY, '1');
+    this.storage.setItem(this.prefix + META_MIGRATED_KEY, MIGRATED_MARKER_VALUE);
   }
 }
 

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -186,7 +186,16 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
         const parsed: unknown = JSON.parse(legacyIndexRaw);
         if (Array.isArray(parsed)) {
           for (const entry of parsed) {
-            if (typeof entry === 'string') legacyKeys.add(entry);
+            // Defensive: skip the index sentinel itself. A v1 store that
+            // hit the original collision bug (saving under a key of
+            // `__agentonomous/index__`) could leave that string listed
+            // in the index; copying the raw payload at that path — which
+            // is index metadata, not a snapshot — into the new data
+            // namespace would surface garbage as an AgentSnapshot and
+            // break `load()` for that key.
+            if (typeof entry === 'string' && entry !== LEGACY_INDEX_SUFFIX) {
+              legacyKeys.add(entry);
+            }
           }
         }
       } catch {

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -248,10 +248,17 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       legacyKeys.add(META_MIGRATED_KEY);
     }
 
+    // Track whether we could parse the legacy index into a usable array.
+    // If the index exists but is not parseable AND the backend doesn't
+    // expose iteration, we have no way to enumerate legacy payloads —
+    // abort before touching anything so a later construction (maybe on
+    // an iterable backend) can still recover the data.
+    let legacyIndexParseable = false;
     if (legacyIndexRaw !== null) {
       try {
         const parsed: unknown = JSON.parse(legacyIndexRaw);
         if (Array.isArray(parsed)) {
+          legacyIndexParseable = true;
           for (const entry of parsed) {
             // Defensive: skip the index sentinel itself. A v1 store that
             // hit the original collision bug (saving under a key of
@@ -266,9 +273,20 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
           }
         }
       } catch {
-        // Corrupted legacy index — fall through with whatever the
-        // orphan scan (if available) finds. Best-effort recovery.
+        // Corrupted legacy index — fall through; `legacyIndexParseable`
+        // stays false so the non-iterable abort below fires.
       }
+    }
+
+    // Abort without clearing artifacts when:
+    //   1. Legacy index is present but not parseable as a string array
+    //      (corrupt, or holds a colliding v1 snapshot), AND
+    //   2. The backend does not expose iteration, so we cannot find
+    //      orphans via scan.
+    // Leaving legacy artifacts intact lets a subsequent construction
+    // (different backend wiring, restored index) retry migration.
+    if (!isIterableStorage(this.storage) && legacyIndexRaw !== null && !legacyIndexParseable) {
+      return;
     }
 
     if (isIterableStorage(this.storage)) {

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -90,6 +90,14 @@ export interface LocalStorageSnapshotStoreOptions {
 export class LocalStorageSnapshotStore implements SnapshotStorePort {
   private readonly prefix: string;
   private readonly storage: StorageLike;
+  /**
+   * True when `migrateLegacyKeys` returned without being able to safely
+   * finalize — legacy artifacts exist but this backend couldn't
+   * enumerate them. Writes are refused in that state so a later
+   * construction on an iterable backend still has a chance to recover
+   * the legacy payloads.
+   */
+  private migrationAborted = false;
 
   constructor(opts: LocalStorageSnapshotStoreOptions = {}) {
     const prefix = opts.prefix ?? 'agentonomous/';
@@ -115,22 +123,28 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   }
 
   save(key: string, snapshot: AgentSnapshot): Promise<void> {
+    if (this.migrationAborted) {
+      return Promise.reject(
+        new Error(
+          'LocalStorageSnapshotStore: refusing to save — legacy migration could not finalize on this backend; reconstruct on an iterable backend (one exposing `length` + `key(i)`) to recover legacy payloads before writing new data.',
+        ),
+      );
+    }
     let encoded: string;
     try {
       encoded = this.dataKey(key);
     } catch (cause) {
       return Promise.reject(cause as Error);
     }
+    // Stamp the re-entrance sentinel BEFORE the data/index writes. A
+    // partial-failure path (quota exhaustion between the data and
+    // index writes) must never leave new-layout entries on storage
+    // without the marker — that state would trick the next
+    // construction's orphan scan into treating them as v1 user keys.
+    // Idempotent: skipped if the marker is already stamped.
+    this.ensureMigrationMarker();
     this.storage.setItem(encoded, JSON.stringify(snapshot));
     this.appendIndex(key);
-    // Lazily stamp the re-entrance sentinel on the first write. The
-    // constructor deliberately skips this for empty stores so
-    // read-only / quota-exceeded backends can still construct a load-
-    // only store. Once the consumer does write, we have to record
-    // that the store is in v2 shape — otherwise a subsequent
-    // construction would scan the new-layout entries we just wrote
-    // and mis-migrate them as v1 user keys.
-    this.ensureMigrationMarker();
     return Promise.resolve();
   }
 
@@ -155,6 +169,13 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
   }
 
   delete(key: string): Promise<void> {
+    if (this.migrationAborted) {
+      return Promise.reject(
+        new Error(
+          'LocalStorageSnapshotStore: refusing to delete — legacy migration could not finalize on this backend; reconstruct on an iterable backend (one exposing `length` + `key(i)`) to recover legacy payloads before mutating data.',
+        ),
+      );
+    }
     let encoded: string;
     try {
       encoded = this.dataKey(key);
@@ -335,6 +356,20 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       plan.push({ userKey, encoded, raw });
     }
 
+    // Early exit when nothing to migrate AND no legacy index to clean
+    // up — a fresh install on any backend should not perform a
+    // `setItem` for the marker (which could throw on a read-only /
+    // quota-exceeded store and turn a no-op upgrade path into a
+    // startup failure). Subsequent constructions re-enter this
+    // function, find nothing again, and short-circuit at zero cost.
+    // Crucially, this check precedes the `safeToFinalize` gate so
+    // an empty non-iterable store isn't classified as "aborted"
+    // (there's no unresolved legacy data to protect).
+    const hasLegacyArtifacts = plan.length > 0 || legacyIndexRaw !== null;
+    if (!hasLegacyArtifacts) {
+      return;
+    }
+
     // Phase 2: decide whether to finalize. Conditions:
     //
     //   - Iterable backend: the orphan scan observed every key under
@@ -345,26 +380,15 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
     //     have updated the index so ghosts are rare and don't
     //     indicate lost data.
     //
-    // Anything else (non-iterable + no index; non-iterable + unparseable
-    // index) leaves the legacy artifacts intact. A later construction
-    // on an iterable backend, or after the index is restored, can
-    // still recover orphans.
+    // Anything else (non-iterable + unparseable index) leaves the
+    // legacy artifacts intact AND flags the store as aborted so
+    // `save` / `delete` refuse to mutate — otherwise a write path
+    // would stamp the marker and strand the legacy payloads.
     const iterable = isIterableStorage(this.storage);
     const safeToFinalize = iterable || legacyIndexParseable;
 
     if (!safeToFinalize) {
-      return;
-    }
-
-    // Phase 3: commit the plan. Skip entirely when there's nothing
-    // to migrate AND no legacy index to clean up — a fresh install
-    // on any backend should not perform a `setItem` for the marker
-    // (which could throw on a read-only / quota-exceeded store and
-    // turn a no-op upgrade path into a startup failure). Subsequent
-    // constructions will re-enter this function, find nothing again,
-    // and short-circuit at zero cost.
-    const hasLegacyArtifacts = plan.length > 0 || legacyIndexRaw !== null;
-    if (!hasLegacyArtifacts) {
+      this.migrationAborted = true;
       return;
     }
 

--- a/src/persistence/LocalStorageSnapshotStore.ts
+++ b/src/persistence/LocalStorageSnapshotStore.ts
@@ -339,9 +339,20 @@ export class LocalStorageSnapshotStore implements SnapshotStorePort {
       return;
     }
 
-    // Phase 3: commit the plan. Every write here is part of a path
-    // that ends with the finalized marker — no half-finished state
-    // can outlive the constructor.
+    // Phase 3: commit the plan. Skip entirely when there's nothing
+    // to migrate AND no legacy index to clean up — a fresh install
+    // on any backend should not perform a `setItem` for the marker
+    // (which could throw on a read-only / quota-exceeded store and
+    // turn a no-op upgrade path into a startup failure). Subsequent
+    // constructions will re-enter this function, find nothing again,
+    // and short-circuit at zero cost.
+    const hasLegacyArtifacts = plan.length > 0 || legacyIndexRaw !== null;
+    if (!hasLegacyArtifacts) {
+      return;
+    }
+
+    // Every write here is part of a path that ends with the finalized
+    // marker — no half-finished state can outlive the constructor.
     for (const { userKey, encoded, raw } of plan) {
       this.storage.setItem(encoded, raw);
       this.storage.removeItem(this.prefix + userKey);

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -332,6 +332,67 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     expect(storage.getItem('p/__agentonomous/index__')).toBeNull();
   });
 
+  it('migrates v1 user data saved under the exact META_MIGRATED_KEY sentinel path', async () => {
+    // The re-entrance marker lives at `__agentonomous/meta/migrated`. A
+    // v1 user could legitimately have saved under that exact key before
+    // upgrade. Matching merely on the path's PRESENCE would treat their
+    // snapshot as "migrated already done" and leave it orphaned. The
+    // guard matches the VALUE instead (a distinctive sentinel string),
+    // so v1 payloads at that path fall through into the migration
+    // branch like any other legacy key.
+    const storage = new FakeStorage();
+    const collidingKey = '__agentonomous/meta/migrated';
+    storage.setItem(`p/${collidingKey}`, JSON.stringify(snap(collidingKey, 1)));
+    // Legacy index DELIBERATELY missing so we exercise the rawAtMarker
+    // path (not the legacy-index-parse path).
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    expect([...(await store.list())]).toEqual([collidingKey]);
+    expect(await store.load(collidingKey)).toMatchObject({ identity: { id: collidingKey } });
+    // The marker path now holds the sentinel value, not the old snapshot.
+    expect(storage.getItem(`p/${collidingKey}`)).not.toBeNull();
+    expect(storage.getItem(`p/${collidingKey}`)).not.toBe(JSON.stringify(snap(collidingKey, 1)));
+  });
+
+  it('save / load / delete report a clear error for lone-surrogate (malformed UTF-16) keys', async () => {
+    // encodeURIComponent throws URIError on lone surrogates. The pre-
+    // split layout accepted such strings verbatim because it wrote
+    // them to storage unchanged. After the split, callers that pass
+    // one get a store-specific error pointing at the offending key
+    // instead of a bare runtime URIError.
+    const storage = new FakeStorage();
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    const loneSurrogate = '\uD800'; // High surrogate with no matching low.
+
+    await expect(store.save(loneSurrogate, snap('x', 0))).rejects.toThrow(
+      /not a well-formed UTF-16 string/,
+    );
+    await expect(store.load(loneSurrogate)).rejects.toThrow(/not a well-formed UTF-16 string/);
+    await expect(store.delete(loneSurrogate)).rejects.toThrow(/not a well-formed UTF-16 string/);
+  });
+
+  it('migration skips malformed-UTF-16 legacy entries without crashing store init', async () => {
+    // A legacy index could theoretically list a key whose string
+    // representation is not well-formed UTF-16 (lone surrogate). Pre-
+    // fix, encodeURIComponent on such a string would throw from inside
+    // migration and block the whole constructor from succeeding. The
+    // store now skips those entries and migrates the rest.
+    const storage = new FakeStorage();
+    const loneSurrogate = '\uD800';
+    storage.setItem(`p/${loneSurrogate}`, JSON.stringify(snap('wellformed', 0)));
+    storage.setItem('p/good', JSON.stringify(snap('good', 0)));
+    storage.setItem('p/__agentonomous/index__', JSON.stringify([loneSurrogate, 'good']));
+
+    // Constructor must succeed.
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    // `good` migrated; the malformed key was skipped, not crashed on.
+    expect([...(await store.list())]).toEqual(['good']);
+    expect(await store.load('good')).toMatchObject({ identity: { id: 'good' } });
+  });
+
   it("rejects an empty prefix so migration can't match and nuke unrelated storage keys", () => {
     // A prefix of '' would make startsWith(prefix) true for every key in
     // the storage, so migration would rewrite and delete unrelated

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -13,21 +13,8 @@ function snap(id: string, at = 0): AgentSnapshot {
   };
 }
 
-/**
- * Minimal `Storage`-shaped fake that supports iteration. Mirrors the
- * browser `Storage` API (getItem / setItem / removeItem / length /
- * key(i)) so migration scans find legacy entries.
- */
 class FakeStorage implements StorageLike {
   private readonly data = new Map<string, string>();
-
-  get length(): number {
-    return this.data.size;
-  }
-
-  key(index: number): string | null {
-    return [...this.data.keys()][index] ?? null;
-  }
 
   getItem(key: string): string | null {
     return this.data.get(key) ?? null;
@@ -46,36 +33,6 @@ class FakeStorage implements StorageLike {
   }
 }
 
-/**
- * `StorageLike`-satisfying fake WITHOUT iteration — exposes only the
- * three methods the public interface requires. Used to assert that
- * persistent custom adapters (which may not implement `length` / `key`)
- * still get legacy data migrated via the legacy-index lookup path.
- */
-class NonIterableStorage implements StorageLike {
-  private readonly data = new Map<string, string>();
-
-  getItem(key: string): string | null {
-    return this.data.get(key) ?? null;
-  }
-
-  setItem(key: string, value: string): void {
-    this.data.set(key, value);
-  }
-
-  removeItem(key: string): void {
-    this.data.delete(key);
-  }
-
-  seed(key: string, value: string): void {
-    this.data.set(key, value);
-  }
-
-  has(key: string): boolean {
-    return this.data.has(key);
-  }
-}
-
 describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () => {
   it('save / load / list / delete round-trip for a plain key', async () => {
     const storage = new FakeStorage();
@@ -90,35 +47,27 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     expect(await store.list()).toEqual([]);
   });
 
-  it("user key equal to the legacy index path ('__agentonomous/index__') no longer corrupts the index", async () => {
+  it("user key that would have collided with the pre-split index path ('__agentonomous/index__') does not overwrite the index", async () => {
     const storage = new FakeStorage();
     const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
 
-    // Save a legitimate entry first so the index is non-empty.
     await store.save('real', snap('real', 1));
-    // Save under a key string that matches the legacy index path byte-for-byte.
-    const evilKey = '__agentonomous/index__';
-    await store.save(evilKey, snap(evilKey, 2));
+    const collidingKey = '__agentonomous/index__';
+    await store.save(collidingKey, snap(collidingKey, 2));
 
-    // Both keys are listed, index unaffected.
-    expect(await store.list()).toEqual(expect.arrayContaining(['real', evilKey]));
+    // Both keys round-trip; index still lists them.
+    expect(await store.list()).toEqual(expect.arrayContaining(['real', collidingKey]));
     expect(await store.load('real')).toMatchObject({ identity: { id: 'real' } });
-    expect(await store.load(evilKey)).toMatchObject({ identity: { id: evilKey } });
+    expect(await store.load(collidingKey)).toMatchObject({ identity: { id: collidingKey } });
 
-    // Index is stored under the new meta path, not the legacy one.
+    // Index lives at the new meta path; the pre-split path is unused.
     expect(storage.getItem('p/__agentonomous/meta/index')).not.toBeNull();
-    // Nothing lives under the legacy index path.
     expect(storage.getItem('p/__agentonomous/index__')).toBeNull();
   });
 
   it('recovers gracefully when the index payload is malformed JSON', async () => {
     const storage = new FakeStorage();
-    // Pre-populate storage with a corrupt index BEFORE constructing the
-    // store. Stamp the migrated sentinel so migration short-circuits
-    // and the corrupt payload is read by list() directly (the path
-    // this test is actually exercising — defensive index parsing).
     storage.setItem('p/__agentonomous/meta/index', '{not valid json');
-    storage.setItem('p/__agentonomous/meta/migrated', '__agentonomous_v2_migrated__');
     const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
 
     // list() does not throw; returns empty.
@@ -142,232 +91,21 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
       expect(await store.load(k)).toMatchObject({ identity: { id: k } });
     }
 
-    // No raw storage key contains the unencoded special chars in the
-    // user-supplied portion — all live under the encoded data/ prefix.
-    // Entries under the meta/ sub-namespace (index, migrated sentinel)
-    // are internal bookkeeping and not subject to the data-encoding
-    // invariant.
+    // Every raw storage key is either the meta index or lives under
+    // the encoded data prefix.
     for (const rawKey of storage.rawKeys()) {
-      if (rawKey.startsWith('p/__agentonomous/meta/')) continue;
+      if (rawKey === 'p/__agentonomous/meta/index') continue;
       expect(rawKey.startsWith('p/__agentonomous/data/')).toBe(true);
     }
   });
 
-  it('migrates legacy (pre-split) entries on construction', async () => {
-    const storage = new FakeStorage();
-    // Seed storage with the v1 layout: `{prefix}{userKey}` payloads and a
-    // `{prefix}__agentonomous/index__` index.
-    storage.setItem('p/alpha', JSON.stringify(snap('alpha', 1)));
-    storage.setItem('p/beta', JSON.stringify(snap('beta', 2)));
-    storage.setItem('p/__agentonomous/index__', JSON.stringify(['alpha', 'beta']));
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    // list() reports decoded user keys.
-    const listed = [...(await store.list())].sort();
-    expect(listed).toEqual(['alpha', 'beta']);
-
-    // Payloads load from the new encoded data path.
-    expect(await store.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
-    expect(await store.load('beta')).toMatchObject({ identity: { id: 'beta' } });
-
-    // Legacy keys are gone from raw storage; new keys under data/ + meta/.
-    expect(storage.getItem('p/alpha')).toBeNull();
-    expect(storage.getItem('p/beta')).toBeNull();
-    expect(storage.getItem('p/__agentonomous/index__')).toBeNull();
-    expect(storage.getItem('p/__agentonomous/data/alpha')).not.toBeNull();
-    expect(storage.getItem('p/__agentonomous/data/beta')).not.toBeNull();
-    expect(storage.getItem('p/__agentonomous/meta/index')).not.toBeNull();
-  });
-
-  it('migration recovers data entries even when the legacy index is missing', async () => {
-    // The legacy shipping bug could have wiped the index (user key ==
-    // '__agentonomous/index__'). Data entries still live under raw
-    // prefixed paths; migration picks them up from the storage scan.
-    const storage = new FakeStorage();
-    storage.setItem('p/alpha', JSON.stringify(snap('alpha', 1)));
-    storage.setItem('p/beta', JSON.stringify(snap('beta', 2)));
-    // Deliberately no legacy index.
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    const listed = [...(await store.list())].sort();
-    expect(listed).toEqual(['alpha', 'beta']);
-  });
-
-  it('migration handles legacy user keys that look like reserved subpaths', async () => {
-    // v1 layout was `{prefix}{userKey}`, so a user could legitimately have
-    // saved under a key like `__agentonomous/data/foo` or
-    // `__agentonomous/meta/something`. The scan filter that keeps the
-    // migration re-entrant for new-layout entries would otherwise skip
-    // those legacy entries, leaving the data orphaned at the old path
-    // while the new index claimed it existed — `load()` would return
-    // null and the snapshot would be unreachable. The legacy index union
-    // ensures index-registered keys migrate regardless of their shape.
-    const storage = new FakeStorage();
-    const reservedDataKey = '__agentonomous/data/foo';
-    const reservedMetaKey = '__agentonomous/meta/dashboard';
-    storage.setItem(`p/${reservedDataKey}`, JSON.stringify(snap(reservedDataKey, 1)));
-    storage.setItem(`p/${reservedMetaKey}`, JSON.stringify(snap(reservedMetaKey, 2)));
-    storage.setItem('p/__agentonomous/index__', JSON.stringify([reservedDataKey, reservedMetaKey]));
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    const listed = [...(await store.list())].sort();
-    expect(listed).toEqual([reservedDataKey, reservedMetaKey].sort());
-
-    expect(await store.load(reservedDataKey)).toMatchObject({
-      identity: { id: reservedDataKey },
-    });
-    expect(await store.load(reservedMetaKey)).toMatchObject({
-      identity: { id: reservedMetaKey },
-    });
-
-    // Legacy paths cleared; data lives under encoded new-layout paths.
-    expect(storage.getItem(`p/${reservedDataKey}`)).toBeNull();
-    expect(storage.getItem(`p/${reservedMetaKey}`)).toBeNull();
-    expect(storage.getItem('p/__agentonomous/index__')).toBeNull();
-    expect(
-      storage.getItem(`p/__agentonomous/data/${encodeURIComponent(reservedDataKey)}`),
-    ).not.toBeNull();
-    expect(
-      storage.getItem(`p/__agentonomous/data/${encodeURIComponent(reservedMetaKey)}`),
-    ).not.toBeNull();
-  });
-
-  it('migration is idempotent — second construction does not re-process new-layout entries', async () => {
-    // Migration runs once on construction. A second construction over the
-    // same storage must NOT re-process the new-layout `data/` entries
-    // written by the first run as if they were legacy keys (which would
-    // double-encode them and corrupt the layout).
-    const storage = new FakeStorage();
-    storage.setItem('p/alpha', JSON.stringify(snap('alpha', 1)));
-    storage.setItem('p/__agentonomous/index__', JSON.stringify(['alpha']));
-
-    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-    const rawAfterFirst = [...storage.rawKeys()].sort();
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-    const rawAfterSecond = [...storage.rawKeys()].sort();
-
-    expect(rawAfterSecond).toEqual(rawAfterFirst);
-    expect(await store.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
-    expect([...(await store.list())]).toEqual(['alpha']);
-  });
-
-  it('migration works on StorageLike backends that do NOT expose iteration (length/key)', async () => {
-    // Persistent custom adapters (`node-localstorage`-style, custom
-    // IndexedDB shims) may satisfy only the required getItem/setItem/
-    // removeItem surface of StorageLike. Without iteration the store
-    // cannot do an orphan scan, but it CAN still migrate every key
-    // registered in the legacy index — the index path is known, read via
-    // getItem. Snapshots listed in the legacy index must therefore
-    // migrate end-to-end on those backends too.
-    const storage = new NonIterableStorage();
-    storage.seed('p/alpha', JSON.stringify(snap('alpha', 1)));
-    storage.seed('p/beta', JSON.stringify(snap('beta', 2)));
-    storage.seed('p/__agentonomous/index__', JSON.stringify(['alpha', 'beta']));
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    const listed = [...(await store.list())].sort();
-    expect(listed).toEqual(['alpha', 'beta']);
-    expect(await store.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
-    expect(await store.load('beta')).toMatchObject({ identity: { id: 'beta' } });
-
-    // Legacy paths cleared; data lives under the new encoded data path.
-    expect(storage.has('p/alpha')).toBe(false);
-    expect(storage.has('p/beta')).toBe(false);
-    expect(storage.has('p/__agentonomous/index__')).toBe(false);
-    expect(storage.has('p/__agentonomous/data/alpha')).toBe(true);
-    expect(storage.has('p/__agentonomous/data/beta')).toBe(true);
-    expect(storage.has('p/__agentonomous/meta/index')).toBe(true);
-  });
-
-  it('orphan scan recovers v1 data-subpath keys when the legacy index is missing', async () => {
-    // Pathological v1 state: user saved under a key like
-    // `__agentonomous/data/foo` AND the legacy index is missing (the
-    // recovery path this scan is meant to handle). The payload sits at
-    // the old `{prefix}{key}` location; without an orphan scan that
-    // includes the data-subpath shape, migration would leave the
-    // payload behind and `load()` could no longer reach it.
-    const storage = new FakeStorage();
-    const v1Key = '__agentonomous/data/foo';
-    storage.setItem(`p/${v1Key}`, JSON.stringify(snap(v1Key, 1)));
-    // Deliberately no legacy index.
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    expect([...(await store.list())]).toEqual([v1Key]);
-    expect(await store.load(v1Key)).toMatchObject({ identity: { id: v1Key } });
-
-    // Old path cleared; data lives under the new encoded path.
-    expect(storage.getItem(`p/${v1Key}`)).toBeNull();
-    expect(storage.getItem(`p/__agentonomous/data/${encodeURIComponent(v1Key)}`)).not.toBeNull();
-  });
-
-  it('migration skips the legacy index sentinel even when the pre-split index listed it as a user key', async () => {
-    // A v1 store could hit a nasty state: after saving under the evil key
-    // `__agentonomous/index__`, the store's appendIndex path could leave
-    // the legacy index listing `['__agentonomous/index__']` — pointing
-    // back at its own path. If migration treated that entry as a normal
-    // user key, it would copy the index metadata into the data namespace
-    // and `load('__agentonomous/index__')` would return an array typed
-    // as AgentSnapshot, breaking downstream restore.
-    const storage = new FakeStorage();
-    storage.setItem('p/foo', JSON.stringify(snap('foo', 1)));
-    // Legacy index lists a real key AND the index sentinel itself.
-    storage.setItem('p/__agentonomous/index__', JSON.stringify(['foo', '__agentonomous/index__']));
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    // Real user key migrated normally.
-    expect(await store.load('foo')).toMatchObject({ identity: { id: 'foo' } });
-    // Index sentinel is NOT promoted to a data entry.
-    expect(await store.load('__agentonomous/index__')).toBeNull();
-    // Listed keys do not include the sentinel.
-    expect([...(await store.list())]).toEqual(['foo']);
-    // No stray data-namespace write for the sentinel encoding.
-    expect(
-      storage.getItem(`p/__agentonomous/data/${encodeURIComponent('__agentonomous/index__')}`),
-    ).toBeNull();
-    // Legacy index cleared post-migration.
-    expect(storage.getItem('p/__agentonomous/index__')).toBeNull();
-  });
-
-  it('migrates v1 user data saved under the exact META_MIGRATED_KEY sentinel path', async () => {
-    // The re-entrance marker lives at `__agentonomous/meta/migrated`. A
-    // v1 user could legitimately have saved under that exact key before
-    // upgrade. Matching merely on the path's PRESENCE would treat their
-    // snapshot as "migrated already done" and leave it orphaned. The
-    // guard matches the VALUE instead (a distinctive sentinel string),
-    // so v1 payloads at that path fall through into the migration
-    // branch like any other legacy key.
-    const storage = new FakeStorage();
-    const collidingKey = '__agentonomous/meta/migrated';
-    storage.setItem(`p/${collidingKey}`, JSON.stringify(snap(collidingKey, 1)));
-    // Legacy index DELIBERATELY missing so we exercise the rawAtMarker
-    // path (not the legacy-index-parse path).
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    expect([...(await store.list())]).toEqual([collidingKey]);
-    expect(await store.load(collidingKey)).toMatchObject({ identity: { id: collidingKey } });
-    // The marker path now holds the sentinel value, not the old snapshot.
-    expect(storage.getItem(`p/${collidingKey}`)).not.toBeNull();
-    expect(storage.getItem(`p/${collidingKey}`)).not.toBe(JSON.stringify(snap(collidingKey, 1)));
-  });
-
   it('save / load / delete report a clear error for lone-surrogate (malformed UTF-16) keys', async () => {
-    // encodeURIComponent throws URIError on lone surrogates. The pre-
-    // split layout accepted such strings verbatim because it wrote
-    // them to storage unchanged. After the split, callers that pass
-    // one get a store-specific error pointing at the offending key
-    // instead of a bare runtime URIError.
+    // encodeURIComponent throws URIError on lone surrogates. Re-raise
+    // with a store-specific message that points at the offending key.
     const storage = new FakeStorage();
     const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
 
-    const loneSurrogate = '\uD800'; // High surrogate with no matching low.
+    const loneSurrogate = '\uD800';
 
     await expect(store.save(loneSurrogate, snap('x', 0))).rejects.toThrow(
       /not a well-formed UTF-16 string/,
@@ -376,302 +114,10 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     await expect(store.delete(loneSurrogate)).rejects.toThrow(/not a well-formed UTF-16 string/);
   });
 
-  it('orphan scan recovers v1 user keys under __agentonomous/meta/* subpath', async () => {
-    // Pre-split v1 accepted any string as a key. `__agentonomous/meta/
-    // dashboard` was a legal v1 user key. If the legacy index is
-    // missing (original collision bug) the orphan scan is the only
-    // recovery path, and it must not filter out meta-subpath keys or
-    // those snapshots become permanently unreachable after upgrade.
-    const storage = new FakeStorage();
-    const v1MetaKey = '__agentonomous/meta/dashboard';
-    storage.setItem(`p/${v1MetaKey}`, JSON.stringify(snap(v1MetaKey, 1)));
-    // Deliberately no legacy index.
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    expect([...(await store.list())]).toEqual([v1MetaKey]);
-    expect(await store.load(v1MetaKey)).toMatchObject({ identity: { id: v1MetaKey } });
-    expect(storage.getItem(`p/${v1MetaKey}`)).toBeNull();
-    expect(
-      storage.getItem(`p/__agentonomous/data/${encodeURIComponent(v1MetaKey)}`),
-    ).not.toBeNull();
-  });
-
-  it('non-iterable backend tolerates ghost entries in a parseable legacy index', async () => {
-    // Non-iterable adapter. Legacy index lists entries but none of the
-    // payload paths resolve — a stale v1 index where prior deletes
-    // didn't clean up the listing. Under the plan-then-commit
-    // migration policy, no storage writes happen for unresolved
-    // entries, so there's nothing to orphan. The new index drops the
-    // ghosts and migration finalizes cleanly.
-    const storage = new NonIterableStorage();
-    storage.seed('p/__agentonomous/index__', JSON.stringify(['ghost-alpha', 'ghost-beta']));
-    // Deliberately no payloads at `p/ghost-alpha` or `p/ghost-beta`.
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    // Legacy index cleared; marker stamped.
-    expect(storage.has('p/__agentonomous/index__')).toBe(false);
-    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(true);
-    // list() reports the empty state — ghosts were not promoted into
-    // the new-layout index.
-    expect([...(await store.list())]).toEqual([]);
-  });
-
-  it('aborted non-iterable pass does not leave data/ writes behind for a later iterable retry', () => {
-    // Scenario per Codex P1 on 6443730: a prior non-iterable pass
-    // that couldn't finalize must leave NO new-layout entries behind.
-    // Otherwise a subsequent iterable pass's orphan scan would pick
-    // them up as v1 user keys and double-encode them.
-    //
-    // Here we trigger the abort path: non-iterable + unparseable
-    // legacy index. Then we construct a fresh iterable store on the
-    // same storage (promoted via the FakeStorage constructor) and
-    // verify that the iterable pass produces the correct user-facing
-    // state without the double-encoded corruption.
-    const nonIterable = new NonIterableStorage();
-    // Corrupt legacy index (not a string array) forces the abort path.
-    nonIterable.seed('p/__agentonomous/index__', '{"this":"is not an array"}');
-    nonIterable.seed('p/alpha', JSON.stringify(snap('alpha', 1)));
-
-    new LocalStorageSnapshotStore({ storage: nonIterable, prefix: 'p/' });
-
-    // Nothing was written to the data namespace during the aborted pass.
-    expect(nonIterable.has('p/__agentonomous/data/alpha')).toBe(false);
-    // Legacy artifacts preserved for retry.
-    expect(nonIterable.has('p/__agentonomous/index__')).toBe(true);
-    expect(nonIterable.has('p/alpha')).toBe(true);
-    expect(nonIterable.has('p/__agentonomous/meta/migrated')).toBe(false);
-  });
-
-  it('non-iterable backend with no legacy index does NOT stamp the migrated sentinel', () => {
-    // Non-iterable + no legacy index is ambiguous: genuinely fresh
-    // install OR pathological v1 that lost its index to the original
-    // collision bug. On a non-iterable backend we can't tell them
-    // apart — if we stamp the marker in the pathological case,
-    // orphaned `{prefix}{userKey}` payloads become permanently
-    // unreachable (future constructions short-circuit on the marker).
-    // Err safe: refuse to finalize; keep the retry door open for a
-    // later construction on an iterable backend.
-    const storage = new NonIterableStorage();
-    // No seeded data at all.
-
-    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(false);
-  });
-
-  it('aborts migration cleanup when non-iterable backend has a non-parseable legacy index', () => {
-    // Non-iterable backend (StorageLike minimum) + legacy index that
-    // isn't a string array (corrupted, or holds a colliding v1
-    // snapshot). The store has no way to enumerate legacy payload
-    // paths. If migration still cleared the legacy index and stamped
-    // the marker, legacy {prefix}{userKey} entries would become
-    // permanently unreachable after upgrade. Instead, migration must
-    // bail without touching either artifact so a subsequent
-    // construction (maybe on an iterable backend, or after the
-    // corruption is fixed) can retry.
-    const storage = new NonIterableStorage();
-    // Simulate the original v1 collision: legacy index path now holds
-    // a snapshot JSON (not an array).
-    const colliding = JSON.stringify(snap('__agentonomous/index__', 1));
-    storage.seed('p/__agentonomous/index__', colliding);
-    // And a v1 user payload at an unrelated path, which we can't find
-    // via orphan scan on this backend.
-    storage.seed('p/alpha', JSON.stringify(snap('alpha', 2)));
-
-    // Constructor must not crash, and must NOT destroy the legacy
-    // artifacts.
-    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    expect(storage.has('p/__agentonomous/index__')).toBe(true);
-    expect(storage.getItem('p/__agentonomous/index__')).toBe(colliding);
-    expect(storage.has('p/alpha')).toBe(true);
-    // Marker NOT set — next construction can retry.
-    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(false);
-  });
-
-  it('migration skips malformed-UTF-16 legacy entries without crashing store init', async () => {
-    // A legacy index could theoretically list a key whose string
-    // representation is not well-formed UTF-16 (lone surrogate). Pre-
-    // fix, encodeURIComponent on such a string would throw from inside
-    // migration and block the whole constructor from succeeding. The
-    // store now skips those entries and migrates the rest.
-    const storage = new FakeStorage();
-    const loneSurrogate = '\uD800';
-    storage.setItem(`p/${loneSurrogate}`, JSON.stringify(snap('wellformed', 0)));
-    storage.setItem('p/good', JSON.stringify(snap('good', 0)));
-    storage.setItem('p/__agentonomous/index__', JSON.stringify([loneSurrogate, 'good']));
-
-    // Constructor must succeed.
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    // `good` migrated; the malformed key was skipped, not crashed on.
-    expect([...(await store.list())]).toEqual(['good']);
-    expect(await store.load('good')).toMatchObject({ identity: { id: 'good' } });
-  });
-
-  it('construct → save → construct → load round-trips cleanly on iterable backend', async () => {
-    // Codex P0 on f8930fd: the prior fresh-install-no-writes fix
-    // left the migrated sentinel unset, so a subsequent construction
-    // re-scanned the v2 entries saved in between and mis-migrated
-    // them as if they were v1 user keys. The marker must be stamped
-    // lazily on the first save so subsequent constructions
-    // short-circuit before their orphan scan runs.
-    const storage = new FakeStorage();
-
-    // First construction — fresh empty store.
-    const store1 = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-    await store1.save('alpha', snap('alpha', 1));
-    expect(await store1.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
-    expect([...(await store1.list())]).toEqual(['alpha']);
-
-    // Sanity: marker is now present in raw storage.
-    expect(storage.getItem('p/__agentonomous/meta/migrated')).not.toBeNull();
-
-    // Second construction over the same storage — simulates a page
-    // reload or fresh process. Must see the saved data intact.
-    const store2 = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-    expect(await store2.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
-    expect([...(await store2.list())]).toEqual(['alpha']);
-
-    // Raw storage shape should not have changed across reconstruction.
-    expect(storage.getItem('p/__agentonomous/data/alpha')).not.toBeNull();
-    expect(storage.getItem('p/__agentonomous/meta/index')).not.toBeNull();
-  });
-
-  it('fresh install does not perform any storage writes during construction', () => {
-    // A store constructed against empty storage must not call setItem
-    // at all. Otherwise a read-only / quota-exceeded backend would
-    // throw from the constructor for a no-op upgrade path, breaking
-    // consumers who only want to load-and-list pre-existing snapshots.
-    class WriteCountingStorage implements StorageLike {
-      public writes = 0;
-      public removals = 0;
-      private readonly data = new Map<string, string>();
-
-      get length(): number {
-        return this.data.size;
-      }
-
-      key(index: number): string | null {
-        return [...this.data.keys()][index] ?? null;
-      }
-
-      getItem(key: string): string | null {
-        return this.data.get(key) ?? null;
-      }
-
-      setItem(key: string, value: string): void {
-        this.writes++;
-        this.data.set(key, value);
-      }
-
-      removeItem(key: string): void {
-        this.removals++;
-        this.data.delete(key);
-      }
-    }
-
-    const storage = new WriteCountingStorage();
-    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    expect(storage.writes).toBe(0);
-    expect(storage.removals).toBe(0);
-  });
-
-  it('save and delete reject when migration aborted so unresolved legacy data is preserved', async () => {
-    // Non-iterable + unparseable legacy index = migrateLegacyKeys
-    // aborts. Allowing save() to proceed would stamp the marker and
-    // permanently close the recovery path — a later iterable
-    // construction would short-circuit the scan and lose the legacy
-    // payloads. save and delete refuse to mutate in that state.
-    const storage = new NonIterableStorage();
-    storage.seed('p/__agentonomous/index__', '{"corrupt":true}');
-    storage.seed('p/alpha', JSON.stringify(snap('alpha', 1)));
-
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    await expect(store.save('beta', snap('beta', 2))).rejects.toThrow(
-      /legacy migration could not finalize/,
-    );
-    await expect(store.delete('alpha')).rejects.toThrow(/legacy migration could not finalize/);
-
-    // No marker stamped; legacy artifacts preserved for a later retry.
-    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(false);
-    expect(storage.has('p/alpha')).toBe(true);
-    expect(storage.has('p/__agentonomous/index__')).toBe(true);
-  });
-
-  it('save stamps marker before writing data so partial failures never leave data without marker', async () => {
-    // Codex P2 ordering concern: if the data write or appendIndex
-    // throws (quota exhaustion), a prior ordering where the marker
-    // was written last could leave `data/alpha` persisted without
-    // the marker — next construction mis-migrates it. Verify the
-    // marker lands in storage BEFORE the data and index writes.
-    const writeOrder: string[] = [];
-    class OrderCapturingStorage implements StorageLike {
-      private readonly data = new Map<string, string>();
-
-      get length(): number {
-        return this.data.size;
-      }
-
-      key(index: number): string | null {
-        return [...this.data.keys()][index] ?? null;
-      }
-
-      getItem(key: string): string | null {
-        return this.data.get(key) ?? null;
-      }
-
-      setItem(key: string, value: string): void {
-        writeOrder.push(key);
-        this.data.set(key, value);
-      }
-
-      removeItem(key: string): void {
-        this.data.delete(key);
-      }
-    }
-
-    const storage = new OrderCapturingStorage();
-    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
-
-    await store.save('alpha', snap('alpha', 1));
-
-    // First write observed should be the marker stamp, before the
-    // data and index writes.
-    expect(writeOrder[0]).toBe('p/__agentonomous/meta/migrated');
-    expect(writeOrder).toContain('p/__agentonomous/data/alpha');
-    expect(writeOrder).toContain('p/__agentonomous/meta/index');
-    expect(writeOrder.indexOf('p/__agentonomous/meta/migrated')).toBeLessThan(
-      writeOrder.indexOf('p/__agentonomous/data/alpha'),
-    );
-  });
-
-  it("rejects an empty prefix so migration can't match and nuke unrelated storage keys", () => {
-    // A prefix of '' would make startsWith(prefix) true for every key in
-    // the storage, so migration would rewrite and delete unrelated
-    // application data on first construction. Fail loudly at the
-    // boundary instead.
+  it("rejects an empty prefix so it can't collide with unrelated storage keys", () => {
     const storage = new FakeStorage();
     expect(() => new LocalStorageSnapshotStore({ storage, prefix: '' })).toThrow(
       /prefix.*must not be empty/i,
     );
-  });
-
-  it('empty-prefix guard does not corrupt pre-existing unrelated storage data', () => {
-    // Concretely: if a consumer tried the misuse, the constructor must
-    // throw BEFORE migration runs, so any unrelated keys they had in
-    // storage stay untouched.
-    const storage = new FakeStorage();
-    storage.setItem('unrelated-app/userPrefs', JSON.stringify({ theme: 'dark' }));
-    storage.setItem('other-tool/cache', 'abc');
-
-    expect(() => new LocalStorageSnapshotStore({ storage, prefix: '' })).toThrow();
-
-    expect(storage.getItem('unrelated-app/userPrefs')).toBe(JSON.stringify({ theme: 'dark' }));
-    expect(storage.getItem('other-tool/cache')).toBe('abc');
   });
 });

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -415,6 +415,23 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     expect(storage.has('p/__agentonomous/meta/migrated')).toBe(false);
   });
 
+  it('non-iterable backend with no legacy index does NOT stamp the migrated sentinel', () => {
+    // Non-iterable + no legacy index is ambiguous: genuinely fresh
+    // install OR pathological v1 that lost its index to the original
+    // collision bug. On a non-iterable backend we can't tell them
+    // apart — if we stamp the marker in the pathological case,
+    // orphaned `{prefix}{userKey}` payloads become permanently
+    // unreachable (future constructions short-circuit on the marker).
+    // Err safe: refuse to finalize; keep the retry door open for a
+    // later construction on an iterable backend.
+    const storage = new NonIterableStorage();
+    // No seeded data at all.
+
+    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(false);
+  });
+
   it('aborts migration cleanup when non-iterable backend has a non-parseable legacy index', () => {
     // Non-iterable backend (StorageLike minimum) + legacy index that
     // isn't a string array (corrupted, or holds a colliding v1

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -158,4 +158,64 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     const listed = [...(await store.list())].sort();
     expect(listed).toEqual(['alpha', 'beta']);
   });
+
+  it('migration handles legacy user keys that look like reserved subpaths', async () => {
+    // v1 layout was `{prefix}{userKey}`, so a user could legitimately have
+    // saved under a key like `__agentonomous/data/foo` or
+    // `__agentonomous/meta/something`. The scan filter that keeps the
+    // migration re-entrant for new-layout entries would otherwise skip
+    // those legacy entries, leaving the data orphaned at the old path
+    // while the new index claimed it existed — `load()` would return
+    // null and the snapshot would be unreachable. The legacy index union
+    // ensures index-registered keys migrate regardless of their shape.
+    const storage = new FakeStorage();
+    const reservedDataKey = '__agentonomous/data/foo';
+    const reservedMetaKey = '__agentonomous/meta/dashboard';
+    storage.setItem(`p/${reservedDataKey}`, JSON.stringify(snap(reservedDataKey, 1)));
+    storage.setItem(`p/${reservedMetaKey}`, JSON.stringify(snap(reservedMetaKey, 2)));
+    storage.setItem('p/__agentonomous/index__', JSON.stringify([reservedDataKey, reservedMetaKey]));
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    const listed = [...(await store.list())].sort();
+    expect(listed).toEqual([reservedDataKey, reservedMetaKey].sort());
+
+    expect(await store.load(reservedDataKey)).toMatchObject({
+      identity: { id: reservedDataKey },
+    });
+    expect(await store.load(reservedMetaKey)).toMatchObject({
+      identity: { id: reservedMetaKey },
+    });
+
+    // Legacy paths cleared; data lives under encoded new-layout paths.
+    expect(storage.getItem(`p/${reservedDataKey}`)).toBeNull();
+    expect(storage.getItem(`p/${reservedMetaKey}`)).toBeNull();
+    expect(storage.getItem('p/__agentonomous/index__')).toBeNull();
+    expect(
+      storage.getItem(`p/__agentonomous/data/${encodeURIComponent(reservedDataKey)}`),
+    ).not.toBeNull();
+    expect(
+      storage.getItem(`p/__agentonomous/data/${encodeURIComponent(reservedMetaKey)}`),
+    ).not.toBeNull();
+  });
+
+  it('migration is idempotent — second construction does not re-process new-layout entries', async () => {
+    // Migration runs once on construction. A second construction over the
+    // same storage must NOT re-process the new-layout `data/` entries
+    // written by the first run as if they were legacy keys (which would
+    // double-encode them and corrupt the layout).
+    const storage = new FakeStorage();
+    storage.setItem('p/alpha', JSON.stringify(snap('alpha', 1)));
+    storage.setItem('p/__agentonomous/index__', JSON.stringify(['alpha']));
+
+    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+    const rawAfterFirst = [...storage.rawKeys()].sort();
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+    const rawAfterSecond = [...storage.rawKeys()].sort();
+
+    expect(rawAfterSecond).toEqual(rawAfterFirst);
+    expect(await store.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
+    expect([...(await store.list())]).toEqual(['alpha']);
+  });
 });

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -278,6 +278,35 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     expect(storage.has('p/__agentonomous/meta/index')).toBe(true);
   });
 
+  it('migration skips the legacy index sentinel even when the pre-split index listed it as a user key', async () => {
+    // A v1 store could hit a nasty state: after saving under the evil key
+    // `__agentonomous/index__`, the store's appendIndex path could leave
+    // the legacy index listing `['__agentonomous/index__']` — pointing
+    // back at its own path. If migration treated that entry as a normal
+    // user key, it would copy the index metadata into the data namespace
+    // and `load('__agentonomous/index__')` would return an array typed
+    // as AgentSnapshot, breaking downstream restore.
+    const storage = new FakeStorage();
+    storage.setItem('p/foo', JSON.stringify(snap('foo', 1)));
+    // Legacy index lists a real key AND the index sentinel itself.
+    storage.setItem('p/__agentonomous/index__', JSON.stringify(['foo', '__agentonomous/index__']));
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    // Real user key migrated normally.
+    expect(await store.load('foo')).toMatchObject({ identity: { id: 'foo' } });
+    // Index sentinel is NOT promoted to a data entry.
+    expect(await store.load('__agentonomous/index__')).toBeNull();
+    // Listed keys do not include the sentinel.
+    expect([...(await store.list())]).toEqual(['foo']);
+    // No stray data-namespace write for the sentinel encoding.
+    expect(
+      storage.getItem(`p/__agentonomous/data/${encodeURIComponent('__agentonomous/index__')}`),
+    ).toBeNull();
+    // Legacy index cleared post-migration.
+    expect(storage.getItem('p/__agentonomous/index__')).toBeNull();
+  });
+
   it("rejects an empty prefix so migration can't match and nuke unrelated storage keys", () => {
     // A prefix of '' would make startsWith(prefix) true for every key in
     // the storage, so migration would rewrite and delete unrelated

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentSnapshot } from '../../../src/persistence/AgentSnapshot.js';
+import {
+  LocalStorageSnapshotStore,
+  type StorageLike,
+} from '../../../src/persistence/LocalStorageSnapshotStore.js';
+
+function snap(id: string, at = 0): AgentSnapshot {
+  return {
+    schemaVersion: 1,
+    snapshotAt: at,
+    identity: { id, name: id, version: '0.0.0', role: 'npc', species: 'cat' },
+  };
+}
+
+/**
+ * Minimal `Storage`-shaped fake that supports iteration. Mirrors the
+ * browser `Storage` API (getItem / setItem / removeItem / length /
+ * key(i)) so migration scans find legacy entries.
+ */
+class FakeStorage implements StorageLike {
+  private readonly data = new Map<string, string>();
+
+  get length(): number {
+    return this.data.size;
+  }
+
+  key(index: number): string | null {
+    return [...this.data.keys()][index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+
+  rawKeys(): string[] {
+    return [...this.data.keys()];
+  }
+}
+
+describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () => {
+  it('save / load / list / delete round-trip for a plain key', async () => {
+    const storage = new FakeStorage();
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    await store.save('pet', snap('pet', 10));
+    expect(await store.load('pet')).toMatchObject({ identity: { id: 'pet' } });
+    expect(await store.list()).toEqual(['pet']);
+
+    await store.delete('pet');
+    expect(await store.load('pet')).toBeNull();
+    expect(await store.list()).toEqual([]);
+  });
+
+  it("user key equal to the legacy index path ('__agentonomous/index__') no longer corrupts the index", async () => {
+    const storage = new FakeStorage();
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    // Save a legitimate entry first so the index is non-empty.
+    await store.save('real', snap('real', 1));
+    // Save under a key string that matches the legacy index path byte-for-byte.
+    const evilKey = '__agentonomous/index__';
+    await store.save(evilKey, snap(evilKey, 2));
+
+    // Both keys are listed, index unaffected.
+    expect(await store.list()).toEqual(expect.arrayContaining(['real', evilKey]));
+    expect(await store.load('real')).toMatchObject({ identity: { id: 'real' } });
+    expect(await store.load(evilKey)).toMatchObject({ identity: { id: evilKey } });
+
+    // Index is stored under the new meta path, not the legacy one.
+    expect(storage.getItem('p/__agentonomous/meta/index')).not.toBeNull();
+    // Nothing lives under the legacy index path.
+    expect(storage.getItem('p/__agentonomous/index__')).toBeNull();
+  });
+
+  it('recovers gracefully when the index payload is malformed JSON', async () => {
+    const storage = new FakeStorage();
+    // Pre-populate storage with a corrupt index BEFORE constructing the store
+    // so migration has nothing to rewrite and the corrupt payload survives.
+    storage.setItem('p/__agentonomous/meta/index', '{not valid json');
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    // list() does not throw; returns empty.
+    expect(await store.list()).toEqual([]);
+
+    // Subsequent save overwrites the corrupt index with a valid one.
+    await store.save('pet', snap('pet', 0));
+    expect(await store.list()).toEqual(['pet']);
+  });
+
+  it('round-trips keys containing URI-special characters', async () => {
+    const storage = new FakeStorage();
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    const keys = ['a/b', 'c:d', 'with space', 'café', '🐱-pet', '%20preencoded'];
+    for (const k of keys) await store.save(k, snap(k, 0));
+
+    const listed = [...(await store.list())].sort();
+    expect(listed).toEqual([...keys].sort());
+    for (const k of keys) {
+      expect(await store.load(k)).toMatchObject({ identity: { id: k } });
+    }
+
+    // No raw storage key contains the unencoded special chars in the
+    // user-supplied portion — all live under the encoded data/ prefix.
+    for (const rawKey of storage.rawKeys()) {
+      if (rawKey.endsWith('/meta/index')) continue;
+      expect(rawKey.startsWith('p/__agentonomous/data/')).toBe(true);
+    }
+  });
+
+  it('migrates legacy (pre-split) entries on construction', async () => {
+    const storage = new FakeStorage();
+    // Seed storage with the v1 layout: `{prefix}{userKey}` payloads and a
+    // `{prefix}__agentonomous/index__` index.
+    storage.setItem('p/alpha', JSON.stringify(snap('alpha', 1)));
+    storage.setItem('p/beta', JSON.stringify(snap('beta', 2)));
+    storage.setItem('p/__agentonomous/index__', JSON.stringify(['alpha', 'beta']));
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    // list() reports decoded user keys.
+    const listed = [...(await store.list())].sort();
+    expect(listed).toEqual(['alpha', 'beta']);
+
+    // Payloads load from the new encoded data path.
+    expect(await store.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
+    expect(await store.load('beta')).toMatchObject({ identity: { id: 'beta' } });
+
+    // Legacy keys are gone from raw storage; new keys under data/ + meta/.
+    expect(storage.getItem('p/alpha')).toBeNull();
+    expect(storage.getItem('p/beta')).toBeNull();
+    expect(storage.getItem('p/__agentonomous/index__')).toBeNull();
+    expect(storage.getItem('p/__agentonomous/data/alpha')).not.toBeNull();
+    expect(storage.getItem('p/__agentonomous/data/beta')).not.toBeNull();
+    expect(storage.getItem('p/__agentonomous/meta/index')).not.toBeNull();
+  });
+
+  it('migration recovers data entries even when the legacy index is missing', async () => {
+    // The legacy shipping bug could have wiped the index (user key ==
+    // '__agentonomous/index__'). Data entries still live under raw
+    // prefixed paths; migration picks them up from the storage scan.
+    const storage = new FakeStorage();
+    storage.setItem('p/alpha', JSON.stringify(snap('alpha', 1)));
+    storage.setItem('p/beta', JSON.stringify(snap('beta', 2)));
+    // Deliberately no legacy index.
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    const listed = [...(await store.list())].sort();
+    expect(listed).toEqual(['alpha', 'beta']);
+  });
+});

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -511,6 +511,35 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     expect(await store.load('good')).toMatchObject({ identity: { id: 'good' } });
   });
 
+  it('construct → save → construct → load round-trips cleanly on iterable backend', async () => {
+    // Codex P0 on f8930fd: the prior fresh-install-no-writes fix
+    // left the migrated sentinel unset, so a subsequent construction
+    // re-scanned the v2 entries saved in between and mis-migrated
+    // them as if they were v1 user keys. The marker must be stamped
+    // lazily on the first save so subsequent constructions
+    // short-circuit before their orphan scan runs.
+    const storage = new FakeStorage();
+
+    // First construction — fresh empty store.
+    const store1 = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+    await store1.save('alpha', snap('alpha', 1));
+    expect(await store1.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
+    expect([...(await store1.list())]).toEqual(['alpha']);
+
+    // Sanity: marker is now present in raw storage.
+    expect(storage.getItem('p/__agentonomous/meta/migrated')).not.toBeNull();
+
+    // Second construction over the same storage — simulates a page
+    // reload or fresh process. Must see the saved data intact.
+    const store2 = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+    expect(await store2.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
+    expect([...(await store2.list())]).toEqual(['alpha']);
+
+    // Raw storage shape should not have changed across reconstruction.
+    expect(storage.getItem('p/__agentonomous/data/alpha')).not.toBeNull();
+    expect(storage.getItem('p/__agentonomous/meta/index')).not.toBeNull();
+  });
+
   it('fresh install does not perform any storage writes during construction', () => {
     // A store constructed against empty storage must not call setItem
     // at all. Otherwise a read-only / quota-exceeded backend would

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -511,6 +511,46 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     expect(await store.load('good')).toMatchObject({ identity: { id: 'good' } });
   });
 
+  it('fresh install does not perform any storage writes during construction', () => {
+    // A store constructed against empty storage must not call setItem
+    // at all. Otherwise a read-only / quota-exceeded backend would
+    // throw from the constructor for a no-op upgrade path, breaking
+    // consumers who only want to load-and-list pre-existing snapshots.
+    class WriteCountingStorage implements StorageLike {
+      public writes = 0;
+      public removals = 0;
+      private readonly data = new Map<string, string>();
+
+      get length(): number {
+        return this.data.size;
+      }
+
+      key(index: number): string | null {
+        return [...this.data.keys()][index] ?? null;
+      }
+
+      getItem(key: string): string | null {
+        return this.data.get(key) ?? null;
+      }
+
+      setItem(key: string, value: string): void {
+        this.writes++;
+        this.data.set(key, value);
+      }
+
+      removeItem(key: string): void {
+        this.removals++;
+        this.data.delete(key);
+      }
+    }
+
+    const storage = new WriteCountingStorage();
+    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    expect(storage.writes).toBe(0);
+    expect(storage.removals).toBe(0);
+  });
+
   it("rejects an empty prefix so migration can't match and nuke unrelated storage keys", () => {
     // A prefix of '' would make startsWith(prefix) true for every key in
     // the storage, so migration would rewrite and delete unrelated

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -141,8 +141,11 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
 
     // No raw storage key contains the unencoded special chars in the
     // user-supplied portion — all live under the encoded data/ prefix.
+    // Entries under the meta/ sub-namespace (index, migrated sentinel)
+    // are internal bookkeeping and not subject to the data-encoding
+    // invariant.
     for (const rawKey of storage.rawKeys()) {
-      if (rawKey.endsWith('/meta/index')) continue;
+      if (rawKey.startsWith('p/__agentonomous/meta/')) continue;
       expect(rawKey.startsWith('p/__agentonomous/data/')).toBe(true);
     }
   });
@@ -276,6 +279,28 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     expect(storage.has('p/__agentonomous/data/alpha')).toBe(true);
     expect(storage.has('p/__agentonomous/data/beta')).toBe(true);
     expect(storage.has('p/__agentonomous/meta/index')).toBe(true);
+  });
+
+  it('orphan scan recovers v1 data-subpath keys when the legacy index is missing', async () => {
+    // Pathological v1 state: user saved under a key like
+    // `__agentonomous/data/foo` AND the legacy index is missing (the
+    // recovery path this scan is meant to handle). The payload sits at
+    // the old `{prefix}{key}` location; without an orphan scan that
+    // includes the data-subpath shape, migration would leave the
+    // payload behind and `load()` could no longer reach it.
+    const storage = new FakeStorage();
+    const v1Key = '__agentonomous/data/foo';
+    storage.setItem(`p/${v1Key}`, JSON.stringify(snap(v1Key, 1)));
+    // Deliberately no legacy index.
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    expect([...(await store.list())]).toEqual([v1Key]);
+    expect(await store.load(v1Key)).toMatchObject({ identity: { id: v1Key } });
+
+    // Old path cleared; data lives under the new encoded path.
+    expect(storage.getItem(`p/${v1Key}`)).toBeNull();
+    expect(storage.getItem(`p/__agentonomous/data/${encodeURIComponent(v1Key)}`)).not.toBeNull();
   });
 
   it('migration skips the legacy index sentinel even when the pre-split index listed it as a user key', async () => {

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -373,6 +373,36 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     await expect(store.delete(loneSurrogate)).rejects.toThrow(/not a well-formed UTF-16 string/);
   });
 
+  it('aborts migration cleanup when non-iterable backend has a non-parseable legacy index', () => {
+    // Non-iterable backend (StorageLike minimum) + legacy index that
+    // isn't a string array (corrupted, or holds a colliding v1
+    // snapshot). The store has no way to enumerate legacy payload
+    // paths. If migration still cleared the legacy index and stamped
+    // the marker, legacy {prefix}{userKey} entries would become
+    // permanently unreachable after upgrade. Instead, migration must
+    // bail without touching either artifact so a subsequent
+    // construction (maybe on an iterable backend, or after the
+    // corruption is fixed) can retry.
+    const storage = new NonIterableStorage();
+    // Simulate the original v1 collision: legacy index path now holds
+    // a snapshot JSON (not an array).
+    const colliding = JSON.stringify(snap('__agentonomous/index__', 1));
+    storage.seed('p/__agentonomous/index__', colliding);
+    // And a v1 user payload at an unrelated path, which we can't find
+    // via orphan scan on this backend.
+    storage.seed('p/alpha', JSON.stringify(snap('alpha', 2)));
+
+    // Constructor must not crash, and must NOT destroy the legacy
+    // artifacts.
+    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    expect(storage.has('p/__agentonomous/index__')).toBe(true);
+    expect(storage.getItem('p/__agentonomous/index__')).toBe(colliding);
+    expect(storage.has('p/alpha')).toBe(true);
+    // Marker NOT set — next construction can retry.
+    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(false);
+  });
+
   it('migration skips malformed-UTF-16 legacy entries without crashing store init', async () => {
     // A legacy index could theoretically list a key whose string
     // representation is not well-formed UTF-16 (lone surrogate). Pre-

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -46,6 +46,36 @@ class FakeStorage implements StorageLike {
   }
 }
 
+/**
+ * `StorageLike`-satisfying fake WITHOUT iteration — exposes only the
+ * three methods the public interface requires. Used to assert that
+ * persistent custom adapters (which may not implement `length` / `key`)
+ * still get legacy data migrated via the legacy-index lookup path.
+ */
+class NonIterableStorage implements StorageLike {
+  private readonly data = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.data.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.data.delete(key);
+  }
+
+  seed(key: string, value: string): void {
+    this.data.set(key, value);
+  }
+
+  has(key: string): boolean {
+    return this.data.has(key);
+  }
+}
+
 describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () => {
   it('save / load / list / delete round-trip for a plain key', async () => {
     const storage = new FakeStorage();
@@ -217,5 +247,59 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     expect(rawAfterSecond).toEqual(rawAfterFirst);
     expect(await store.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
     expect([...(await store.list())]).toEqual(['alpha']);
+  });
+
+  it('migration works on StorageLike backends that do NOT expose iteration (length/key)', async () => {
+    // Persistent custom adapters (`node-localstorage`-style, custom
+    // IndexedDB shims) may satisfy only the required getItem/setItem/
+    // removeItem surface of StorageLike. Without iteration the store
+    // cannot do an orphan scan, but it CAN still migrate every key
+    // registered in the legacy index — the index path is known, read via
+    // getItem. Snapshots listed in the legacy index must therefore
+    // migrate end-to-end on those backends too.
+    const storage = new NonIterableStorage();
+    storage.seed('p/alpha', JSON.stringify(snap('alpha', 1)));
+    storage.seed('p/beta', JSON.stringify(snap('beta', 2)));
+    storage.seed('p/__agentonomous/index__', JSON.stringify(['alpha', 'beta']));
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    const listed = [...(await store.list())].sort();
+    expect(listed).toEqual(['alpha', 'beta']);
+    expect(await store.load('alpha')).toMatchObject({ identity: { id: 'alpha' } });
+    expect(await store.load('beta')).toMatchObject({ identity: { id: 'beta' } });
+
+    // Legacy paths cleared; data lives under the new encoded data path.
+    expect(storage.has('p/alpha')).toBe(false);
+    expect(storage.has('p/beta')).toBe(false);
+    expect(storage.has('p/__agentonomous/index__')).toBe(false);
+    expect(storage.has('p/__agentonomous/data/alpha')).toBe(true);
+    expect(storage.has('p/__agentonomous/data/beta')).toBe(true);
+    expect(storage.has('p/__agentonomous/meta/index')).toBe(true);
+  });
+
+  it("rejects an empty prefix so migration can't match and nuke unrelated storage keys", () => {
+    // A prefix of '' would make startsWith(prefix) true for every key in
+    // the storage, so migration would rewrite and delete unrelated
+    // application data on first construction. Fail loudly at the
+    // boundary instead.
+    const storage = new FakeStorage();
+    expect(() => new LocalStorageSnapshotStore({ storage, prefix: '' })).toThrow(
+      /prefix.*must not be empty/i,
+    );
+  });
+
+  it('empty-prefix guard does not corrupt pre-existing unrelated storage data', () => {
+    // Concretely: if a consumer tried the misuse, the constructor must
+    // throw BEFORE migration runs, so any unrelated keys they had in
+    // storage stay untouched.
+    const storage = new FakeStorage();
+    storage.setItem('unrelated-app/userPrefs', JSON.stringify({ theme: 'dark' }));
+    storage.setItem('other-tool/cache', 'abc');
+
+    expect(() => new LocalStorageSnapshotStore({ storage, prefix: '' })).toThrow();
+
+    expect(storage.getItem('unrelated-app/userPrefs')).toBe(JSON.stringify({ theme: 'dark' }));
+    expect(storage.getItem('other-tool/cache')).toBe('abc');
   });
 });

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -580,6 +580,76 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     expect(storage.removals).toBe(0);
   });
 
+  it('save and delete reject when migration aborted so unresolved legacy data is preserved', async () => {
+    // Non-iterable + unparseable legacy index = migrateLegacyKeys
+    // aborts. Allowing save() to proceed would stamp the marker and
+    // permanently close the recovery path — a later iterable
+    // construction would short-circuit the scan and lose the legacy
+    // payloads. save and delete refuse to mutate in that state.
+    const storage = new NonIterableStorage();
+    storage.seed('p/__agentonomous/index__', '{"corrupt":true}');
+    storage.seed('p/alpha', JSON.stringify(snap('alpha', 1)));
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    await expect(store.save('beta', snap('beta', 2))).rejects.toThrow(
+      /legacy migration could not finalize/,
+    );
+    await expect(store.delete('alpha')).rejects.toThrow(/legacy migration could not finalize/);
+
+    // No marker stamped; legacy artifacts preserved for a later retry.
+    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(false);
+    expect(storage.has('p/alpha')).toBe(true);
+    expect(storage.has('p/__agentonomous/index__')).toBe(true);
+  });
+
+  it('save stamps marker before writing data so partial failures never leave data without marker', async () => {
+    // Codex P2 ordering concern: if the data write or appendIndex
+    // throws (quota exhaustion), a prior ordering where the marker
+    // was written last could leave `data/alpha` persisted without
+    // the marker — next construction mis-migrates it. Verify the
+    // marker lands in storage BEFORE the data and index writes.
+    const writeOrder: string[] = [];
+    class OrderCapturingStorage implements StorageLike {
+      private readonly data = new Map<string, string>();
+
+      get length(): number {
+        return this.data.size;
+      }
+
+      key(index: number): string | null {
+        return [...this.data.keys()][index] ?? null;
+      }
+
+      getItem(key: string): string | null {
+        return this.data.get(key) ?? null;
+      }
+
+      setItem(key: string, value: string): void {
+        writeOrder.push(key);
+        this.data.set(key, value);
+      }
+
+      removeItem(key: string): void {
+        this.data.delete(key);
+      }
+    }
+
+    const storage = new OrderCapturingStorage();
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    await store.save('alpha', snap('alpha', 1));
+
+    // First write observed should be the marker stamp, before the
+    // data and index writes.
+    expect(writeOrder[0]).toBe('p/__agentonomous/meta/migrated');
+    expect(writeOrder).toContain('p/__agentonomous/data/alpha');
+    expect(writeOrder).toContain('p/__agentonomous/meta/index');
+    expect(writeOrder.indexOf('p/__agentonomous/meta/migrated')).toBeLessThan(
+      writeOrder.indexOf('p/__agentonomous/data/alpha'),
+    );
+  });
+
   it("rejects an empty prefix so migration can't match and nuke unrelated storage keys", () => {
     // A prefix of '' would make startsWith(prefix) true for every key in
     // the storage, so migration would rewrite and delete unrelated

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -85,8 +85,9 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     const keys = ['a/b', 'c:d', 'with space', 'café', '🐱-pet', '%20preencoded'];
     for (const k of keys) await store.save(k, snap(k, 0));
 
-    const listed = [...(await store.list())].sort();
-    expect(listed).toEqual([...keys].sort());
+    const byCodePoint = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+    const listed = [...(await store.list())].sort(byCodePoint);
+    expect(listed).toEqual([...keys].sort(byCodePoint));
     for (const k of keys) {
       expect(await store.load(k)).toMatchObject({ identity: { id: k } });
     }

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -397,22 +397,51 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     ).not.toBeNull();
   });
 
-  it('non-iterable backend with legacy-index entries that do not resolve leaves artifacts for retry', () => {
+  it('non-iterable backend tolerates ghost entries in a parseable legacy index', async () => {
     // Non-iterable adapter. Legacy index lists entries but none of the
-    // payload paths resolve (getItem returns null) — migration can't
-    // confirm it recovered anything. Finalizing would set the marker
-    // and destroy the legacy index, losing any still-orphaned data a
-    // later retry could recover. Migration must preserve the legacy
-    // artifacts instead.
+    // payload paths resolve — a stale v1 index where prior deletes
+    // didn't clean up the listing. Under the plan-then-commit
+    // migration policy, no storage writes happen for unresolved
+    // entries, so there's nothing to orphan. The new index drops the
+    // ghosts and migration finalizes cleanly.
     const storage = new NonIterableStorage();
     storage.seed('p/__agentonomous/index__', JSON.stringify(['ghost-alpha', 'ghost-beta']));
     // Deliberately no payloads at `p/ghost-alpha` or `p/ghost-beta`.
 
-    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
 
-    // Legacy index retained; migrated sentinel NOT set.
-    expect(storage.has('p/__agentonomous/index__')).toBe(true);
-    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(false);
+    // Legacy index cleared; marker stamped.
+    expect(storage.has('p/__agentonomous/index__')).toBe(false);
+    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(true);
+    // list() reports the empty state — ghosts were not promoted into
+    // the new-layout index.
+    expect([...(await store.list())]).toEqual([]);
+  });
+
+  it('aborted non-iterable pass does not leave data/ writes behind for a later iterable retry', () => {
+    // Scenario per Codex P1 on 6443730: a prior non-iterable pass
+    // that couldn't finalize must leave NO new-layout entries behind.
+    // Otherwise a subsequent iterable pass's orphan scan would pick
+    // them up as v1 user keys and double-encode them.
+    //
+    // Here we trigger the abort path: non-iterable + unparseable
+    // legacy index. Then we construct a fresh iterable store on the
+    // same storage (promoted via the FakeStorage constructor) and
+    // verify that the iterable pass produces the correct user-facing
+    // state without the double-encoded corruption.
+    const nonIterable = new NonIterableStorage();
+    // Corrupt legacy index (not a string array) forces the abort path.
+    nonIterable.seed('p/__agentonomous/index__', '{"this":"is not an array"}');
+    nonIterable.seed('p/alpha', JSON.stringify(snap('alpha', 1)));
+
+    new LocalStorageSnapshotStore({ storage: nonIterable, prefix: 'p/' });
+
+    // Nothing was written to the data namespace during the aborted pass.
+    expect(nonIterable.has('p/__agentonomous/data/alpha')).toBe(false);
+    // Legacy artifacts preserved for retry.
+    expect(nonIterable.has('p/__agentonomous/index__')).toBe(true);
+    expect(nonIterable.has('p/alpha')).toBe(true);
+    expect(nonIterable.has('p/__agentonomous/meta/migrated')).toBe(false);
   });
 
   it('non-iterable backend with no legacy index does NOT stamp the migrated sentinel', () => {

--- a/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
+++ b/tests/unit/persistence/LocalStorageSnapshotStore.test.ts
@@ -113,9 +113,12 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
 
   it('recovers gracefully when the index payload is malformed JSON', async () => {
     const storage = new FakeStorage();
-    // Pre-populate storage with a corrupt index BEFORE constructing the store
-    // so migration has nothing to rewrite and the corrupt payload survives.
+    // Pre-populate storage with a corrupt index BEFORE constructing the
+    // store. Stamp the migrated sentinel so migration short-circuits
+    // and the corrupt payload is read by list() directly (the path
+    // this test is actually exercising — defensive index parsing).
     storage.setItem('p/__agentonomous/meta/index', '{not valid json');
+    storage.setItem('p/__agentonomous/meta/migrated', '__agentonomous_v2_migrated__');
     const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
 
     // list() does not throw; returns empty.
@@ -371,6 +374,45 @@ describe('LocalStorageSnapshotStore — keyspace split (PR #2 remediation)', () 
     );
     await expect(store.load(loneSurrogate)).rejects.toThrow(/not a well-formed UTF-16 string/);
     await expect(store.delete(loneSurrogate)).rejects.toThrow(/not a well-formed UTF-16 string/);
+  });
+
+  it('orphan scan recovers v1 user keys under __agentonomous/meta/* subpath', async () => {
+    // Pre-split v1 accepted any string as a key. `__agentonomous/meta/
+    // dashboard` was a legal v1 user key. If the legacy index is
+    // missing (original collision bug) the orphan scan is the only
+    // recovery path, and it must not filter out meta-subpath keys or
+    // those snapshots become permanently unreachable after upgrade.
+    const storage = new FakeStorage();
+    const v1MetaKey = '__agentonomous/meta/dashboard';
+    storage.setItem(`p/${v1MetaKey}`, JSON.stringify(snap(v1MetaKey, 1)));
+    // Deliberately no legacy index.
+
+    const store = new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    expect([...(await store.list())]).toEqual([v1MetaKey]);
+    expect(await store.load(v1MetaKey)).toMatchObject({ identity: { id: v1MetaKey } });
+    expect(storage.getItem(`p/${v1MetaKey}`)).toBeNull();
+    expect(
+      storage.getItem(`p/__agentonomous/data/${encodeURIComponent(v1MetaKey)}`),
+    ).not.toBeNull();
+  });
+
+  it('non-iterable backend with legacy-index entries that do not resolve leaves artifacts for retry', () => {
+    // Non-iterable adapter. Legacy index lists entries but none of the
+    // payload paths resolve (getItem returns null) — migration can't
+    // confirm it recovered anything. Finalizing would set the marker
+    // and destroy the legacy index, losing any still-orphaned data a
+    // later retry could recover. Migration must preserve the legacy
+    // artifacts instead.
+    const storage = new NonIterableStorage();
+    storage.seed('p/__agentonomous/index__', JSON.stringify(['ghost-alpha', 'ghost-beta']));
+    // Deliberately no payloads at `p/ghost-alpha` or `p/ghost-beta`.
+
+    new LocalStorageSnapshotStore({ storage, prefix: 'p/' });
+
+    // Legacy index retained; migrated sentinel NOT set.
+    expect(storage.has('p/__agentonomous/index__')).toBe(true);
+    expect(storage.has('p/__agentonomous/meta/migrated')).toBe(false);
   });
 
   it('aborts migration cleanup when non-iterable backend has a non-parseable legacy index', () => {


### PR DESCRIPTION
## Summary

- `LocalStorageSnapshotStore` stored payloads and the O(1) index list under `{prefix}{key}`, so a user-supplied key of `'__agentonomous/index__'` silently overwrote the index. `list()` returned garbage and the snapshot was unreachable.
- Fix: split the keyspace into disjoint sub-namespaces — `{prefix}__agentonomous/data/{encodeURIComponent(userKey)}` for payloads, `{prefix}__agentonomous/meta/index` for the index.
- `encodeURIComponent`-encoded user keys cannot escape the data subspace.
- Empty-prefix guard at the constructor: rejects `''` before it could collide with unrelated storage keys.
- Lone-surrogate UTF-16 error wrapping on `save` / `load` / `delete`: `URIError` from `encodeURIComponent` re-raised with a store-specific message.

Track A remediation, PR #2 of 4 — source: 2026-04-24 review §PR-2 (MAJOR). One finding, one PR, regression tests in the same diff per `docs/plans/2026-04-24-polish-and-harden.md`.

## Scope note — migration layer ripped

Earlier revisions of this PR shipped a legacy-migration layer to protect consumers holding the pre-split `{prefix}{userKey}` layout on disk. This is pre-1.0; no package has been published, no storage shape is committed to, no consumer has that layout anywhere. The migration logic was solving a hypothetical.

All migration code has been removed (latest commit). The PR now carries only the real fixes listed above.

## Public API changes

- `StorageLike` interface unchanged (`getItem` / `setItem` / `removeItem`).
- Storage shape is an internal detail; changelog notes that pre-1.0 consumers of earlier pre-release builds should clear their `__agentonomous/` namespace.
- Changeset: **minor** (storage layout shifted; no API-level break).

## Test plan

New `tests/unit/persistence/LocalStorageSnapshotStore.test.ts` covers:

- [x] save / load / list / delete round-trip happy path.
- [x] `key === '__agentonomous/index__'` saves / loads / lists correctly; the index lives at the new meta path.
- [x] Malformed index payload — `list()` recovers gracefully; next `save()` overwrites.
- [x] Encode/decode round-trip for `/`, `:`, space, `é`, emoji, pre-encoded `%20`.
- [x] Lone-surrogate UTF-16 keys produce a store-specific error from `save` / `load` / `delete`.
- [x] Empty prefix is rejected at construction.
- [x] Existing `SnapshotStore.test.ts` block still green (API-level coverage unchanged).
- [x] `npm run verify` green: all tests pass, typecheck + lint + build clean.

## Notes for review

- Bundle size: `dist/index.js` gzip 34.16 → 34.51 KB (+0.35 KB). Well under the 50 KB budget. The migration-layer bump (+1.75 KB) was reverted when the layer was ripped.
- Also adds `graphify-out` to `.prettierignore` — same one-line unblock as PRs #71, #73, #74. First to merge wins; subsequent PRs become no-op diffs against develop.
- Changeset: minor, storage layout changed but no API break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)