### PR TITLE
refactor(agent): extract tick helpers to drop Agent.tick complexity

### DIFF
--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -49,7 +49,6 @@ import { INTERACTION_REQUESTED } from '../interaction/InteractionRequestedEvent.
 import type { AgentFacade } from './AgentFacade.js';
 import type { AgentIdentity } from './AgentIdentity.js';
 import type { AgentModule, ReactiveHandler } from './AgentModule.js';
-import { isInvokeSkillAction } from './AgentAction.js';
 import type { ControlMode } from './ControlMode.js';
 import type { DecisionTrace } from './DecisionTrace.js';
 import { InvalidTimeScaleError, MissingDependencyError } from './errors.js';
@@ -60,6 +59,11 @@ import { MoodReconciler } from './internal/MoodReconciler.js';
 import { AnimationReconciler } from './internal/AnimationReconciler.js';
 import { CognitionPipeline } from './internal/CognitionPipeline.js';
 import { runRestore } from './internal/RestoreCoordinator.js';
+import {
+  buildHaltedTrace,
+  buildTickDeltas,
+  summarizeSelectedAction,
+} from './internal/tickHelpers.js';
 import { runDeath } from './internal/DeathCoordinator.js';
 import { assembleSnapshot } from './internal/SnapshotAssembler.js';
 
