### PR TITLE
docs: worktree rule + result/cognition/skills JSDoc (rows 23-25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ docs/api
 !.vscode/settings.json
 examples/**/dist
 examples/**/node_modules
+.worktrees
 .claude/settings.local.json
 .claude/.last-run
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,15 @@ MVP is a virtual-pet nurture demo (`examples/nurture-pet`).
   after the fact means cherry-picking, three parallel review rounds, and
   three verify cycles. Only share a branch when a later task genuinely
   depends on an earlier unmerged one (rare).
+- **Worktrees per topic branch.** All feature / refactor / chore work
+  happens in an isolated `git worktree` under `.worktrees/<branch-slug>`.
+  Worktree directory is `.worktrees/` (gitignored). This keeps
+  `D:\Projects\agent-library` itself on `develop` so multiple parallel
+  agents (one per worktree) can each run `npm install` / `npm test` /
+  `npm run dev` without stepping on each other's `node_modules` or vite
+  caches. After PR merges: prune the worktree via
+  `git worktree remove .worktrees/<branch-slug>` then delete the local
+  branch. Never edit `develop` directly outside of post-merge pulls.
 - **Post-merge cleanup.** After a PR merges: `git switch develop && git
 pull origin develop && git branch -d <topic>`. Delete the remote topic
   branch via the merged-PR UI (or `git push origin --delete <topic>` if

--- a/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
+++ b/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
@@ -78,6 +78,7 @@ end-to-end, with each PR Codex-reviewed and resolved before the next.
 | 14  | #84 | `feat/demo-train-epoch-progress`             | `TfjsReasoner.train` `onEpochEnd` callback (minor bump); demo HUD goes live mid-fit.   |
 | 15  | #85 | `feat/llm-port-example-and-readme`           | README LLM section, `examples/llm-mock/` deterministic playback example, vision spec status update. |
 | 16  | TBD | `feat/tfjs-learner-in-demo`                  | `Agent.setLearner` + Stage-8 score on every SkillFailed branch (minor bump); demo Learning mode wires `TfjsLearner` with `Buffered: N/50` HUD. |
+| 23–25 | TBD | `docs/worktrees-and-jsdoc`                 | CLAUDE.md `.worktrees/` rule + JSDoc on `result.ts` / `IntentionCandidate.ts` / `SkillRegistry.ts`. |
 
 ---
 
@@ -261,17 +262,30 @@ counting).
 
 **Cost:** XS.
 
-### 23 / 24 / 25 — JSDoc gaps (bundle as one PR)
+### 23 / 24 / 25 — JSDoc gaps (bundle as one PR) — **shipped**
 
-**Branch:** `docs/result-and-cognition-jsdoc`
+**Branch:** `docs/worktrees-and-jsdoc` (renamed from
+`docs/result-and-cognition-jsdoc` to bundle the new CLAUDE.md
+worktree non-negotiable in the same diff).
 
-- `src/agent/result.ts:14-37` — one-sentence JSDoc on `isOk`,
-  `isErr`, `map`, `mapErr`, `andThen`, `unwrap`. Used widely in
-  skills.
-- `src/cognition/IntentionCandidate.ts` — describe `discriminant`
-  (`[0, 1]` range, tie-break intent).
-- `src/skills/SkillRegistry.ts` — `invoke()` JSDoc `@throws` clause
-  (actual code throws on unregistered).
+**As shipped:**
+
+- `src/agent/result.ts` — one-sentence JSDoc added on `isOk`, `isErr`,
+  `map`, `mapErr`, `andThen`, `unwrap` per STYLE_GUIDE.md's "JSDoc on
+  every exported symbol" rule. Pre-existing module-level JSDoc on the
+  `Result<T, E>` type and on `ok` / `err` was left untouched.
+- `src/cognition/IntentionCandidate.ts` — `score` field's JSDoc now
+  documents the `[0, 1]` range, urgency-alignment, and the tie-break
+  intent (equal scores → policy source order wins, since the
+  `JsSonReasoner` scan uses strict `>` so the first contributor keeps
+  the slot). The original review note's `discriminant` name referred
+  conceptually to `score`; no field was renamed or added.
+- `src/skills/SkillRegistry.ts` — `invoke()` JSDoc gained an explicit
+  `@throws {SkillInvocationError}` clause documenting that an
+  unregistered `id` is a wiring bug surfaced as a typed `AgentError`,
+  not a domain `err(...)`.
+
+No library behavior change. No changeset.
 
 **Cost:** XS combined.
 

--- a/src/agent/result.ts
+++ b/src/agent/result.ts
@@ -11,26 +11,35 @@ export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E };
 export const ok = <T>(value: T): Result<T, never> => ({ ok: true, value });
 export const err = <E>(error: E): Result<never, E> => ({ ok: false, error });
 
