### PR TITLE
refactor(agent): drop constructor + restore complexity below ratchet cap

### DIFF
--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -9,40 +9,33 @@ import {
   type ModifierRemovedEvent,
 } from '../events/standardEvents.js';
 import {
-  AnimationStateMachine,
+  type AnimationStateMachine,
   type AnimationStateMachineOptions,
 } from '../animation/AnimationStateMachine.js';
 import type { Embodiment } from '../body/Embodiment.js';
 import type { BehaviorRunner } from '../cognition/behavior/BehaviorRunner.js';
-import { DirectBehaviorRunner } from '../cognition/behavior/DirectBehaviorRunner.js';
 import type { Learner } from '../cognition/learning/Learner.js';
-import { NoopLearner } from '../cognition/learning/NoopLearner.js';
 import type { Reasoner } from '../cognition/reasoning/Reasoner.js';
-import { UrgencyReasoner } from '../cognition/reasoning/UrgencyReasoner.js';
 import type { NeedsPolicy } from '../needs/NeedsPolicy.js';
 import type { AgeModel } from '../lifecycle/AgeModel.js';
 import { DECEASED_STAGE, type LifeStage } from '../lifecycle/LifeStage.js';
 import type { StageCapabilityMap } from '../lifecycle/StageCapabilities.js';
 import type { MemoryRepository } from '../memory/MemoryRepository.js';
 import type { Modifier } from '../modifiers/Modifier.js';
-import { Modifiers } from '../modifiers/Modifiers.js';
+import { type Modifiers } from '../modifiers/Modifiers.js';
 import type { Mood } from '../mood/Mood.js';
 import type { MoodModel } from '../mood/MoodModel.js';
 import type { Needs } from '../needs/Needs.js';
 import type { AgentSnapshot, SnapshotPart } from '../persistence/AgentSnapshot.js';
-import {
-  AutoSaveTracker,
-  DEFAULT_AUTOSAVE_POLICY,
-  type AutoSavePolicy,
-} from '../persistence/AutoSavePolicy.js';
+import type { AutoSaveTracker, AutoSavePolicy } from '../persistence/AutoSavePolicy.js';
 import type { SnapshotStorePort } from '../persistence/SnapshotStorePort.js';
 import type { RandomEventTicker } from '../randomEvents/RandomEventTicker.js';
-import { SkillRegistry } from '../skills/SkillRegistry.js';
+import { type SkillRegistry } from '../skills/SkillRegistry.js';
 import type { RemoteController } from './RemoteController.js';
 import type { ScriptedController } from './ScriptedController.js';
 import type { Rng } from '../ports/Rng.js';
 import type { WallClock } from '../ports/WallClock.js';
-import { NullLogger, type Logger } from '../ports/Logger.js';
+import type { Logger } from '../ports/Logger.js';
 import type { Validator } from '../ports/Validator.js';
 import type { AgentState } from '../persistence/AgentState.js';
 import { INTERACTION_REQUESTED } from '../interaction/InteractionRequestedEvent.js';
@@ -51,7 +44,7 @@ import type { AgentIdentity } from './AgentIdentity.js';
 import type { AgentModule, ReactiveHandler } from './AgentModule.js';
 import type { ControlMode } from './ControlMode.js';
 import type { DecisionTrace } from './DecisionTrace.js';
-import { InvalidTimeScaleError, MissingDependencyError } from './errors.js';
+import { InvalidTimeScaleError } from './errors.js';
 import { LifecycleTicker } from './internal/LifecycleTicker.js';
 import { ModifiersTicker } from './internal/ModifiersTicker.js';
 import { NeedsTicker } from './internal/NeedsTicker.js';
@@ -66,8 +59,13 @@ import {
 } from './internal/tickHelpers.js';
 import { runDeath } from './internal/DeathCoordinator.js';
 import { assembleSnapshot } from './internal/SnapshotAssembler.js';