@@ -318,17 +322,14 @@ export class Agent {
 
     // Stage -1: halted short-circuit.
     if (this.halted) {
-      return {
+      return buildHaltedTrace({
         agentId: this.identity.id,
         tickStartedAt,
         virtualDtSeconds,
         controlMode: this.controlMode,
-        stage: DECEASED_STAGE,
-        halted: true,
         perceived: [],
-        actions: [],
         emitted: [],
-      };
+      });
     }
 
     this.emittedThisTick = [];
@@ -365,17 +366,14 @@ export class Agent {
     // If health just hit 0 during decay we die here and short-circuit.
     const needsDeltas = this.needsTicker.run(virtualDtSeconds, tickStartedAt);
     if (this.halted) {
-      return {
+      return buildHaltedTrace({
         agentId: this.identity.id,
         tickStartedAt,
         virtualDtSeconds,
         controlMode: this.controlMode,
-        stage: DECEASED_STAGE,
-        halted: true,
         perceived,
-        actions: [],
         emitted: [...this.emittedThisTick],
-      };
+      });
     }
 
     // Stage 2.7: mood evaluate. Skipped at scale 0.
@@ -405,18 +403,15 @@ export class Agent {
     }
 
     // Stage 10: return trace.
-    const deltasRecord: Record<string, unknown> = {};
-    if (needsDeltas.length > 0) deltasRecord.needs = needsDeltas;
-    if (expired.length > 0) deltasRecord.modifiersExpired = expired.map((r) => r.modifier.id);
-    const activeModifierIds = this.modifiers.list().map((m) => m.id);
-    if (activeModifierIds.length > 0) deltasRecord.activeModifiers = activeModifierIds;
-    if (stageTransitions.length > 0) {
-      deltasRecord.stageTransitions = stageTransitions;
-    }
-    if (moodChange) deltasRecord.mood = moodChange;
-    if (animationTransition) deltasRecord.animation = animationTransition;
-    if (candidates.length > 0) deltasRecord.candidates = candidates;
-    const deltas = Object.keys(deltasRecord).length > 0 ? deltasRecord : undefined;
+    const deltas = buildTickDeltas({
+      needsDeltas,
+      expired,
+      activeModifierIds: this.modifiers.list().map((m) => m.id),
+      stageTransitions,
+      moodChange,
+      animationTransition,
+      candidates,
+    });
 
     const stage: LifeStage = this.ageModel?.stage ?? 'alive';
     const trace: DecisionTrace = {
@@ -438,13 +433,7 @@ export class Agent {
     // flows through `this.publish(...)` so subscribers receive it via
     // `agent.subscribe` like any other event.
     this.ticksEmitted += 1;
-    const firstAction = actions[0];
-    const selectedAction =
-      firstAction === undefined
-        ? null
-        : isInvokeSkillAction(firstAction)
-          ? { type: firstAction.type, skillId: firstAction.skillId }
-          : { type: firstAction.type };
+    const selectedAction = summarizeSelectedAction(actions);
     this.publish({
       type: AGENT_TICKED,
       at: tickStartedAt,

--- a/src/agent/internal/tickHelpers.ts
+++ b/src/agent/internal/tickHelpers.ts
@@ -1,0 +1,90 @@
+import { isInvokeSkillAction, type AgentAction } from '../AgentAction.js';
+import type { DomainEvent } from '../../events/DomainEvent.js';
+import type { ControlMode } from '../ControlMode.js';
+import type { DecisionTrace } from '../DecisionTrace.js';
+import { DECEASED_STAGE } from '../../lifecycle/LifeStage.js';
+import type { IntentionCandidate } from '../../cognition/IntentionCandidate.js';
+import type { LifeStageTransition } from '../../lifecycle/AgeModel.js';
+import type { ModifierRemoval } from '../../modifiers/Modifiers.js';
+import type { NeedsDelta } from '../../needs/Need.js';
+
+/**
+ * Selected-action summary for `AgentTickedEvent`. `null` when the tick
+ * decided no action; otherwise mirrors the action's discriminant + (for
+ * invoke-skill) the skill id.
+ */
+export type SelectedActionSummary = { type: string; skillId?: string } | null;
+
+/**
+ * Inputs that feed `Agent.tick`'s `deltas` record. Each field is omitted
+ * from the resulting record when empty / null — keeps the trace shape
+ * stable across ticks where a subsystem produced nothing.
+ */
+export interface TickDeltasInput {
+  needsDeltas: readonly NeedsDelta[];
+  expired: readonly ModifierRemoval[];
+  activeModifierIds: readonly string[];
+  stageTransitions: readonly LifeStageTransition[];
+  moodChange: { from: string | undefined; to: string; valence: number | undefined } | null;
+  animationTransition: { from: string; to: string; reason?: string } | null;
+  candidates: readonly IntentionCandidate[];
+}
+
+/** Inputs needed to assemble a halted-tick `DecisionTrace`. */
+export interface HaltedTraceInput {
+  agentId: string;
+  tickStartedAt: number;
+  virtualDtSeconds: number;
+  controlMode: ControlMode;
+  perceived: readonly DomainEvent[];
+  emitted: readonly DomainEvent[];
+}
+
+/**
+ * Builds the optional `deltas` record from the per-stage tick outputs.
+ * Returns `undefined` when no subsystem produced anything — keeps
+ * `DecisionTrace.deltas` cleanly absent on idle ticks.
+ */
+export function buildTickDeltas(input: TickDeltasInput): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {};
+  if (input.needsDeltas.length > 0) out.needs = input.needsDeltas;
+  if (input.expired.length > 0) out.modifiersExpired = input.expired.map((r) => r.modifier.id);
+  if (input.activeModifierIds.length > 0) out.activeModifiers = input.activeModifierIds;
+  if (input.stageTransitions.length > 0) out.stageTransitions = input.stageTransitions;
+  if (input.moodChange) out.mood = input.moodChange;
+  if (input.animationTransition) out.animation = input.animationTransition;
+  if (input.candidates.length > 0) out.candidates = input.candidates;
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Builds the `DecisionTrace` returned from a halted tick (deceased
+ * short-circuit at Stage -1 or mid-tick death from Stage 2.5 needs).
+ * Both call-sites share the same shape; centralizing prevents drift.
+ */
+export function buildHaltedTrace(input: HaltedTraceInput): DecisionTrace {
+  return {
+    agentId: input.agentId,
+    tickStartedAt: input.tickStartedAt,
+    virtualDtSeconds: input.virtualDtSeconds,
+    controlMode: input.controlMode,
+    stage: DECEASED_STAGE,
+    halted: true,
+    perceived: input.perceived,
+    actions: [],
+    emitted: input.emitted,
+  };
+}
+
+/**
+ * Maps the tick's first decided action (if any) to the
+ * `AgentTickedEvent.selectedAction` summary shape.
+ */
+export function summarizeSelectedAction(actions: readonly AgentAction[]): SelectedActionSummary {
+  const first = actions[0];
+  if (first === undefined) return null;
+  if (isInvokeSkillAction(first)) {
+    return { type: first.type, skillId: first.skillId };
+  }
+  return { type: first.type };
+}


### PR DESCRIPTION
## Summary

Reduces `Agent.tick`'s cyclomatic complexity **21 → under 15** by lifting three internal patterns into `src/agent/internal/tickHelpers.ts`:

- **`buildHaltedTrace(input)`** — replaces the two duplicated halted-trace return blocks (Stage -1 deceased short-circuit, Stage 2.5 mid-tick death from needs).
- **`buildTickDeltas(input)`** — replaces the 8 conditional `if (… > 0) out.X = …` lines that built the optional `deltas` record. Returns `undefined` when no subsystem produced anything.
- **`summarizeSelectedAction(actions)`** — replaces the inline `firstAction === undefined ? null : isInvokeSkillAction(...) ? …` ternary chain that mapped an action to the `AgentTickedEvent` summary shape.

`Agent.tick` is now a flat orchestration; helpers carry the decision-shaping. No public API changes; trace + event shapes identical.

Roadmap row 8 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md`.

## Test plan

- [x] `npm run verify` green locally (format, lint, typecheck, test, build, docs).
- [x] `Agent.tick` no longer flagged by ESLint `complexity` rule.
- [x] CI green on this PR.

## Notes for review

- No public API changes.
- Helpers live under `src/agent/internal/` (per CLAUDE.md, not re-exported from the barrel).
- No changeset — refactor with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)