### PR TITLE
feat(tfjs,demo): per-epoch training progress callback + live HUD

### DIFF
--- a/.changeset/tfjs-on-epoch-end.md
+++ b/.changeset/tfjs-on-epoch-end.md
@@ -1,0 +1,11 @@
+---
+'agentonomous': minor
+---
+
+Add `onEpochEnd?: (epoch, loss) => void` to `TfjsReasoner.train`'s
+`TrainOptions`. Fires synchronously after each `model.fit` epoch with
+the 0-indexed epoch number and that epoch's loss — drives progress UIs
+("Training… 42/100") or live loss-curve renderers without waiting for
+the full fit to resolve. Determinism is preserved (no scheduling
+added; callback runs on the same backend + microtask stage as the
+fit).

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -20,7 +20,13 @@ type TrainResultLike = {
 type TrainableReasoner = {
   train: (
     pairs: Array<{ features: number[]; label: number[] }>,
-    opts?: { epochs?: number; learningRate?: number; seed?: number; shuffle?: boolean },
+    opts?: {
+      epochs?: number;
+      learningRate?: number;
+      seed?: number;
+      shuffle?: boolean;
+      onEpochEnd?: (epoch: number, loss: number) => void;
+    },
   ) => Promise<TrainResultLike>;
   toJSON: () => unknown;
   dispose?: () => void;
@@ -251,10 +257,25 @@ export function mountCognitionSwitcher(agent: Agent, rootEl: HTMLElement): Cogni
         const urgency = 1 - min;
         return { features, label: [urgency] };
       });
+      // Live mid-fit progress: update the button text + push points
+      // into the sparkline as each epoch completes. Both branches are
+      // gated on the run still owning the active reasoner so a stale
+      // callback after a mode switch doesn't leak into the new HUD.
+      const liveLosses: number[] = [];
       const result = await reasoner.train!(pairs, {
         epochs: TRAIN_EPOCHS,
         learningRate: 0.1,
         seed: Math.floor(trainRng() * 0x7fff_ffff),
+        onEpochEnd: (epoch, loss) => {
+          if (disposed) return;
+          if (reasonerHandle !== activeReasoner || activeModeId !== 'learning') return;
+          // `epoch` is 0-indexed; show 1-indexed N/M.
+          trainBtn.textContent = `Training… ${epoch + 1}/${TRAIN_EPOCHS}`;
+          liveLosses.push(loss);
+          if (sparkline && liveLosses.length >= 2) {
+            renderLossSparkline(sparkline, liveLosses);
+          }
+        },
       });
       try {
         const snapshot = reasoner.toJSON!();

--- a/src/cognition/adapters/tfjs/TfjsReasoner.ts
+++ b/src/cognition/adapters/tfjs/TfjsReasoner.ts
@@ -127,6 +127,16 @@ export type TrainOptions = {
   learningRate?: number;
   shuffle?: boolean;
   seed?: number;
+  /**
+   * Per-epoch progress callback. Fires synchronously after each
+   * `model.fit` epoch completes with the 0-indexed epoch number and
+   * that epoch's loss. Use it to drive a progress UI ("Training… 42/100")
+   * or a live loss-curve renderer.
+   *
+   * @remarks Determinism note: the callback runs on the same backend +
+   * microtask stage as the rest of the fit; no scheduling is added.
+   */
+  onEpochEnd?: (epoch: number, loss: number) => void;
 };
 
 /**
@@ -247,12 +257,22 @@ export class TfjsReasoner<In = unknown, Out = unknown> implements Reasoner {
     const featuresTensor = tf.tensor(shuffled.map((p) => p.features) as never);
     const labelsTensor = tf.tensor(shuffled.map((p) => p.label) as never);
 
+    const onEpochEnd = opts.onEpochEnd;
     try {
       const history = await this.model.fit(featuresTensor, labelsTensor, {
         epochs,
         batchSize,
         shuffle: false,
         verbose: 0,
+        ...(onEpochEnd
+          ? {
+              callbacks: {
+                onEpochEnd: (epoch: number, logs?: { loss?: number }) => {
+                  if (logs?.loss !== undefined) onEpochEnd(epoch, logs.loss);
+                },
+              },
+            }
+          : {}),
       });
       const lossHistory = (history.history.loss as number[]).slice();
       return {

--- a/tests/unit/cognition/adapters/TfjsReasoner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsReasoner.test.ts
@@ -258,6 +258,42 @@ describe('TfjsReasoner — training', () => {
     r1.dispose();
     r2.dispose();
   });
+
+  it('onEpochEnd fires once per epoch with monotonic 0-indexed epoch + numeric loss', async () => {
+    const pairs = makeConvergingPairs();
+    const r = new TfjsReasoner({
+      model: makeLinearModel(),
+      featuresOf: () => [0, 0],
+      interpret: () => null,
+    });
+    const calls: Array<{ epoch: number; loss: number }> = [];
+    const result = await r.train(pairs, {
+      epochs: 5,
+      learningRate: 0.1,
+      seed: 42,
+      onEpochEnd: (epoch, loss) => {
+        calls.push({ epoch, loss });
+      },
+    });
+    expect(calls).toHaveLength(5);
+    expect(calls.map((c) => c.epoch)).toEqual([0, 1, 2, 3, 4]);
+    for (const c of calls) expect(Number.isFinite(c.loss)).toBe(true);
+    // Last callback's loss matches the result's final loss exactly.
+    expect(calls[4]!.loss).toBeCloseTo(result.finalLoss, 5);
+    r.dispose();
+  });
+
+  it('train without onEpochEnd does not throw (callback is optional)', async () => {
+    const r = new TfjsReasoner({
+      model: makeLinearModel(),
+      featuresOf: () => [0, 0],
+      interpret: () => null,
+    });
+    await expect(
+      r.train(makeConvergingPairs(), { epochs: 2, learningRate: 0.1, seed: 0 }),
+    ).resolves.toBeDefined();
+    r.dispose();
+  });
 });
 
 describe('TfjsReasoner — persistence', () => {


### PR DESCRIPTION
## Summary

**Library:** add `onEpochEnd?: (epoch, loss) => void` to `TfjsReasoner.train`'s `TrainOptions`. Wired through `model.fit`'s `callbacks.onEpochEnd`; runs synchronously after each epoch with the 0-indexed epoch number and that epoch's loss. Determinism preserved — no scheduling added; callback fires on the same backend + microtask stage as the fit.

**Demo:** cognitionSwitcher consumes the new callback to drive live in-flight UI:

- Train button updates to `Training… N/100` per epoch (instead of staying frozen at `Training…` for the duration).
- Sparkline pushes loss points as they arrive so the curve animates while `model.fit` is still running, not just at the end.

Both branches are gated on the run still owning the active reasoner AND the active mode still being Learning, so a stale callback after a mode switch can't leak into the new HUD.

Roadmap row 14 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md`.

## Test plan

- [x] `npm run verify` green locally.
- [x] 2 new unit tests in `tests/unit/cognition/adapters/TfjsReasoner.test.ts`: monotonic 0-indexed epoch + final loss matches `result.finalLoss`; optional-callback path still resolves cleanly.
- [ ] CI green.

## Notes for review

- **Bump: minor** — additive `TrainOptions` field, no breaking change. Changeset added.
- Conditional spread of `callbacks` keeps the no-callback path identical to before (no extra alloc, no callback-invocation overhead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)