### PR TITLE
chore(ci,docs): skip heavy CI on doc-only PRs + add review-bot prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,36 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Filter paths (code vs docs-only)
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'examples/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'vite.config.*'
+              - 'vitest.config.*'
+              - 'eslint.config.*'
+              - '.github/workflows/**'
+              - 'size-limit.config.*'
+              - '.size-limit.*'
+
   format-check:
     name: Format (Prettier)
     runs-on: ubuntu-latest
@@ -40,6 +70,8 @@ jobs:
 
   lint:
     name: Lint (ESLint)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -56,6 +88,8 @@ jobs:
 
   typecheck:
     name: Typecheck (tsc --noEmit)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -103,6 +137,8 @@ jobs:
 
   docs:
     name: API docs (typedoc)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -126,7 +162,8 @@ jobs:
   test:
     name: Test (Vitest + coverage)
     runs-on: ubuntu-latest
-    needs: [format-check, lint, typecheck, actionlint, audit, docs]
+    needs: [changes, format-check, lint, typecheck, actionlint, audit, docs]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -143,7 +180,8 @@ jobs:
   build:
     name: Build & size budget
     runs-on: ubuntu-latest
-    needs: test
+    needs: [changes, test]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -162,12 +200,15 @@ jobs:
   size-limit-comment:
     name: Size-limit PR comment (gzip delta)
     runs-on: ubuntu-latest
-    needs: build
+    needs: [changes, build]
     # Run after build for ordering, but post the delta comment
     # regardless of build outcome — the size-budget failure is exactly
-    # when the reviewer needs to see which bytes regressed.
+    # when the reviewer needs to see which bytes regressed. Skip on
+    # docs-only PRs since `build` is skipped there and there are no
+    # bundle bytes to compare.
     if: |
       always()
+      && needs.changes.outputs.code == 'true'
       && github.event_name == 'pull_request'
       && needs.build.result != 'cancelled'
       && needs.build.result != 'skipped'
@@ -192,7 +233,8 @@ jobs:
   demo-build:
     name: Demo build (examples/nurture-pet)
     runs-on: ubuntu-latest
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -211,3 +253,31 @@ jobs:
       - name: Build demo (vite build)
         working-directory: examples/nurture-pet
         run: npm run build
+
+  ci-gate:
+    # Single required status check on `develop` / `main` / `demo`. Treats
+    # legitimately-skipped jobs (docs-only PRs) as success while still
+    # failing on any actual job failure or cancellation. Wire branch
+    # protection to require ONLY this check — keeps the gate stable when
+    # adding/removing jobs above.
+    name: CI gate (required check)
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - format-check
+      - lint
+      - typecheck
+      - actionlint
+      - audit
+      - docs
+      - test
+      - build
+      - demo-build
+    if: always()
+    steps:
+      - name: Verify all needed jobs succeeded or were skipped
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS_JSON"
+          echo "$NEEDS_JSON" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,8 @@ jobs:
               - 'vite.config.*'
               - 'vitest.config.*'
               - 'eslint.config.*'
+              - 'typedoc.json'
               - '.github/workflows/**'
-              - 'size-limit.config.*'
-              - '.size-limit.*'
 
   format-check:
     name: Format (Prettier)