+/** Narrows a `Result<T, E>` to its `Ok<T>` branch. */
 export function isOk<T, E>(r: Result<T, E>): r is { ok: true; value: T } {
   return r.ok;
 }
 
+/** Narrows a `Result<T, E>` to its `Err<E>` branch. */
 export function isErr<T, E>(r: Result<T, E>): r is { ok: false; error: E } {
   return !r.ok;
 }
 
+/** Runs `fn` on the success value if any; passes through `Err` unchanged. */
 export function map<T, U, E>(r: Result<T, E>, fn: (value: T) => U): Result<U, E> {
   return r.ok ? ok(fn(r.value)) : r;
 }
 
+/** Runs `fn` on the error value if any; passes through `Ok` unchanged. */
 export function mapErr<T, E, F>(r: Result<T, E>, fn: (error: E) => F): Result<T, F> {
   return r.ok ? r : err(fn(r.error));
 }
 
+/** Chains another `Result`-returning fn on the success value; short-circuits on `Err`. */
 export function andThen<T, U, E>(r: Result<T, E>, fn: (value: T) => Result<U, E>): Result<U, E> {
   return r.ok ? fn(r.value) : r;
 }
 
+/**
+ * Returns the `Ok` value or throws on `Err`. Use only in tests / boundaries
+ * where failure is unrecoverable.
+ */
 export function unwrap<T, E>(r: Result<T, E>, message?: string): T {
   if (r.ok) return r.value;
   throw new Error(message ?? `Called unwrap() on an Err: ${String(r.error)}`);

--- a/src/cognition/IntentionCandidate.ts
+++ b/src/cognition/IntentionCandidate.ts
@@ -7,7 +7,12 @@ import type { Intention } from './Intention.js';
  */
 export interface IntentionCandidate {
   intention: Intention;
-  /** Urgency / priority in [0, 1]. Higher is better. */
+  /**
+   * Urgency / priority in `[0, 1]` — urgency-aligned, larger means more
+   * urgent. Acts as the primary discriminant when the reasoner picks a
+   * winner: when two candidates have equal `score`, the policy's source
+   * order wins (first contributor's candidate beats later contributors).
+   */
   score: number;
   /** Origin of this candidate — helps debugging and trace inspection. */
   source: 'needs' | 'task' | 'reactive' | 'plugin' | (string & {});

--- a/src/skills/SkillRegistry.ts
+++ b/src/skills/SkillRegistry.ts
@@ -59,9 +59,12 @@ export class SkillRegistry {
   }
 
   /**
-   * Invoke a skill by id. Throws `SkillInvocationError` if the skill isn't
-   * registered (infrastructure failure). Returns the skill's `Result` for
-   * domain-level success/failure.
+   * Invoke a skill by id. Returns the skill's `Result` for domain-level
+   * success/failure; infrastructure failures (unregistered id) throw.
+   *
+   * @throws {SkillInvocationError} If no skill is registered under `id`.
+   *   Unregistered invocation is a wiring bug, not a domain error, so it
+   *   surfaces as a typed `AgentError` rather than an `err(...)`.
    */
   async invoke(
     id: string,


### PR DESCRIPTION
## Summary

- Adds a `Worktrees per topic branch` non-negotiable to `CLAUDE.md` so parallel agents can each work in their own `.worktrees/<slug>` checkout without stepping on shared `node_modules` / vite cache.
- Closes plan rows 23 / 24 / 25 — JSDoc gaps on `result.ts`, `IntentionCandidate.ts`, and `SkillRegistry.invoke()`.

## Test plan

- [x] `npm run verify` green (format + lint + typecheck + test + build + docs).
- [x] No library behavior change. No changeset.

## Notes for review

- Doc-only PR; no source surface change. Plan rows 23/24/25 marked shipped in the same diff per `feedback_docs_alongside_pr.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)