### PR TITLE
fix(persistence): FsSnapshotStore.list() returns keys in deterministic order

### DIFF
--- a/.changeset/fs-store-deterministic-list-order.md
+++ b/.changeset/fs-store-deterministic-list-order.md
@@ -3,14 +3,17 @@
 ---
 
 Fix: `FsSnapshotStore.list()` now returns keys in deterministic
-`localeCompare` order.
+Unicode code-point order.
 
 Previously the method returned whatever order the underlying
 `readdir(path)` handed back — ext4 hash order, NTFS MFT order, tmpfs
 insertion order, etc. — so a Linux CI run and a Windows developer
 machine could see different results from the same snapshot directory.
 
-The store now sorts the decoded key list before returning. Consumers
-get reproducible output across platforms; determinism-sensitive
-callers (snapshot replay, trace comparisons) no longer need to sort
-themselves.
+The store now sorts the decoded key list with a locale-independent
+code-point comparison before returning. `localeCompare` would
+re-introduce cross-host divergence for non-ASCII keys (different
+`LANG` / ICU locales order them differently), so the store uses raw
+code-point order to stay stable regardless of process locale.
+Determinism-sensitive callers (snapshot replay, trace comparisons) no
+longer need to sort themselves.

--- a/.changeset/fs-store-deterministic-list-order.md
+++ b/.changeset/fs-store-deterministic-list-order.md
@@ -1,0 +1,16 @@
+---
+'agentonomous': patch
+---
+
+Fix: `FsSnapshotStore.list()` now returns keys in deterministic
+`localeCompare` order.
+
+Previously the method returned whatever order the underlying
+`readdir(path)` handed back — ext4 hash order, NTFS MFT order, tmpfs
+insertion order, etc. — so a Linux CI run and a Windows developer
+machine could see different results from the same snapshot directory.
+
+The store now sorts the decoded key list before returning. Consumers
+get reproducible output across platforms; determinism-sensitive
+callers (snapshot replay, trace comparisons) no longer need to sort
+themselves.

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ dist
 coverage
 docs
 node_modules
+graphify-out
 *.min.js
 pnpm-lock.yaml
 package-lock.json

--- a/src/persistence/FsSnapshotStore.ts
+++ b/src/persistence/FsSnapshotStore.ts
@@ -68,6 +68,10 @@ export class FsSnapshotStore implements SnapshotStorePort {
         // surfacing it would just hand callers an unusable key.
       }
     }
+    // Sort before returning so callers see deterministic output across
+    // platforms — ext4, NTFS, tmpfs, and various CI runners all return
+    // readdir entries in different orders.
+    out.sort((a, b) => a.localeCompare(b));
     return out;
   }
 

--- a/src/persistence/FsSnapshotStore.ts
+++ b/src/persistence/FsSnapshotStore.ts
@@ -70,8 +70,11 @@ export class FsSnapshotStore implements SnapshotStorePort {
     }
     // Sort before returning so callers see deterministic output across
     // platforms — ext4, NTFS, tmpfs, and various CI runners all return
-    // readdir entries in different orders.
-    out.sort((a, b) => a.localeCompare(b));
+    // readdir entries in different orders. Use a locale-independent
+    // code-point comparison so the order stays stable regardless of the
+    // host process's `LANG` / ICU locale; `localeCompare` would re-
+    // introduce cross-host divergence for non-ASCII keys.
+    out.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     return out;
   }
 

--- a/tests/unit/persistence/FsSnapshotStore.test.ts
+++ b/tests/unit/persistence/FsSnapshotStore.test.ts
@@ -143,6 +143,26 @@ describe('FsSnapshotStore', () => {
     await expect(store.delete('never-saved')).resolves.toBeUndefined();
   });
 