-
-const DEFAULT_TIME_SCALE = 1;
+import {
+  assertRequiredDeps,
+  resolveCognition,
+  resolveCorePorts,
+  resolvePersistence,
+  resolveSubsystems,
+} from './internal/agentDepsResolver.js';
 
 /**
  * Dependencies required to construct an `Agent` directly.
@@ -213,48 +211,45 @@ export class Agent {
   private readonly cognitionPipeline: CognitionPipeline;
 
   constructor(deps: AgentDependencies) {
-    if (!deps.identity) throw new MissingDependencyError('identity');
-    if (!deps.eventBus) throw new MissingDependencyError('eventBus');
-    if (!deps.clock) throw new MissingDependencyError('clock');
-    if (!deps.rng) throw new MissingDependencyError('rng');
-
+    assertRequiredDeps(deps);
     this.identity = deps.identity;
     this.eventBus = deps.eventBus;
     this.clock = deps.clock;
     this.rng = deps.rng;
-    this.logger = deps.logger ?? new NullLogger();
-    this.validator = deps.validator;
-    this.timeScale = deps.timeScale ?? DEFAULT_TIME_SCALE;
-    this.controlMode = deps.controlMode ?? 'autonomous';
-    this.needs = deps.needs;
-    this.modifiers = deps.modifiers ?? new Modifiers();
-    this.ageModel = deps.ageModel;
-    this.stageCapabilities = deps.stageCapabilities;
-    this.moodModel = deps.moodModel;
-    this.embodiment = deps.embodiment;
-    this.randomEvents = deps.randomEvents;
-    this.memory = deps.memory;
-    this.remote = deps.remote;
-    this.scripted = deps.scripted;
-    this.snapshotStore = deps.snapshotStore;
-    this.autoSaveKey = deps.autoSaveKey ?? this.identity.id;
-    this.autoSaveTracker =
-      this.snapshotStore !== undefined
-        ? new AutoSaveTracker(deps.autoSave ?? DEFAULT_AUTOSAVE_POLICY)
-        : undefined;
-    this.reasoner = deps.reasoner ?? new UrgencyReasoner();
-    this.behavior = deps.behavior ?? new DirectBehaviorRunner();
-    this.learner = deps.learner ?? new NoopLearner();
-    this.skills = deps.skills ?? new SkillRegistry();
-    this.needsPolicy = deps.needsPolicy;
-    this.animation =
-      deps.animation instanceof AnimationStateMachine
-        ? deps.animation
-        : new AnimationStateMachine(deps.animation);
+
+    const ports = resolveCorePorts(deps);
+    this.logger = ports.logger;
+    this.validator = ports.validator;
+    this.timeScale = ports.timeScale;
+    this.controlMode = ports.controlMode;
+
+    const subs = resolveSubsystems(deps);
+    this.needs = subs.needs;
+    this.modifiers = subs.modifiers;
+    this.ageModel = subs.ageModel;
+    this.stageCapabilities = subs.stageCapabilities;
+    this.moodModel = subs.moodModel;
+    this.embodiment = subs.embodiment;
+    this.randomEvents = subs.randomEvents;
+    this.memory = subs.memory;
+    this.remote = subs.remote;
+    this.scripted = subs.scripted;
+
+    const cog = resolveCognition(deps);
+    this.reasoner = cog.reasoner;
+    this.behavior = cog.behavior;
+    this.learner = cog.learner;
+    this.skills = cog.skills;
+    this.needsPolicy = cog.needsPolicy;
+    this.animation = cog.animation;
+
+    const persistence = resolvePersistence(deps, this.identity.id);
+    this.snapshotStore = persistence.snapshotStore;
+    this.autoSaveKey = persistence.autoSaveKey;
+    this.autoSaveTracker = persistence.autoSaveTracker;
+
     this.virtualNowSeconds = this.ageModel?.ageSeconds ?? 0;
-    if (this.ageModel?.stage === DECEASED_STAGE) {
-      this.halted = true;
-    }
+    if (this.ageModel?.stage === DECEASED_STAGE) this.halted = true;
 
     // Wire up the tick-pipeline helpers. They keep a reference back to the
     // agent and read/mutate state through the (now-public) field surface.
@@ -265,7 +260,6 @@ export class Agent {
     this.animationReconciler = new AnimationReconciler(this);
     this.cognitionPipeline = new CognitionPipeline(this);
 
-    // Install config-time modules.
     for (const mod of deps.modules ?? []) {
       this.installModule(mod);
     }

--- a/src/agent/internal/RestoreCoordinator.ts
+++ b/src/agent/internal/RestoreCoordinator.ts
@@ -33,92 +33,91 @@ export async function runRestore(
 ): Promise<void> {
   // Apply the snapshotted timeScale first so catch-up (below) and any
   // subsequent ticks run at the cadence the snapshot was taken at, not
-  // the fresh agent's constructor value. Pre-v2 snapshots omit this
-  // field and keep the constructor value. Routed through
-  // `setTimeScale` so a corrupted snapshot (negative / NaN / Infinity)
-  // throws `InvalidTimeScaleError` instead of silently poisoning the
-  // tick loop.
+  // the fresh agent's constructor value. Routed through `setTimeScale`
+  // so a corrupted snapshot (negative / NaN / Infinity) throws
+  // `InvalidTimeScaleError` instead of silently poisoning the tick loop.
   if (snapshot.timeScale !== undefined) {
     agent.setTimeScale(snapshot.timeScale);
   }
 
-  if (snapshot.lifecycle) {
-    agent.applyLifecycleSnapshot(snapshot.lifecycle);
-  }
-
-  if (snapshot.needs && agent.needs) {
-    agent.needs.restore(snapshot.needs);
-  }
-
-  if (snapshot.modifiers) {
-    // Restore replaces (not merges) modifier state — see restore()'s
-    // contract on Agent. Clear any pre-existing modifiers on the
-    // target before re-applying the snapshot's. Gated on presence of
-    // the `modifiers` slice so partial snapshots (`include: [...]`)
-    // still leave unrelated slices untouched on the target.
-    for (const existingId of new Set(agent.modifiers.list().map((m) => m.id))) {
-      agent.modifiers.removeAll(existingId);
-    }
-    const nowMs = agent.clock.now();
-    for (const mod of snapshot.modifiers) {
-      // Boundary case: modifiers whose expiresAt has already passed at
-      // the clock's current time are dropped on restore AND a
-      // `ModifierExpired` event fires exactly once so downstream
-      // consumers (stores, UIs, logs) see the expiration in the same
-      // shape they would from a normal tick.
-      if (mod.expiresAt !== undefined && mod.expiresAt <= nowMs) {
-        agent.publishEvent({
-          type: MODIFIER_EXPIRED,
-          at: nowMs,
-          agentId: agent.identity.id,
-          modifierId: mod.id,
-          source: mod.source,
-          ...(mod.visual?.fxHint !== undefined ? { fxHint: mod.visual.fxHint } : {}),
-        });
-        continue;
-      }
-      agent.modifiers.apply(mod);
-    }
-  }
-
-  if (snapshot.mood) {
-    agent.currentMood = { ...snapshot.mood };
-  }
-
-  if (snapshot.animation) {
-    agent.animation.restore({ state: snapshot.animation.state });
-    agent.currentActiveSkillId = snapshot.animation.activeSkillId;
-  }
-
-  if (snapshot.memory && agent.memory && isInMemoryMemoryAdapter(agent.memory)) {
-    agent.memory.restore(snapshot.memory);
-  }
-
-  if (opts.catchUp !== undefined && opts.catchUp !== false) {
-    const nowMs = agent.clock.now();
-    const elapsedMs = Math.max(0, nowMs - snapshot.snapshotAt);
-    // Total virtual budget is computed once at restore entry. The
-    // per-chunk divisor below re-reads `getTimeScale()` so a reactive
-    // handler that calls `setTimeScale()` mid-catch-up still applies
-    // on the next chunk, matching the documented `setTimeScale`
-    // semantics ("takes effect on the NEXT tick").
-    const elapsedSec = (elapsedMs / 1000) * agent.getTimeScale();
-    const chunkOpts =
-      typeof opts.catchUp === 'object' && opts.catchUp.chunkVirtualSeconds !== undefined
-        ? { chunkVirtualSeconds: opts.catchUp.chunkVirtualSeconds }
-        : {};
-    await runCatchUp(
-      elapsedSec,
-      async (chunk) => {
-        // Feed virtual dt back through tick(). dt is in real seconds
-        // before timeScale; invert it here using the *current* scale
-        // so a setTimeScale() between chunks propagates.
-        const realDt = chunk / agent.getTimeScale();
-        await agent.tick(realDt);
-      },
-      chunkOpts,
-    );
-  }
+  if (snapshot.lifecycle) agent.applyLifecycleSnapshot(snapshot.lifecycle);
+  if (snapshot.needs && agent.needs) agent.needs.restore(snapshot.needs);
+  if (snapshot.modifiers) restoreModifiers(agent, snapshot.modifiers);
+  if (snapshot.mood) agent.currentMood = { ...snapshot.mood };
+  if (snapshot.animation) restoreAnimation(agent, snapshot.animation);
+  restoreMemory(agent, snapshot);
+  await runCatchUpIfRequested(agent, snapshot, opts);
 
   agent.reasoner.reset?.();
+}
+
+/**
+ * Replaces (not merges) modifier state. Pre-existing modifiers on the
+ * target are cleared before re-applying the snapshot's. Modifiers whose
+ * `expiresAt` has already passed at the clock's current time are dropped
+ * AND a `ModifierExpired` event fires exactly once so downstream
+ * consumers (stores, UIs, logs) see the expiration in the same shape
+ * they would from a normal tick.
+ */
+function restoreModifiers(agent: Agent, modifiers: AgentSnapshot['modifiers']): void {
+  if (!modifiers) return;
+  for (const existingId of new Set(agent.modifiers.list().map((m) => m.id))) {
+    agent.modifiers.removeAll(existingId);
+  }
+  const nowMs = agent.clock.now();
+  for (const mod of modifiers) {
+    if (mod.expiresAt !== undefined && mod.expiresAt <= nowMs) {
+      agent.publishEvent({
+        type: MODIFIER_EXPIRED,
+        at: nowMs,
+        agentId: agent.identity.id,
+        modifierId: mod.id,
+        source: mod.source,
+        ...(mod.visual?.fxHint !== undefined ? { fxHint: mod.visual.fxHint } : {}),
+      });
+      continue;
+    }
+    agent.modifiers.apply(mod);
+  }
+}
+
+function restoreAnimation(agent: Agent, animation: NonNullable<AgentSnapshot['animation']>): void {
+  agent.animation.restore({ state: animation.state });
+  agent.currentActiveSkillId = animation.activeSkillId;
+}
+
+function restoreMemory(agent: Agent, snapshot: AgentSnapshot): void {
+  if (!snapshot.memory) return;
+  if (!agent.memory) return;
+  if (!isInMemoryMemoryAdapter(agent.memory)) return;
+  agent.memory.restore(snapshot.memory);
+}
+
+/**
+ * Replays the wall-clock gap between snapshotAt and now, in chunks, by
+ * feeding virtual dt back through `tick()`. Mid-catch-up `setTimeScale`
+ * propagates because `tick()` re-reads timeScale per tick — see
+ * `setTimeScale`'s documented "takes effect on the NEXT tick" semantics.
+ */
+async function runCatchUpIfRequested(
+  agent: Agent,
+  snapshot: AgentSnapshot,
+  opts: RestoreOptions,
+): Promise<void> {
+  if (opts.catchUp === undefined || opts.catchUp === false) return;
+  const nowMs = agent.clock.now();
+  const elapsedMs = Math.max(0, nowMs - snapshot.snapshotAt);
+  const elapsedSec = (elapsedMs / 1000) * agent.getTimeScale();
+  const chunkOpts =
+    typeof opts.catchUp === 'object' && opts.catchUp.chunkVirtualSeconds !== undefined
+      ? { chunkVirtualSeconds: opts.catchUp.chunkVirtualSeconds }
+      : {};
+  await runCatchUp(
+    elapsedSec,
+    async (chunk) => {
+      const realDt = chunk / agent.getTimeScale();
+      await agent.tick(realDt);
+    },
+    chunkOpts,
+  );
 }

