### PR TITLE
chore(release): claim npm package name with v0 stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# agentonomous
+
+Name reserved for an upcoming TypeScript autonomous-agent library.
+
+The first public release (`v1.0.0`) is forthcoming. Until then this package is published only as a name-reservation stub on the `reserved` dist-tag and is **not installable via `npm install agentonomous`** (no `latest` tag is set).
+
+Track development at https://github.com/luis85/agentonomous
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "LICENSE"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "reserved"
   },
   "keywords": [
     "agent",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "agentonomous",
+  "version": "0.0.0",
+  "description": "Autonomous agent library for TypeScript simulations, engine-agnostic. Name reserved for upcoming v1.0.0 release.",
+  "license": "MIT",
+  "author": "luis85",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/luis85/agentonomous.git"
+  },
+  "bugs": {
+    "url": "https://github.com/luis85/agentonomous/issues"
+  },
+  "homepage": "https://github.com/luis85/agentonomous#readme",
+  "files": [
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "agent",
+    "autonomous",
+    "simulation",
+    "nurture",
+    "virtual-pet",
+    "ecs",
+    "excalibur",
+    "sim-ecs",
+    "typescript"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds bare-minimum `package.json` + `README.md` to `main` so we can publish a `0.0.0` stub to npm and reserve the `agentonomous` name.
- Stub will be published to the `reserved` dist-tag (no `latest`) and immediately deprecated.
- Strips scripts, deps, exports, and `provenance: true` from this `package.json` — it exists only to claim the name. Real package shape lands later via the `release/v1.0.0` flow from `develop`.

## Why

Owner created the npm account and wants to lock the package name now while v1.0 is still on hold. Doing this without going through the full release flow keeps pending major changesets on `develop` untouched.

## Notes

- No workflows on `main` yet, so this push won't trigger `release.yml`.
- Required CI status checks aren't on this branch (cut from `main`, which has no workflow files). Merge requires temporarily lifting the "Do not allow bypassing" protection on `main`, or removing the required checks for this single bootstrap merge.
- Post-merge: \`npm publish --access public --tag reserved\` from `main`, then \`npm deprecate\`.

## Test plan

- [ ] Toggle bypass on `main` protection
- [ ] Squash-merge with admin override
- [ ] Restore bypass guard
- [ ] \`npm publish --access public --tag reserved\` from `main`
- [ ] \`npm deprecate "agentonomous@0.0.0" "Name reserved; v1.0.0 forthcoming."\`
- [ ] Verify npmjs.com page: version `0.0.0`, deprecated banner, no `latest` tag
- [ ] \`npm view agentonomous dist-tags\` → only `reserved: 0.0.0`
- [ ] \`npm install agentonomous\` in scratch dir → fails (no latest)
- [ ] Delete topic branch local + remote