### PR TITLE
docs(repo): codebase-review doc fixups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,11 @@ PRs that change library behavior need a changeset (`npm run changeset`).
 Docs / refactor / chore PRs can skip it. The `.changeset/*.md` file goes in
 the same PR.
 
+> The pile of unconsumed changesets on `develop` is intentional — the 1.0
+> publish is held by owner decision until library + demo polish is done.
+> See `MEMORY.md → project_v1_release_hold.md`. Don't run
+> `npx changeset version` to consume them; let them accumulate.
+
 ## Common pitfalls
 
 - **Adding a new `Skill`:** register it via an `AgentModule` or the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,11 @@ Docs / refactor / chore PRs can skip it. The `.changeset/*.md` file goes in
 the same PR.
 
 > The pile of unconsumed changesets on `develop` is intentional — the 1.0
-> publish is held by owner decision until library + demo polish is done.
-> See `MEMORY.md → project_v1_release_hold.md`. Don't run
-> `npx changeset version` to consume them; let them accumulate.
+> publish is held by owner decision until library + demo polish lands.
+> Don't run `npx changeset version` to consume them; let them accumulate
+> until the owner is ready to ship. The next push to `main` is what
+> triggers `changesets/action` to open a version PR; until that happens,
+> the queued bumps stay queued.
 
 ## Common pitfalls
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,20 +108,25 @@ into `develop` afterwards so the fix propagates.
 
 ## Commit messages
 
-Subject line: `<type>(<scope>): <summary>` (Conventional Commits).
+Subject line: `<type>: <summary>` or `<type>(<scope>): <summary>`
+(Conventional Commits — scope optional).
 
 - `type` is one of `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `build`, `ci`.
 - Keep subjects under 72 chars.
 - Body explains **why**, not what. Wrap at 72.
 - One logical change per commit. Squash noise before opening a PR.
 
-Example:
+Examples:
 
 ```
 fix: snapshot mood roundtrip no longer re-emits MoodChanged
 
 The previous restore path set `currentMood` only when a snapshot
 carried one, leaving stale state on partial restores. …
+```
+
+```
+feat(persistence): add LocalStorage adapter
 ```
 
 ## Pull requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ into `develop` afterwards so the fix propagates.
 
 ## Commit messages
 
-Subject line: `<type>: <summary>` or `<Rxx>: <summary>` for remediation items.
+Subject line: `<type>(<scope>): <summary>` (Conventional Commits).
 
 - `type` is one of `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `build`, `ci`.
 - Keep subjects under 72 chars.

--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@ Autonomous agent library for TypeScript simulations. Engine-agnostic, fully
 testable, designed to nurture an agent from birth to death in the browser with
 zero configuration.
 
-**Status:** pre-release (`0.1.0`). The Phase A MVP — a virtual-pet nurture demo
-— ships in `examples/nurture-pet`.
+**Status:** pre-release (`0.0.0` per `package.json`). The Phase A MVP — a
+virtual-pet nurture demo — ships in `examples/nurture-pet`.
 
 **Demo:** https://luis85.github.io/agentonomous/
+
+> **Pre-v1 — not yet on npm.** The package is not published. To evaluate
+> locally, clone this repo and resolve `agentonomous` via a `file:` or
+> `link:` dependency in your consuming project. The `npm install agentonomous`
+> snippet below describes the post-publish flow.
 
 ## What you get
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -78,7 +78,6 @@ const externalPackages = [
   'mistreevous',
   'openai',
   'sim-ecs',
-  'gray-matter',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Bundles four small drift fixes from the 2026-04-24 codebase review into one PR.

- **README.md** — replace stale `(0.1.0)` claim with `0.0.0` (the actual `package.json` version), add a pre-v1 banner above Quickstart pointing local-eval consumers at `file:` / `link:` resolution.
- **CONTRIBUTING.md** — drop the `<Rxx>: <summary>` commit prefix claim. No recent commit uses it; convention is Conventional Commits.
- **vite.config.ts** — remove `gray-matter` from `externalPackages`. Stale entry, not a dep, not imported.
- **CLAUDE.md** — inline a one-paragraph note in `## Changesets` explaining the intentional unconsumed-changeset pile so readers don't try to consume it.

Roadmap row 5 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md`.

## Test plan

- [x] `npm run verify` green locally.
- [x] CI green on this PR.

## Notes for review

- No changeset — docs / config only.
- All four items are independent but tiny; bundled per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)