--- a/src/agent/internal/agentDepsResolver.ts
+++ b/src/agent/internal/agentDepsResolver.ts
@@ -1,0 +1,121 @@
+import { AnimationStateMachine } from '../../animation/AnimationStateMachine.js';
+import type { Embodiment } from '../../body/Embodiment.js';
+import type { BehaviorRunner } from '../../cognition/behavior/BehaviorRunner.js';
+import { DirectBehaviorRunner } from '../../cognition/behavior/DirectBehaviorRunner.js';
+import type { Learner } from '../../cognition/learning/Learner.js';
+import { NoopLearner } from '../../cognition/learning/NoopLearner.js';
+import type { Reasoner } from '../../cognition/reasoning/Reasoner.js';
+import { UrgencyReasoner } from '../../cognition/reasoning/UrgencyReasoner.js';
+import type { AgeModel } from '../../lifecycle/AgeModel.js';
+import type { StageCapabilityMap } from '../../lifecycle/StageCapabilities.js';
+import type { MemoryRepository } from '../../memory/MemoryRepository.js';
+import { Modifiers } from '../../modifiers/Modifiers.js';
+import type { MoodModel } from '../../mood/MoodModel.js';
+import type { Needs } from '../../needs/Needs.js';
+import type { NeedsPolicy } from '../../needs/NeedsPolicy.js';
+import { AutoSaveTracker, DEFAULT_AUTOSAVE_POLICY } from '../../persistence/AutoSavePolicy.js';
+import type { SnapshotStorePort } from '../../persistence/SnapshotStorePort.js';
+import { NullLogger, type Logger } from '../../ports/Logger.js';
+import type { Validator } from '../../ports/Validator.js';
+import type { RandomEventTicker } from '../../randomEvents/RandomEventTicker.js';
+import { SkillRegistry } from '../../skills/SkillRegistry.js';
+import type { AgentDependencies } from '../Agent.js';
+import type { ControlMode } from '../ControlMode.js';
+import { MissingDependencyError } from '../errors.js';
+import type { RemoteController } from '../RemoteController.js';
+import type { ScriptedController } from '../ScriptedController.js';
+
+const DEFAULT_TIME_SCALE = 1;
+
+/** @internal Throws when any of the required ports is missing. */
+export function assertRequiredDeps(deps: AgentDependencies): void {
+  if (!deps.identity) throw new MissingDependencyError('identity');
+  if (!deps.eventBus) throw new MissingDependencyError('eventBus');
+  if (!deps.clock) throw new MissingDependencyError('clock');
+  if (!deps.rng) throw new MissingDependencyError('rng');
+}
+
+export interface ResolvedPorts {
+  logger: Logger;
+  validator: Validator | undefined;
+  timeScale: number;
+  controlMode: ControlMode;
+}
+
+export function resolveCorePorts(deps: AgentDependencies): ResolvedPorts {
+  return {
+    logger: deps.logger ?? new NullLogger(),
+    validator: deps.validator,
+    timeScale: deps.timeScale ?? DEFAULT_TIME_SCALE,
+    controlMode: deps.controlMode ?? 'autonomous',
+  };
+}
+
+export interface ResolvedSubsystems {
+  needs: Needs | undefined;
+  modifiers: Modifiers;
+  ageModel: AgeModel | undefined;
+  stageCapabilities: StageCapabilityMap | undefined;
+  moodModel: MoodModel | undefined;
+  embodiment: Embodiment | undefined;
+  randomEvents: RandomEventTicker | undefined;
+  memory: MemoryRepository | undefined;
+  remote: RemoteController | undefined;
+  scripted: ScriptedController | undefined;
+}
+
+export function resolveSubsystems(deps: AgentDependencies): ResolvedSubsystems {
+  return {
+    needs: deps.needs,
+    modifiers: deps.modifiers ?? new Modifiers(),
+    ageModel: deps.ageModel,
+    stageCapabilities: deps.stageCapabilities,
+    moodModel: deps.moodModel,
+    embodiment: deps.embodiment,
+    randomEvents: deps.randomEvents,
+    memory: deps.memory,
+    remote: deps.remote,
+    scripted: deps.scripted,
+  };
+}
+
+export interface ResolvedCognition {
+  reasoner: Reasoner;
+  behavior: BehaviorRunner;
+  learner: Learner;
+  skills: SkillRegistry;
+  needsPolicy: NeedsPolicy | undefined;
+  animation: AnimationStateMachine;
+}
+
+export function resolveCognition(deps: AgentDependencies): ResolvedCognition {
+  return {
+    reasoner: deps.reasoner ?? new UrgencyReasoner(),
+    behavior: deps.behavior ?? new DirectBehaviorRunner(),
+    learner: deps.learner ?? new NoopLearner(),
+    skills: deps.skills ?? new SkillRegistry(),
+    needsPolicy: deps.needsPolicy,
+    animation:
+      deps.animation instanceof AnimationStateMachine
+        ? deps.animation
+        : new AnimationStateMachine(deps.animation),
+  };
+}
+
+export interface ResolvedPersistence {
+  snapshotStore: SnapshotStorePort | undefined;
+  autoSaveKey: string;
+  autoSaveTracker: AutoSaveTracker | undefined;
+}
+
+export function resolvePersistence(deps: AgentDependencies, agentId: string): ResolvedPersistence {
+  const snapshotStore = deps.snapshotStore;
+  return {
+    snapshotStore,
+    autoSaveKey: deps.autoSaveKey ?? agentId,
+    autoSaveTracker:
+      snapshotStore !== undefined
+        ? new AutoSaveTracker(deps.autoSave ?? DEFAULT_AUTOSAVE_POLICY)
+        : undefined,
+  };
+}


