### PR TITLE
chore(ci): add npm audit gate for production deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
 # CI — runs on every push and PR to main, develop, and demo.
 #
-# Static checks (format, lint, typecheck, workflow lint) run in
-# parallel for fast feedback. Tests depend on all four passing. Build +
-# bundle-size budget runs last. Mirrors the `npm run verify` pre-PR
-# gate.
+# Static checks (format, lint, typecheck, workflow lint, audit) run in
+# parallel for fast feedback. Tests depend on the static gate passing.
+# Build + bundle-size budget runs last. Mirrors the `npm run verify`
+# pre-PR gate; `audit` blocks on `high`-severity vulnerabilities in
+# production deps to close the supply-chain hole.
 
 name: CI
 
@@ -77,6 +78,22 @@ jobs:
         with:
           fail_level: error
           reporter: github-check
+
+  audit:
+    name: Audit production deps (npm audit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies (npm ci)
+        run: npm ci
+      - name: Audit production dependencies (high severity blocks)
+        run: npm audit --omit=dev --audit-level=high
 
   docs:
     name: API docs (typedoc)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
   test:
     name: Test (Vitest + coverage)
     runs-on: ubuntu-latest
-    needs: [format-check, lint, typecheck, actionlint, docs]
+    needs: [format-check, lint, typecheck, actionlint, audit, docs]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Add a blocking `audit` job to PR CI running `npm audit --omit=dev --audit-level=high`.
- Closes the brain.js-style supply-chain hole where a known-vulnerable production dep could slip in unnoticed.
- Runs in parallel with the other static checks (no `needs:`) for fast feedback.

Roadmap row 2 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md`.

## Test plan

- [x] `npm audit --omit=dev --audit-level=high` reports `0 vulnerabilities` on current develop.
- [x] `npm run verify` green locally.
- [ ] CI green on this PR.
- [ ] A test PR adding a known-vulnerable dep (e.g. an old `lodash`) fails the gate.

## Notes for review

- `--omit=dev` keeps dev-only vulnerabilities (e.g. transitive build tooling) out of the gate; consumer security is the goal.
- `--audit-level=high` ignores moderate/low — the bar is "would this hurt a consumer importing the lib", not "is the lockfile pristine".
- No changeset — CI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)