### PR TITLE
docs(review-bot): smoke test ci path filter

### DIFF
--- a/docs/review-bot/README.md
+++ b/docs/review-bot/README.md
@@ -97,3 +97,5 @@ just noisy in the rolling issue.
 - Output dumps: `docs/daily-reviews/YYYY-MM-DD.md`
 - CI workflow: `.github/workflows/ci.yml`
 - Branch policy + workflow rules: `CLAUDE.md`, `CONTRIBUTING.md`
+
+<!-- smoke test for ci path filter -->


### PR DESCRIPTION
Verifying doc-only PRs skip heavy CI and `ci-gate` reports green via the new aggregator. Delete branch after merge — no changes worth keeping in the diff.

Expected check outcomes:
- Detect changed paths: ✓
- Format (Prettier): ✓
- Lint workflows (actionlint): ✓
- Audit production deps (npm audit): ✓
- CI gate (required check): ✓
- All other heavy jobs: Skipped