### PR TITLE
chore(changesets): switch baseBranch from main to develop

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "develop",
   "updateInternalDependencies": "patch",
   "ignore": []
 }


### PR DESCRIPTION
## Summary

`.changeset/config.json` had `baseBranch: "main"` but PRs target `develop` per CLAUDE.md §Non-negotiables. The "changed since base" logic on develop-targeted PRs was undercounting or misclassifying because it diffed against `main`. Flip to `develop` so the changeset CLI sees the right diff base for every day-to-day PR.

Release-time consumption reads the `.changeset/*.md` files directly when `main` advances, so this only changes the during-PR diff base, not the published changelog flow.

Roadmap row 6 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md`.

## Test plan

- [x] `npm run verify` green locally.
- [ ] CI green on this PR.
- [ ] `npx changeset status` on a develop-targeted PR sees the right diff.

## Notes for review

- No changeset — config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)