+  it('list() returns keys in deterministic localeCompare order regardless of readdir order', async () => {
+    // Stub readdir to return an unsorted response — real filesystems do
+    // this (ext4 hash order, NTFS MFT order, tmpfs insertion order), so
+    // list() must sort before returning to give callers reproducible
+    // output across platforms.
+    const unsorted = ['charlie.json', 'alpha.json', 'bravo.json', 'aardvark.json'];
+    const fs: FsAdapter = {
+      readFile: () => Promise.resolve('{}'),
+      writeFile: () => Promise.resolve(),
+      mkdir: () => Promise.resolve(),
+      readdir: () => Promise.resolve([...unsorted]),
+      unlink: () => Promise.resolve(),
+      access: () => Promise.resolve(),
+    };
+    const store = new FsSnapshotStore({ directory: '/var/snaps', fs });
+
+    const keys = await store.list();
+    expect(keys).toEqual(['aardvark', 'alpha', 'bravo', 'charlie']);
+  });
+
   it('list() skips files whose names the encoder would never produce', async () => {
     // Foreign `.json` files in a shared snapshot directory must not cause
     // list() to reject — `decodeURIComponent` throws URIError on malformed

--- a/tests/unit/persistence/FsSnapshotStore.test.ts
+++ b/tests/unit/persistence/FsSnapshotStore.test.ts
@@ -143,7 +143,7 @@ describe('FsSnapshotStore', () => {
     await expect(store.delete('never-saved')).resolves.toBeUndefined();
   });
 
-  it('list() returns keys in deterministic localeCompare order regardless of readdir order', async () => {
+  it('list() returns keys in deterministic order regardless of readdir order', async () => {
     // Stub readdir to return an unsorted response — real filesystems do
     // this (ext4 hash order, NTFS MFT order, tmpfs insertion order), so
     // list() must sort before returning to give callers reproducible
@@ -161,6 +161,43 @@ describe('FsSnapshotStore', () => {
 
     const keys = await store.list();
     expect(keys).toEqual(['aardvark', 'alpha', 'bravo', 'charlie']);
+  });
+
+  it('list() sort is locale-independent — non-ASCII keys follow Unicode code-point order', async () => {
+    // `localeCompare` would re-introduce cross-host divergence for
+    // non-ASCII keys (the sort order depends on the process `LANG` / ICU
+    // locale). The store uses raw code-point comparison instead so the
+    // list() output stays byte-identical across machines regardless of
+    // their configured locale.
+    //
+    // Code points:
+    //   'cafe'  = [99, 97, 102, 101]
+    //   'café'  = [99, 97, 102, 233]
+    //   'caffé' = [99, 97, 102, 102, 233]
+    //   'zebra' = [122, …]
+    // Comparing 'café' vs 'caffé' at index 3: 'é' (233) vs 'f' (102) —
+    // 102 < 233, so 'caffé' sorts BEFORE 'café' in code-point order.
+    // ICU locales typically sort these the other way ('café' < 'caffé')
+    // via collation rules; the test pins the code-point behavior so
+    // we'd catch a regression back to `localeCompare`.
+    const fs: FsAdapter = {
+      readFile: () => Promise.resolve('{}'),
+      writeFile: () => Promise.resolve(),
+      mkdir: () => Promise.resolve(),
+      readdir: () =>
+        Promise.resolve([
+          `${encodeKey('zebra')}.json`,
+          `${encodeKey('café')}.json`,
+          `${encodeKey('cafe')}.json`,
+          `${encodeKey('caffé')}.json`,
+        ]),
+      unlink: () => Promise.resolve(),
+      access: () => Promise.resolve(),
+    };
+    const store = new FsSnapshotStore({ directory: '/var/snaps', fs });
+
+    const keys = await store.list();
+    expect(keys).toEqual(['cafe', 'caffé', 'café', 'zebra']);
   });
 
   it('list() skips files whose names the encoder would never produce', async () => {


### PR DESCRIPTION
## Summary

- `FsSnapshotStore.list()` returned whatever order the underlying `readdir(path)` handed back — ext4 hash order, NTFS MFT order, tmpfs insertion order. A Linux CI run and a Windows developer machine saw different results from the same snapshot directory.
- Fix: sort the decoded key list with `localeCompare` before returning.

Track A remediation, PR #4 of 4 — source: 2026-04-24 review §PR-4 (MINOR). One finding, one PR, regression test in the same diff per `docs/plans/2026-04-24-polish-and-harden.md`.

## Public API changes

None. Signature and return type unchanged; observable behavior tightens from "whatever the filesystem decided" to "`localeCompare`-sorted". Determinism-sensitive callers (snapshot replay, trace comparisons) no longer need to sort themselves.

Changeset: **patch** (determinism fix; no contract change).

## Test plan

- [x] New test: stubs `readdir` to return `['charlie.json', 'alpha.json', 'bravo.json', 'aardvark.json']`; asserts `list()` returns `['aardvark', 'alpha', 'bravo', 'charlie']`.
- [x] Existing `FsSnapshotStore` tests still green (no order assertions broken — the test that compares against `new Set(...)` is unaffected).
- [x] `npm run verify` green: 457 tests pass, typecheck + lint + build clean.

## Notes for review

- `O(n log n)` added to a cold-path method. Negligible on typical key counts.
- Also adds `graphify-out` to `.prettierignore` — same one-line unblock as PRs #71, #72, #73. First to merge wins; subsequent PRs become no-op diffs against develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)