### PR TITLE
feat(demo): SVG sparkline of training loss under Train button

### DIFF
--- a/examples/nurture-pet/index.html
+++ b/examples/nurture-pet/index.html
@@ -189,6 +189,23 @@
         margin-left: auto;
         font-variant-numeric: tabular-nums;
       }
+      .loss-sparkline {
+        display: block;
+        margin-top: 4px;
+        opacity: 0.85;
+      }
+      .loss-sparkline .axis {
+        stroke: currentColor;
+        stroke-opacity: 0.2;
+        stroke-width: 1;
+      }
+      .loss-sparkline .curve {
+        fill: none;
+        stroke: #4f8cff;
+        stroke-width: 1.5;
+        stroke-linejoin: round;
+        stroke-linecap: round;
+      }
       .speed-label {
         font-size: 12px;
         opacity: 0.7;
@@ -488,6 +505,16 @@
         <span class="cognition-status" id="cognition-status" data-mode="heuristic">active</span>
         <button id="train-network" type="button" hidden>Train</button>
         <button id="untrain-network" type="button" hidden>Untrain</button>
+        <svg
+          id="loss-sparkline"
+          class="loss-sparkline"
+          width="120"
+          height="32"
+          viewBox="0 0 120 32"
+          aria-label="Training loss curve"
+          role="img"
+          hidden
+        ></svg>
       </div>
       <div class="speed">
         <span class="speed-label">Speed</span>

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -266,7 +266,19 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
         // localStorage unavailable — training still succeeds for this session.
       }
       const losses = result.history?.loss;
-      if (sparkline && losses && losses.length > 0) {
+      // Race guard: a `train()` started in Learning mode can resolve
+      // *after* the user has switched to a different cognition mode.
+      // `setTrainVisibility` already cleared the sparkline on that
+      // switch — repopulating it here would leak stale training state
+      // into a non-Learning HUD. Gate on the run still owning the
+      // active reasoner AND the active mode still being Learning.
+      if (
+        sparkline &&
+        losses &&
+        losses.length > 0 &&
+        activeModeId === 'learning' &&
+        reasonerHandle === activeReasoner
+      ) {
         renderLossSparkline(sparkline, losses);
       }
       flashStatus(status, formatTrainedToast(result), TRAINED_FLASH_MS);

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -1,5 +1,6 @@
 import type { Agent, Reasoner } from 'agentonomous';
 import { COGNITION_MODES, type CognitionModeSpec } from './cognition/index.js';
+import { clearLossSparkline, renderLossSparkline } from './lossSparkline.js';
 
 const NEED_IDS = ['hunger', 'cleanliness', 'happiness', 'energy', 'health'] as const;
 const TRAIN_PAIR_COUNT = 30;
@@ -118,6 +119,7 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
 
   const trainBtn = document.getElementById('train-network') as HTMLButtonElement | null;
   const untrainBtn = document.getElementById('untrain-network') as HTMLButtonElement | null;
+  const sparkline = document.getElementById('loss-sparkline') as unknown as SVGSVGElement | null;
   const setTrainVisibility = (modeId: CognitionModeSpec['id']): void => {
     const show = modeId === 'learning';
     if (trainBtn) {
@@ -128,6 +130,11 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       if (show) untrainBtn.removeAttribute('hidden');
       else untrainBtn.setAttribute('hidden', '');
     }
+    // Sparkline is gated on `learning` mode AND the presence of a prior
+    // train run; renderLossSparkline / clearLossSparkline manage the
+    // hidden attribute. Switching away from learning forces a clear so a
+    // stale curve doesn't bleed into other modes.
+    if (sparkline && !show) clearLossSparkline(sparkline);
   };
 
   let disposed = false;
@@ -258,6 +265,10 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       } catch {
         // localStorage unavailable — training still succeeds for this session.
       }
+      const losses = result.history?.loss;
+      if (sparkline && losses && losses.length > 0) {
+        renderLossSparkline(sparkline, losses);
+      }
       flashStatus(status, formatTrainedToast(result), TRAINED_FLASH_MS);
     };
 
@@ -327,6 +338,7 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
       // localStorage unavailable — the next construct() falls back to
       // the bundled baseline anyway.
     }