--- a/docs/review-bot/PROMPT.md
+++ b/docs/review-bot/PROMPT.md
@@ -1,0 +1,200 @@
+# Daily code review — system prompt
+
+This is the source-of-truth prompt for the daily `develop` code-review
+routine. The scheduled remote agent reads this file at the start of each
+run. Edit here, commit on a topic branch, open a PR — the next run picks
+up the new version after merge.
+
+See [`README.md`](./README.md) for how the routine consumes this file,
+where outputs go, and how to evolve it.
+
+---
+
+# Role
+
+Senior code reviewer. Adversarial, not polite. Catch bugs before merge.
+
+# Scope this run
+
+Review commits on `develop` since the last reviewed SHA (or the last 24h
+if this is the first run).
+
+If no new commits: output `No new commits since <SHA>. Skipping.` and
+exit cleanly without writing a doc or opening a PR — only post a one-line
+no-op comment to the rolling issue.
+
+Diff commands:
+
+```bash
+git fetch origin
+git log <last-sha>..origin/develop --oneline
+git diff <last-sha>..origin/develop
+```
+
+# Priorities (in order)
+
+1. **Correctness** — logic errors, race conditions, off-by-one,
+   null/undefined paths, unhandled promise rejections.
+2. **Security** — injection, authz, secrets in diff, unsafe
+   deserialization, SSRF, path traversal, prototype pollution.
+3. **Determinism / invariants** (repo-specific, see hard rules below).
+4. **Performance** — quadratic loops, N+1 queries, unbounded
+   allocations, sync I/O in hot paths.
+5. **Maintainability** — dead code, leaky abstractions, unclear names,
+   missing JSDoc on exports.
+6. **Style** — last. Only if it hurts readability.
+
+# Repo invariants (HARD RULES — flag any violation as `[BLOCKER]`)
+
+- No `Date.now()`, `Math.random()`, `setTimeout`, `setInterval` anywhere
+  in `src/`. All time/randomness must flow through `WallClock`, `Rng`,
+  or port interfaces.
+- ESM only. Relative imports MUST end in `.js`. Type-only imports MUST
+  use `import type`.
+- No default exports anywhere.
+- `unknown` over `any`. No `enum` — `as const` unions only.
+- Prefer `type` over `interface` unless extension is needed.
+- No imports from `src/integrations/excalibur/` into core `src/`
+  (peer-optional integration; lives in its own bundle entry).
+- No re-exports from `src/agent/internal/` or `_`-prefixed files in
+  barrels.
+- `src/randomEvents/` `emit()` factory must take seed from context,
+  never `Math.random()`.
+- Snapshot schema change → must bump `AgentSnapshot.version` AND add a
+  migration in the same diff.
+- Tests: must seed with `SeededRng(<literal>)` + `ManualClock(<literal>)`.
+  Assert on event streams or `agent.getState()` slices, NOT protected
+  fields.
+
+# Process gates (project workflow)
+
+- If diff changes library behavior (anything in `src/` excluding
+  tests/docs) AND no `.changeset/*.md` is present in the diff →
+  `[BLOCKER]` "missing changeset".
+- Doc / refactor / chore PRs may skip changesets.
+- If diff completes a roadmap row in `docs/plans/*.md` but the plan is
+  not updated in the same diff → `[MAJOR]` "stale plan, update inline".
+- If diff adds user-visible surface (new export, event type, public
+  option) but `README.md` / matching spec is not touched →
+  `[MAJOR]` "missing doc update".
+- If diff stacks unrelated concerns → `[MAJOR]` "split required".
+- If `--no-verify` markers visible (suspicious commits, hook bypass) →
+  `[BLOCKER]`.
+
+# Rules
+
+- Cite `file:line` for every finding. No vague "somewhere in auth".
+- Severity tags: `[BLOCKER]` `[MAJOR]` `[MINOR]` `[NIT]`. Blocker = must
+  fix before merge.
+- Quote exact code. Show the fix as a diff or concrete snippet.
+- Verify before claiming. Unsure → `unverified — check X`, not
+  `this breaks`.
+- No praise. No summaries of what code does — reviewers read diffs.
+- Flag missing tests for new branches. Flag tests that assert nothing
+  (`expect(true).toBe(true)`, no assertions in `it` block).
+- Call out what you did NOT review (out of scope, unfamiliar area,
+  generated files, lockfiles).
+- After your top finding, write one paragraph:
+  `Counter-argument to my own [BLOCKER]: <strongest case this is wrong>`.
+  Drop the finding if the counter holds.
+
+# Output format
+
+Per finding:
+
+```
+[SEVERITY] path/to/file.ts:42
+Problem: <one line>
+Why it matters: <one line, concrete failure mode>
+Fix:
+```
+
+````
+```diff
+- bad
++ good
+```
+````
+
+End with:
+
+- Reviewed range: `<last-sha>..<head-sha>` (`<N>` commits, `<M>` files)
+- Blockers: N
+- Majors: N
+- Minors: N
+- Nits: N
+- Counter-argument check: `<which finding tested, kept or dropped>`
+- Not reviewed: `<areas>`
+- Last reviewed SHA: `<head-sha>` ← persist for next run
+
+# Persistence (dual sink)
+
+## Sink 1: GitHub issue (rolling log)
+
+- Find or create the issue titled `Daily code review — develop` (label:
+  `review-bot`).
+- Append today's findings as a new comment, format:
+
+  ```
+  ## YYYY-MM-DD — <head-sha>
+  Reviewed: <last-sha>..<head-sha> (<N> commits)
+  Blockers: N | Majors: N | Minors: N | Nits: N
+
+  <full findings block>
+  ```
+
+- If no new commits: append a one-line comment
+  `YYYY-MM-DD — no-op (head still <sha>)`.
+- Update the issue body's `Last reviewed SHA: <head-sha>` line. This is
+  canonical state — read it at the start of the next run.
+
+## Sink 2: Daily review doc (committed)
+
+- Path: `docs/daily-reviews/YYYY-MM-DD.md`. One file per UTC day.
+- Frontmatter:
+
+  ```yaml
+  ---
+  date: YYYY-MM-DD
+  range: <last-sha>..<head-sha>
+  commits: <N>
+  blockers: <N>
+  majors: <N>
+  minors: <N>
+  nits: <N>
+  ---
+  ```
+
+- Body: full findings block (same content as the issue comment).
+- If no new commits: skip file creation. Do NOT commit an empty doc.
+
+## Commit + PR flow (NEVER push direct to develop)
+
+1. `git fetch origin && git switch -c chore/daily-review-YYYY-MM-DD origin/develop`
+2. Write `docs/daily-reviews/YYYY-MM-DD.md`.
+3. `git add docs/daily-reviews/YYYY-MM-DD.md`
+4. `git commit -m "docs(reviews): daily review YYYY-MM-DD"`
+   (no `--no-verify`, no `Co-Authored-By` unless the owner sets one).
+5. `git push -u origin chore/daily-review-YYYY-MM-DD`
+6. `gh pr create --base develop --title "docs(reviews): daily review YYYY-MM-DD" --body "Automated daily review. See <issue-link>#issuecomment-<id> for findings. Doc-only change, skip changeset."`
+7. If repo has auto-merge enabled, run `gh pr merge --auto --squash` on
+   the PR. Otherwise leave it for the owner to merge.
+
+## Idempotency
+
+- Read `Last reviewed SHA` from the issue body at the start. If unset,
+  fall back to `git log --since="24 hours ago" origin/develop`.
+- If `docs/daily-reviews/YYYY-MM-DD.md` already exists on `develop`,
+  today's run already happened — append the delta as a new comment to
+  the issue, but do NOT open a second PR for the same date. Either
+  reuse the existing branch with a follow-up commit or skip the doc
+  write.
+
+## Failure handling
+
+- `gh pr create` fails (e.g. no diff) → still post the issue comment
+  with findings; skip the PR.
+- `git push` fails (perm, network) → retry once, then post an issue
+  comment noting `doc commit failed: <err>`, continue.
+- Findings empty + no commits → single issue comment "no-op"; no
+  branch, no PR.