### PR DESCRIPTION
## Summary

Reduces three remaining ratchet warnings on the agent surface.

- **`Agent` constructor (23 → <15)** — extracts the `??`-default resolution into `src/agent/internal/agentDepsResolver.ts`. Constructor now calls four chunked helpers (`resolveCorePorts`, `resolveSubsystems`, `resolveCognition`, `resolvePersistence`) and assigns each returned field with a plain `=`. Validation moves into a dedicated `assertRequiredDeps(deps)` helper.
- **`RestoreCoordinator.runRestore` (23 → <15)** — extracts per-slice helpers (`restoreModifiers`, `restoreAnimation`, `restoreMemory`, `runCatchUpIfRequested`). Orchestrator reads as a flat sequence of `if (snapshot.X) restoreX(...)` calls.
- **`Agent.restore`** rides along — already a thin async wrapper around `runRestore`, now delegates to a sub-15-complexity body.

No public API changes. Field shapes, snapshot ordering, modifier expiry events, and catch-up replay semantics are byte-identical.

Roadmap row 9 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md`.

## Test plan

- [x] `npm run verify` green locally (format, lint, typecheck, test, build, docs).
- [x] All three ratchet complexity warnings (`Agent` ctor, `Agent.restore`, `runRestore`) now under the 15-cap.
- [ ] CI green on this PR.

## Notes for review

- New file: `src/agent/internal/agentDepsResolver.ts` (resolvers + interfaces). Lives under `internal/` per CLAUDE.md — not re-exported from the barrel.
- No changeset — refactor with no behavior change.
- Bundle: 36.40 → 37.10 KB gzip, well under the 50 KB budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)