+    if (sparkline) clearLossSparkline(sparkline);
 
     const mode = COGNITION_MODES.find((m) => m.id === 'learning');
     if (!mode) {

--- a/examples/nurture-pet/src/lossSparkline.ts
+++ b/examples/nurture-pet/src/lossSparkline.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure-DOM SVG sparkline of a training-loss curve. Renders into the
+ * supplied `<svg>` host using the SVG namespace; no charting library.
+ *
+ * Layout: 1px-padded plot area inside the host's viewBox. The polyline
+ * spans the full width; y-axis is auto-fit between min and max of the
+ * input series. A horizontal baseline at the min value anchors the
+ * reader's eye when loss plateaus.
+ *
+ * Idempotent: each call clears prior children before drawing, so the
+ * caller can re-invoke after every train run without leaking nodes.
+ */
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const PADDING = 2;
+
+export interface RenderLossSparklineOptions {
+  /** Override the curve color. Defaults to the CSS class `.curve` styling. */
+  color?: string;
+}
+
+/**
+ * Renders `losses` into `host`. Hides the host (sets `hidden`) when
+ * the series is empty or has fewer than 2 points — a single-point line
+ * is just a dot and looks like a glitch.
+ */
+export function renderLossSparkline(
+  host: SVGSVGElement,
+  losses: readonly number[],
+  opts: RenderLossSparklineOptions = {},
+): void {
+  while (host.firstChild) host.removeChild(host.firstChild);
+
+  if (losses.length < 2) {
+    host.setAttribute('hidden', '');
+    return;
+  }
+  host.removeAttribute('hidden');
+
+  const { width, height } = readViewBox(host);
+  const plotW = Math.max(1, width - 2 * PADDING);
+  const plotH = Math.max(1, height - 2 * PADDING);
+
+  const min = Math.min(...losses);
+  const max = Math.max(...losses);
+  const span = max - min;
+
+  const xStep = plotW / (losses.length - 1);
+  const points = losses
+    .map((y, i) => {
+      const xPx = PADDING + i * xStep;
+      const norm = span === 0 ? 0.5 : (y - min) / span;
+      const yPx = PADDING + (1 - norm) * plotH;
+      return `${xPx.toFixed(2)},${yPx.toFixed(2)}`;
+    })
+    .join(' ');
+
+  const baseline = document.createElementNS(SVG_NS, 'line');
+  baseline.setAttribute('class', 'axis');
+  baseline.setAttribute('x1', String(PADDING));
+  baseline.setAttribute('x2', String(PADDING + plotW));
+  baseline.setAttribute('y1', String(PADDING + plotH));
+  baseline.setAttribute('y2', String(PADDING + plotH));
+  host.appendChild(baseline);
+
+  const curve = document.createElementNS(SVG_NS, 'polyline');
+  curve.setAttribute('class', 'curve');
+  curve.setAttribute('points', points);
+  if (opts.color !== undefined) curve.setAttribute('stroke', opts.color);
+  host.appendChild(curve);
+
+  host.setAttribute(
+    'aria-label',
+    `Training loss curve: ${losses.length} epochs, final ${max.toPrecision(3)} → ${losses[losses.length - 1]?.toPrecision(3) ?? '?'}`,
+  );
+}
+
+/** Clears the sparkline and hides the host. */
+export function clearLossSparkline(host: SVGSVGElement): void {
+  while (host.firstChild) host.removeChild(host.firstChild);
+  host.setAttribute('hidden', '');
+}
+
+function readViewBox(host: SVGSVGElement): { width: number; height: number } {
+  const vb = host.getAttribute('viewBox');
+  if (vb) {
+    const parts = vb.trim().split(/\s+/).map(Number);
+    if (parts.length === 4 && parts.every((n) => Number.isFinite(n))) {
+      return { width: parts[2] as number, height: parts[3] as number };
+    }
+  }
+  const widthAttr = Number(host.getAttribute('width') ?? 120);
+  const heightAttr = Number(host.getAttribute('height') ?? 32);
+  return { width: widthAttr, height: heightAttr };
+}

--- a/tests/examples/lossSparkline.test.ts
+++ b/tests/examples/lossSparkline.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+/**
+ * Pure-DOM SVG sparkline renderer test. Runs under jsdom; the renderer
+ * uses `document.createElementNS` so the SVG namespace must be present —
+ * jsdom satisfies this without a real browser.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearLossSparkline,
+  renderLossSparkline,
+} from '../../examples/nurture-pet/src/lossSparkline.js';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function renderHost(viewBox = '0 0 120 32'): SVGSVGElement {
+  const host = document.createElementNS(SVG_NS, 'svg');
+  host.setAttribute('viewBox', viewBox);
+  host.setAttribute('width', '120');
+  host.setAttribute('height', '32');
+  document.body.appendChild(host);
+  return host;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('renderLossSparkline', () => {
+  it('renders a polyline with one point per loss sample, plus a baseline', () => {
+    const host = renderHost();
+    renderLossSparkline(host, [1, 0.5, 0.25, 0.1]);
+    const polyline = host.querySelector('polyline.curve');
+    expect(polyline).not.toBeNull();
+    const points = polyline?.getAttribute('points')?.split(/\s+/) ?? [];
+    expect(points).toHaveLength(4);
+    expect(host.querySelector('line.axis')).not.toBeNull();
+    expect(host.hasAttribute('hidden')).toBe(false);
+  });
+
+  it('hides the host when given fewer than 2 points (single-point line is a glitch)', () => {
+    const host = renderHost();
+    renderLossSparkline(host, []);
+    expect(host.hasAttribute('hidden')).toBe(true);
+    expect(host.children.length).toBe(0);
+
+    renderLossSparkline(host, [0.5]);
+    expect(host.hasAttribute('hidden')).toBe(true);
+    expect(host.children.length).toBe(0);
+  });
+
+  it('clears prior children on re-render so repeated train clicks do not leak nodes', () => {
+    const host = renderHost();
+    renderLossSparkline(host, [1, 0.5]);
+    expect(host.children.length).toBe(2);
+    renderLossSparkline(host, [1, 0.8, 0.4]);
+    // 1 baseline + 1 polyline.
+    expect(host.children.length).toBe(2);
+    const polyline = host.querySelector('polyline.curve');
+    expect(polyline?.getAttribute('points')?.split(/\s+/).length).toBe(3);
+  });
+
+  it('maps min loss to the bottom of the plot area and max loss to the top', () => {
+    const host = renderHost('0 0 100 20');
+    renderLossSparkline(host, [1, 0]);
+    const points = host.querySelector('polyline.curve')!.getAttribute('points')!.split(/\s+/);
+    // First point: y=1 → top; last point: y=0 → bottom.
+    const [, y0] = points[0]!.split(',').map(Number) as [number, number];
+    const [, y1] = points[1]!.split(',').map(Number) as [number, number];
+    expect(y0).toBeLessThan(y1);
+  });
+
+  it('handles a flat series (max == min) by drawing a horizontal line', () => {
+    const host = renderHost();
+    renderLossSparkline(host, [0.3, 0.3, 0.3]);
+    const points = host.querySelector('polyline.curve')!.getAttribute('points')!.split(/\s+/);
+    const ys = points.map((p) => Number(p.split(',')[1]));
+    expect(new Set(ys).size).toBe(1);
+  });
+});
+
+describe('clearLossSparkline', () => {
+  it('removes children and re-hides the host', () => {
+    const host = renderHost();
+    renderLossSparkline(host, [1, 0.5]);
+    expect(host.children.length).toBeGreaterThan(0);
+    expect(host.hasAttribute('hidden')).toBe(false);
+    clearLossSparkline(host);
+    expect(host.children.length).toBe(0);
+    expect(host.hasAttribute('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Renders `TfjsReasoner.train()`'s `history.loss` series as a 120×32 SVG polyline directly under the Train button. The player sees the loss curve drop in real time — turns the existing "Trained ✓ — loss X → Y" toast into visible evidence.

Pure DOM, no charting library. The renderer (`examples/nurture-pet/src/lossSparkline.ts`) lives under the demo's own `src/`, not the library — consumers wiring their own UI can copy the 80-line helper or build their own.

## UX wiring

- Sparkline shows after a successful train run when in Learning mode.
- Hidden when fewer than 2 loss samples (single-point line is a glitch).
- Cleared on Untrain and on switching to a non-Learning mode so a stale curve doesn't bleed across sessions.
- Idempotent re-render (clears prior nodes) so repeated train clicks don't leak SVG elements.

## Test plan

- [x] `npm run verify` green locally (format, lint, typecheck, test, build, docs).
- [x] 6 new jsdom unit tests in `tests/examples/lossSparkline.test.ts` cover: render, hide-when-empty, re-render-clears, min/max axis mapping, flat-series horizontal-line, clear+rehide.
- [ ] CI green on this PR.

## Notes for review

- No library change — only `examples/nurture-pet/` + a new test file.
- No changeset — demo only.
- Roadmap row 13 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)