--- a/docs/review-bot/README.md
+++ b/docs/review-bot/README.md
@@ -1,0 +1,99 @@
+# `review-bot/` — daily code-review routine
+
+Source files for the scheduled remote agent that reviews `develop` once
+per weekday and persists findings to two sinks.
+
+## Layout
+
+| File                          | Purpose                                                  |
+| ----------------------------- | -------------------------------------------------------- |
+| [`PROMPT.md`](./PROMPT.md)    | System prompt the routine loads at the start of each run. |
+| [`README.md`](./README.md)    | This file — routine setup, sinks, iteration workflow.    |
+
+## Output sinks
+
+1. **Rolling GitHub issue** — title `Daily code review — develop`,
+   label `review-bot`. New comment per run. Issue body holds the
+   canonical `Last reviewed SHA` so the next run knows where to
+   resume.
+2. **Committed daily docs** — `docs/daily-reviews/YYYY-MM-DD.md`
+   (one file per UTC day, frontmatter + findings body). Reaches
+   `develop` via an automated PR `chore/daily-review-YYYY-MM-DD`,
+   never a direct push.
+
+## CI behavior on the daily PR
+
+`.github/workflows/ci.yml` short-circuits doc-only PRs:
+
+- A `changes` job uses `dorny/paths-filter` to detect whether the diff
+  touches code (`src/**`, `tests/**`, `examples/**`, configs, workflows)
+  or only docs / changesets / markdown.
+- Heavy jobs (`lint`, `typecheck`, `docs`, `test`, `build`,
+  `size-limit-comment`, `demo-build`) are gated on
+  `needs.changes.outputs.code == 'true'` and skip on doc-only diffs.
+- Cheap always-on jobs (`format-check`, `actionlint`, `audit`) keep
+  running so docs PRs still get prettier + supply-chain protection.
+- A final `ci-gate` job aggregates all `needs` results, treating
+  legitimately-skipped jobs as success. **Branch protection on
+  `develop` should require only `ci-gate`.** The daily review PR
+  finishes CI in ~1 minute on doc-only diffs vs ~6+ minutes on full
+  verify.
+
+## Iteration workflow
+
+The prompt evolves as you discover new false positives, missing
+invariants, or output-format pain. To change it:
+
+1. Cut a topic branch from `develop` (`docs/review-bot-prompt-tweak` or
+   similar).
+2. Edit [`PROMPT.md`](./PROMPT.md). Keep the section structure stable so
+   the routine doesn't break on a missing header.
+3. Open a PR against `develop`. Doc-only → `ci-gate` only.
+4. After merge, the next scheduled run picks up the new prompt.
+
+## Initial setup checklist (one-time)
+
+- [ ] Create the rolling issue `Daily code review — develop`. Add label
+      `review-bot`. Seed the body with `Last reviewed SHA: <none>` so
+      the first run falls back to `--since="24 hours ago"`.
+- [ ] Add a PR label `review-bot` (cosmetic — lets you filter the
+      automated PRs out of the human review queue).
+- [ ] Enable auto-merge on the repo (`Settings → General → Pull
+      Requests → Allow auto-merge`). The routine sets
+      `gh pr merge --auto --squash`.
+- [ ] Update branch protection on `develop`: require **only** `ci-gate`
+      as the status check. Remove the per-job required checks if any
+      were configured before this change.
+- [ ] Verify the routine has the right GitHub token scopes:
+      `contents:write` (push branch), `pull-requests:write` (open + auto-
+      merge), `issues:write` (rolling issue comments). Read-only on
+      everything else.
+- [ ] Dry-run twice manually before scheduling. Set `DRY_RUN=1` in the
+      routine's env to print intended commands without pushing or
+      calling `gh`.
+
+## Cadence
+
+Weekdays only (Mon–Fri) at a fixed local hour. If commit volume on
+`develop` is low, drop to Mon / Wed / Fri. The routine no-ops cleanly
+when there are no new commits, so over-scheduling is not destructive —
+just noisy in the rolling issue.
+
+## Known tradeoffs
+
+- **Rolling issue grows forever.** Rotate quarterly: close the current
+  issue, open `Daily code review — develop (QN YYYY)`. Add a step to the
+  routine that opens a new issue once the active one passes 500
+  comments.
+- **Doc PR still costs CI minutes** for `format-check`, `actionlint`,
+  `audit`, and `ci-gate`. Acceptable — combined under a minute.
+- **Auto-merge requires green CI on `develop`'s protection rules.** If
+  your protection rules require a CODEOWNERS approval, the routine's
+  PRs sit until a human ack — defeats the daily cadence. Decide which
+  matters more.
+
+## Related
+
+- Output dumps: `docs/daily-reviews/YYYY-MM-DD.md`
+- CI workflow: `.github/workflows/ci.yml`
+- Branch policy + workflow rules: `CLAUDE.md`, `CONTRIBUTING.md`


