### PR TITLE
fix(persistence): pickDefaultSnapshotStore survives throwing localStorage getter

### DIFF
--- a/.changeset/pick-default-store-throwing-localstorage.md
+++ b/.changeset/pick-default-store-throwing-localstorage.md
@@ -1,0 +1,15 @@
+---
+'agentonomous': patch
+---
+
+Fix: `pickDefaultSnapshotStore()` no longer crashes when
+`globalThis.localStorage` is a throwing getter (e.g. sandboxed
+third-party iframes blocked by `SecurityError`, or strict
+private-browsing modes).
+
+The feature probe now wraps the property access in `try` / `catch`
+and falls back to `InMemorySnapshotStore` on any thrown access —
+matching the existing construction-time fallback for denied storage
+quotas. Consumers in those environments previously saw an
+uncaught exception before store selection could finish; now they get
+an in-memory store that "just works".

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ dist
 coverage
 docs
 node_modules
+graphify-out
 *.min.js
 pnpm-lock.yaml
 package-lock.json

--- a/src/persistence/pickDefaultSnapshotStore.ts
+++ b/src/persistence/pickDefaultSnapshotStore.ts
@@ -30,6 +30,15 @@ export function pickDefaultSnapshotStore(): SnapshotStorePort {
 
 function hasBrowserLocalStorage(): boolean {
   if (typeof globalThis === 'undefined') return false;
-  const g = globalThis as { localStorage?: unknown };
-  return typeof g.localStorage === 'object' && g.localStorage !== null;
+  // Some browser environments install a throwing getter for `localStorage`
+  // (e.g. sandboxed third-party iframes blocked by SecurityError, or
+  // strict private-browsing modes). Reading the property throws; guard
+  // so the caller can still fall back to `InMemorySnapshotStore` instead
+  // of crashing before store selection finishes.
+  try {
+    const g = globalThis as { localStorage?: unknown };
+    return typeof g.localStorage === 'object' && g.localStorage !== null;
+  } catch {
+    return false;
+  }
 }

--- a/tests/unit/persistence/pickDefaultSnapshotStore.test.ts
+++ b/tests/unit/persistence/pickDefaultSnapshotStore.test.ts
@@ -30,4 +30,33 @@ describe('pickDefaultSnapshotStore', () => {
     const store = pickDefaultSnapshotStore();
     expect(store).toBeInstanceOf(LocalStorageSnapshotStore);
   });
+
+  it('returns InMemorySnapshotStore when reading globalThis.localStorage throws (e.g. sandboxed iframe SecurityError)', () => {
+    // Install a property descriptor whose getter throws — mirrors the
+    // behavior some browsers use for blocked third-party storage access.
+    // Save + restore via defineProperty so the outer afterEach's plain
+    // assignment can reach a writable property again on cleanup.
+    const prev = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    try {
+      Object.defineProperty(globalThis, 'localStorage', {
+        configurable: true,
+        get() {
+          throw new Error('SecurityError');
+        },
+      });
+      expect(() => pickDefaultSnapshotStore()).not.toThrow();
+      const store = pickDefaultSnapshotStore();
+      expect(store).toBeInstanceOf(InMemorySnapshotStore);
+    } finally {
+      if (prev) {
+        Object.defineProperty(globalThis, 'localStorage', prev);
+      } else {
+        Object.defineProperty(globalThis, 'localStorage', {
+          configurable: true,
+          writable: true,
+          value: undefined,
+        });
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- `pickDefaultSnapshotStore()`'s feature probe read `globalThis.localStorage` without a guard, so environments with a throwing getter (sandboxed third-party iframes, `SecurityError`, strict private-browsing modes) saw an uncaught exception before store selection could finish.
- Fix: wrap the property access in `try` / `catch` and fall back to `InMemorySnapshotStore` on any thrown access — matches the existing construction-time fallback for denied storage quotas.

Track A remediation, PR #3 of 4 — source: 2026-04-24 review §PR-3 (MAJOR). One finding, one PR, regression test in the same diff per `docs/plans/2026-04-24-polish-and-harden.md`.

## Public API changes

None. `pickDefaultSnapshotStore()` signature and return type unchanged; the only observable difference is that environments that previously threw now get an `InMemorySnapshotStore` instead.

Changeset: **patch** (robustness fix; no contract change).

## Test plan

- [x] New negative test: installs a throwing-getter descriptor on `globalThis.localStorage` via `Object.defineProperty({ configurable: true, get() { throw new Error('SecurityError') } })`; restores via `Object.defineProperty` so the outer `afterEach` assignment can reach a writable property again. Asserts `pickDefaultSnapshotStore()` does not throw and returns an `InMemorySnapshotStore`.
- [x] Existing `pickDefaultSnapshotStore` tests (happy path + undefined-localStorage path) still green.
- [x] `npm run verify` green: 456 tests pass, typecheck + lint + build clean.

## Notes for review

- Also adds `graphify-out` to `.prettierignore` — same one-line unblock as PRs #71 and #72. First to merge wins; subsequent PRs become no-op diffs against develop.
- Bundle impact negligible: `dist/index.js` gzip 34.16 → 34.03 KB (noise from re-chunking; the `try`/`catch` itself is ~20 bytes post-minify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)