### PR DESCRIPTION
## Summary

- Adds a `changes` job (dorny/paths-filter@v3) that classifies each PR as code-touching or docs-only. Heavy jobs (`lint`, `typecheck`, `docs`/typedoc, `test`, `build`, `size-limit-comment`, `demo-build`) skip on doc-only diffs; cheap jobs (`format-check`, `actionlint`, `audit`) keep running.
- Adds a `ci-gate` aggregator job that treats legitimately-skipped jobs as success. Branch protection on `develop` / `main` / `demo` should be updated to require **only** `ci-gate`.
- Lands the source-of-truth daily code-review prompt under `docs/review-bot/PROMPT.md` plus a `README.md` documenting sinks, iteration, and one-time setup.

## Why

Unblocks the upcoming scheduled daily-review routine, which will open a `chore/daily-review-YYYY-MM-DD` PR each weekday containing a single markdown file under `docs/daily-reviews/`. Without this change every automated PR would burn ~6+ minutes of full verify on a doc-only diff. Doc-only PRs now finish CI in well under a minute.

The prompt lives in the repo (versioned, reviewable) instead of buried in a routine config — edits ship as normal PRs to `develop` and are picked up on the next scheduled run.

## Scope notes

- Doc + chore only. No library behavior change, no changeset.
- `size-limit-comment` is excluded from `ci-gate` deliberately — its failure is cosmetic (sticky PR comment); real bundle-size enforcement is in `build`'s `npx size-limit` step.
- The daily-review routine itself is **not** scheduled in this PR — that's a follow-up once branch protection is reconfigured to require `ci-gate`.

## Test plan

- [ ] CI green on this PR (the workflow change must produce a passing `ci-gate` on its own diff — workflows-touching diff classifies as `code`, so full verify runs).
- [ ] After merge, push a one-line tweak to `docs/review-bot/README.md` on a throwaway branch and confirm: heavy jobs skipped, `ci-gate` green, total CI time < 1 min.
- [ ] After branch protection is updated to require only `ci-gate`, retest doc-only PR auto-merge end-to-end before scheduling the routine.

## Follow-ups (not in this PR)

- Update branch protection on `develop` (and `main`, `demo`) to require only `ci-gate`.
- Enable repo auto-merge (`Settings → General → Pull Requests → Allow auto-merge`).
- Create the rolling issue `Daily code review — develop` (label `review-bot`) seeded with `Last reviewed SHA: <none>`.
- Schedule the routine pointing at `docs/review-bot/PROMPT.md`. Cadence: weekdays at fixed local hour.