### PR TITLE
docs: add shared in-repo project memory under .claude/memory

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,19 @@
+# Project memory index
+
+One-line pointers into `.claude/memory/`. Open each file for the full
+reasoning. See [README.md](./README.md) for what belongs here.
+
+## Project state
+
+- [Codex reviews all PRs](project_codex_review.md) — every PR opened against `develop` / `main` is auto-reviewed by Codex; keep diffs small and self-contained.
+- [1.0 release on hold](project_v1_release_hold.md) — major-bump changesets accumulate in `.changeset/` but no npm publish until library + demo polish is done.
+- [Polish + harden roadmap](project_polish_harden_roadmap.md) — pointer to the active pre-1.0 plan in `docs/plans/`.
+- [Graphify knowledge graph](project_graphify_usage.md) — read `graphify-out/GRAPH_REPORT.md` before architecture questions or non-trivial code reviews.
+
+## Workflow rules
+
+- [PR hygiene rules](feedback_pr_hygiene.md) — branch-per-concern, never stack, verify green pre-PR, no `--no-verify`.
+- [PR workflow — independent + batch + multi-pass Codex](feedback_pr_workflow.md) — open all independent PRs first, then sweep Codex reviews PR by PR until 👍.
+- [Pre-1.0 PRs skip migration layers](feedback_prerelease_no_migration.md) — no shipped consumers; clean-break shape changes, no compat shims.
+- [Docs + plan updates ride with their PR](feedback_docs_alongside_pr.md) — every roadmap row or user-visible change updates the plan + relevant docs in the SAME PR.
+- [Worktrees required for feature work](feedback_worktrees_required.md) — every topic branch lives in `.worktrees/<slug>`; main checkout stays on `develop` for parallel agents.

--- a/.claude/memory/README.md
+++ b/.claude/memory/README.md
@@ -1,0 +1,60 @@
+# `.claude/memory/`
+
+Shared, in-repo project memory for AI coding assistants (Claude Code,
+Codex CLI, Cursor, etc.) and human contributors. Everything here is
+checked in so every contributor — human or agent — works from the same
+baseline instead of accumulating it ad-hoc per machine.
+
+## What lives here
+
+Two memory categories, mirroring the Claude Code memory taxonomy:
+
+- **`project_*.md`** — facts about ongoing work, release posture,
+  external review surface, roadmap pointers. State that lives outside
+  the source tree and isn't derivable from `git log`.
+- **`feedback_*.md`** — workflow rules and conventions the team has
+  converged on through trial and incident. Each one carries a
+  **Why:** (the originating reason) and a **How to apply:** (when the
+  rule fires).
+
+Anything user-specific (per-machine paths, individual contributor
+preferences, local tooling quirks) is intentionally **not** stored here
+— that belongs in each contributor's own `~/.claude/` config.
+
+## How to read it
+
+Start with [`MEMORY.md`](./MEMORY.md). It's a one-line-per-entry index
+ordered by relevance to day-to-day PR work. Open the linked file when
+you need the full reasoning.
+
+For Claude Code specifically: [`CLAUDE.md`](../../CLAUDE.md) at the
+repo root points at this directory, so an agent that reads `CLAUDE.md`
+will surface these memories automatically.
+
+## How to update it
+
+Treat memory edits like any other change:
+
+- Cut a topic branch off `develop` in a worktree
+  (`docs/memory-<slug>` or `chore/memory-<slug>`) — see the
+  `Worktrees per topic branch` non-negotiable in
+  [`CLAUDE.md`](../../CLAUDE.md).
+- Add or edit the `.md` file. Keep frontmatter (`name`, `description`,
+  `type`) in sync with the body.
+- Add or update the matching one-liner in `MEMORY.md`.
+- Open a PR to `develop` like normal. Memory edits are docs-only — no
+  changeset required.
+
+When a memory turns out to be wrong or stale, **delete it** rather than
+leaving a corrected duplicate. Index entries should never outlive their
+target file.
+
+## What does not belong here
+
+- Architecture, file paths, or coding conventions already in
+  `CLAUDE.md`, `CONTRIBUTING.md`, `STYLE_GUIDE.md`, or `PUBLISHING.md`.
+- Per-PR snapshots that rot quickly (e.g. "which PRs currently carry a
+  major-bump changeset" — that's what `.changeset/` is for).
+- Debugging recipes or fix-of-the-week notes — fixes live in commits;
+  the _why_ lives in the commit message.
+- Anything sensitive: secrets, tokens, private URLs, customer names.

--- a/.claude/memory/feedback_docs_alongside_pr.md
+++ b/.claude/memory/feedback_docs_alongside_pr.md
@@ -1,0 +1,31 @@
+---
+name: Update plan and docs alongside the PR that touches them
+description: Whenever a PR completes a planned row or changes user-facing behavior, the plan markdown + relevant docs must update inside the same PR — not in a follow-up.
+type: feedback
+---
+
+Every PR that lands roadmap work or changes behavior must bundle the
+plan/doc updates into the same PR. No follow-up "docs catch-up" PRs.
+
+**Why:** Splitting plan updates from the work that completed them
+leaves `docs/plans/...md` stale and forces a second review cycle for
+something that was trivially obvious from the diff. Stale plans also
+make Codex less useful — it cross-references the plan when reviewing
+and degrades when the plan disagrees with the diff.
+
+**How to apply:**
+
+- When implementing a row from `docs/plans/YYYY-MM-DD-<slug>.md`, edit
+  the plan in the same PR — mark the row "Shipped (PR #N)" or move it
+  under a "What's already shipped" heading.
+- When a PR changes user-visible surface (new option on a public
+  helper, new event on the agent bus, new public type, new export),
+  update the relevant doc (`README.md`, `STYLE_GUIDE.md`,
+  `PUBLISHING.md`, the matching `docs/specs/...md`) in the same diff.
+- When a PR introduces a new convention or non-obvious workflow, add
+  a one-paragraph note to `CONTRIBUTING.md` or `CLAUDE.md`.
+- Pure refactor / chore PRs that don't change a roadmap row or public
+  surface can skip plan/doc updates.
+
+If unsure whether the plan needs an update, default to updating it —
+it's cheap, and a stale roadmap costs a future-session round-trip.

--- a/.claude/memory/feedback_pr_hygiene.md
+++ b/.claude/memory/feedback_pr_hygiene.md
@@ -1,0 +1,38 @@
+---
+name: PR hygiene rules for this repo
+description: Branch-per-concern, never stack, verify green pre-PR, no --no-verify. Codex + maintainer review both rely on this shape.
+type: feedback
+---
+
+- **Branch-per-concern.** Each topic branch from `develop` carries
+  exactly one concern. Multiple concerns in one session = multiple
+  branches, each cut fresh from `develop`. Never stack branches.
+- **`npm run verify` green pre-PR.** Always. This is the
+  non-negotiable gate codified in `CLAUDE.md`: format + lint +
+  typecheck + test + build.
+- **Never `--no-verify`.** If a pre-commit hook fails, fix the cause.
+  CI rejects `--no-verify`'d commits anyway, and the harness denies
+  the flag at the permission layer.
+- **Maintainer merges.** Don't merge your own PRs. Open them and wait
+  for maintainer + Codex review. Post-merge cleanup
+  (`git switch develop && git pull && git branch -d <topic>`) happens
+  on the maintainer's side; remote topic branches get deleted via the
+  merged-PR UI.
+- **`.bin` fragility on Windows.** If `npm run verify` reports
+  `prettier not found` (or any other tool from `.bin`), `node_modules/.bin`
+  is empty. Fix:
+  ```bash
+  rm -rf node_modules && npm install
+  ```
+  This regenerates the shims. Common after partial installs or
+  cross-shell switches.
+
+**Why:** Maintainer + Codex reviews both assume small, self-contained
+PRs. Stacked branches confuse Codex's line anchors and force
+cherry-pick during review. Unclean `verify` = CI failure = wasted
+review round.
+
+**How to apply:** When tackling a multi-step session, plan the branch
+list up front, open each PR against `develop` (never against a
+previous topic branch), and include the Codex-friendly Summary +
+Test plan + Notes-for-review body sections.

--- a/.claude/memory/feedback_pr_workflow.md
+++ b/.claude/memory/feedback_pr_workflow.md
@@ -1,0 +1,86 @@
+---
+name: PR workflow — independent branches + batch + multi-pass Codex
+description: Standard per-session loop. Cut independent branches, batch open all PRs first, then sweep Codex reviews PR by PR until 👍, resolve threads, maintainer merges.
+type: feedback
+---
+
+Standard workflow for every multi-PR session in this repo. Confirmed
+in practice on multi-PR sessions where the batch shape consistently
+beat serial PR-by-PR completion.
+
+## The loop
+
+1. **Independent branches per concern.** Each PR is one branch cut
+   fresh from `develop`. Never stack. Never pull a later row's work
+   into the earlier PR. If two branches happen to touch the same
+   file, ship them separately and rebase the second after the first
+   merges.
+2. **Batch execution, batch open.** A session can ship multiple PRs
+   in one go — implement, push, open the PR, then move on to the
+   next row. Do **not** wait serially for Codex on each before
+   starting the next branch. Open every independent PR the session
+   covers, then switch into review-sweep mode.
+3. **Multi-pass Codex resolution.** Sweep PRs in order:
+   - `gh pr view <num> --comments` and
+     `gh api repos/Luis85/agentonomous/pulls/<num>/comments` to read
+     line comments + their commit anchors.
+   - Address real findings with a follow-up commit on the same
+     branch. Push (do **not** rebase mid-review — Codex's line
+     anchors break).
+   - Loop until Codex posts a 👍 reaction
+     (`gh api repos/Luis85/agentonomous/issues/<num>/reactions`) on
+     the latest commit. Per Codex docs: "If Codex has suggestions, it
+     will comment; otherwise it will react with 👍."
+   - **Skip literal re-flags** of comments already addressed by a
+     code-level fix. Note the false-positive in the PR description so
+     the human reviewer sees the rationale, then move on. Don't
+     iterate forever on Codex's pattern-match repeats.
+4. **Resolve the review threads.** Once Codex 👍s and human review
+   passes, mark each conversation as **Resolved** in the GitHub PR
+   review UI (or via `gh api graphql` for bulk-resolve). Codex keeps
+   re-pinging open threads otherwise.
+5. **Maintainer merges.** Don't merge your own PRs. After the
+   merge: `git switch develop && git pull --ff-only origin develop &&
+git fetch --prune origin && git branch -d <topic>`.
+
+## Why
+
+- Codex pattern-matching is per-line; small focused PRs get cleaner
+  reviews than mixed diffs.
+- Batch-opening avoids the dead time between push and Codex review
+  (~5 minutes per PR). One implementation pass + one sweep pass beats
+  N serial pass-pairs.
+- Resolving threads keeps the PR review surface honest — unresolved
+  threads imply unaddressed feedback, which inflates the apparent
+  review backlog.
+
+## Pitfalls
+
+- **Don't `git rebase` mid-Codex-review.** It rewrites SHAs and Codex
+  loses the line anchors on its own comments. Append commits instead;
+  squash at merge time if needed (maintainer's call).
+- **Don't merge your own PRs.** Even if Codex 👍s and tests pass,
+  wait for the maintainer.
+- **Don't `git push --force`** unless you and the maintainer agreed.
+  Topic branches are short-lived; force-pushing them invalidates
+  Codex review state.
+
+## Reference scripts
+
+```bash
+# Bulk PR sweep — replace the PR list with the session's PR numbers
+for pr in 63 64 65 66 67 68 69 70; do
+  echo "===PR#$pr==="
+  gh pr view "$pr" --json reviews \
+    -q '.reviews | map(.author.login + " " + .state) | join(", ")'
+  echo "--reactions--"
+  gh api "repos/Luis85/agentonomous/issues/$pr/reactions" \
+    -q '.[] | "\(.user.login) \(.content)"'
+done
+```
+
+```bash
+# Fetch line comments on the latest fix commit only
+gh api "repos/Luis85/agentonomous/pulls/$PR/comments" \
+  -q ".[] | select(.commit_id[0:8] == \"$SHA\") | {path, line, body}"
+```

--- a/.claude/memory/feedback_prerelease_no_migration.md
+++ b/.claude/memory/feedback_prerelease_no_migration.md
@@ -1,0 +1,39 @@
+---
+name: Pre-1.0 PRs skip legacy-migration / compat layers
+description: In pre-1.0 agentonomous PRs, don't ship migration or backward-compat code for prior pre-release shapes — no consumers have them on disk.
+type: feedback
+---
+
+Pre-1.0, no package version has been npm-published. No consumer has
+any prior storage / snapshot / API shape on disk. A PR that changes
+storage layout, schema version, or public shape should change it
+**directly** — not ship a migration layer or compat shim to "preserve
+v1 data".
+
+**Why:** A prior PR shipped a legacy-migration layer to protect
+consumers holding a pre-split storage layout. There were none. The
+layer kept attracting Codex findings (marker collisions, non-iterable
+adapter paths, re-entrance edge cases, partial-write leaks) — many
+fixups deep before the call was made to rip it. Removing the entire
+migration dropped ~850 lines and ~1.75 KB gzip, produced a cleaner
+core fix, and Codex 👍'd immediately.
+
+**How to apply:**
+
+- When a PR changes on-disk shape (`localStorage` layout, snapshot
+  schema, file path) before the 1.0 publish, prefer a clean break.
+- Document the shape change in the changeset; note that pre-1.0
+  consumers of earlier pre-release builds should clear their
+  namespace before loading. No migration promised.
+- If Codex starts posting findings about migration edge cases, check
+  first whether migration is actually needed — "is there a consumer
+  holding the old shape on disk right now?" For pre-1.0: no.
+- **Post-1.0 is different.** Once published, migrations protect real
+  users and are worth the complexity.
+
+**Signals this rule applies:**
+
+- [`project_v1_release_hold.md`](./project_v1_release_hold.md) is
+  still active.
+- Roadmap track is still "polish/harden pre-1.0".
+- No changeset entries describe a prior shipped shape on npm.

--- a/.claude/memory/feedback_worktrees_required.md
+++ b/.claude/memory/feedback_worktrees_required.md
@@ -1,0 +1,36 @@
+---
+name: Worktrees required for feature work
+description: Every topic branch lives in `.worktrees/<branch>`; the main checkout stays on `develop` so parallel agents can each run their own install / test / dev server.
+type: feedback
+---
+
+All feature / refactor / chore work happens in a `git worktree` under
+`.worktrees/<branch-slug>`. The main checkout stays on `develop` and
+is never edited directly outside of post-merge pulls.
+
+**Why:** Multiple parallel coding agents need to run simultaneously
+without colliding on `node_modules`, Vite caches, `dist/` output, or
+Vitest worker state. Each worktree gets its own isolated install +
+dev server. `CLAUDE.md` codifies this rule under
+"Non-negotiables → Worktrees per topic branch". `.worktrees/` is
+already gitignored.
+
+**How to apply:**
+
+1. Cut every topic branch via:
+   ```bash
+   git worktree add .worktrees/<slug> -b <slug> origin/develop
+   ```
+   Never `git switch -c` in the main checkout.
+2. `cd` into the worktree, then `npm ci` (or `npm install` on a warm
+   cache) before any TDD work.
+3. The verify gate (`npm run verify`) runs **inside** the worktree.
+4. After the PR merges:
+   ```bash
+   git worktree remove .worktrees/<slug>
+   git branch -d <slug>          # from the main checkout
+   git worktree prune            # clear stale entries if needed
+   ```
+5. When dispatching parallel agents, give each agent its own worktree
+   path so they can all run `npm test` / `npm run demo:dev`
+   concurrently without contention.

--- a/.claude/memory/project_codex_review.md
+++ b/.claude/memory/project_codex_review.md
@@ -1,0 +1,45 @@
+---
+name: Codex reviews all PRs
+description: Codex (ChatGPT code-review bot) comments on every PR opened against this repo. Keep diffs small, self-contained, and Codex-friendly.
+type: project
+---
+
+Every PR opened against `develop` (and `main`) is auto-reviewed by Codex
+(OpenAI's ChatGPT code-review bot). Codex posts line-level comments plus
+a summary; the maintainer triages them alongside their own review.
+
+**Why:** Codex is a fixture of this repo's review pipeline, not a
+one-off. Optimizing PR shape for it pays off on every change.
+
+**How to apply:**
+
+- **Small, focused PRs win.** Codex handles one concern at a time far
+  better than a large mixed diff. One PR = one branch = one concern.
+- **Stack-free branches.** Every topic branch is cut fresh from
+  `develop`. Never stack PRs; Codex tries to re-review across the chain
+  and the comments get noisy.
+- **Self-contained commits.** Each commit body should explain the _why_
+  (not just the _what_) — Codex cites them verbatim when summarising
+  changes.
+- **PR body matters.** Use the Summary + Test plan + Notes-for-review
+  format. Codex reads these; structured notes reduce the "why did you
+  do X?" round.
+- **Expect a review round even on docs-only / XS fixes.** Codex
+  comments on everything — don't be surprised by a 1-line PR getting 4
+  comments.
+
+**Workflow after opening a batch of PRs:**
+
+1. Wait for Codex to post its review (usually within a few minutes of
+   push).
+2. Triage PR-by-PR: `gh pr view <num> --comments` (or
+   `gh api repos/Luis85/agentonomous/pulls/<num>/comments` for the
+   line-level comments with their commit anchors).
+3. Address concerns with follow-up commits on the same branch (a fresh
+   push triggers a Codex re-review). **Don't rebase mid-review** — the
+   comments lose their line anchors.
+4. Resolve review threads only once the entire conversation is
+   addressed.
+
+See also: [`feedback_pr_workflow.md`](./feedback_pr_workflow.md) for
+the full multi-PR sweep loop.

--- a/.claude/memory/project_graphify_usage.md
+++ b/.claude/memory/project_graphify_usage.md
@@ -1,0 +1,48 @@
+---
+name: Graphify knowledge graph for codebase navigation
+description: This repo ships a graphify knowledge graph at `graphify-out/`. Consult `GRAPH_REPORT.md` before answering architecture / cross-module questions or starting any non-trivial code review.
+type: project
+---
+
+The repo carries a committed graphify knowledge graph under
+`graphify-out/`. It catalogues god nodes, community structure,
+cross-module dependencies, and INFERRED edges that are not visible from
+a flat grep of the source.
+
+The full ruleset is also reflected in the root
+[`CLAUDE.md`](../../CLAUDE.md) `## graphify` section — this memory
+exists so non-Claude assistants and human reviewers see it too.
+
+**Why:** Grep finds string matches; the graph captures relationships.
+Cross-module "how does X relate to Y" questions resolve in one
+traversal instead of N rounds of grep. Skipping the graph leads to
+shallow reviews that miss indirect coupling and reinvents conclusions
+already encoded in `GRAPH_REPORT.md`.
+
+**How to apply:**
+
+- **Before any architecture or codebase question**, read
+  `graphify-out/GRAPH_REPORT.md` for god nodes and community structure.
+- **Before any non-trivial code review**, scan `GRAPH_REPORT.md` for
+  the touched modules' communities and known god nodes — review
+  comments anchored to graph context land cleaner than grep-shaped
+  ones.
+- If `graphify-out/wiki/index.md` exists, navigate it instead of
+  reading raw source files.
+- For cross-module "how does X relate to Y" questions, prefer the
+  graphify CLI over grep — it traverses the EXTRACTED + INFERRED
+  edges instead of scanning files line-by-line:
+  ```bash
+  graphify query "<question>"
+  graphify path "<A>" "<B>"
+  graphify explain "<concept>"
+  ```
+- After modifying source files in a session, run
+  `graphify update .` to keep the graph current. The update is
+  AST-only — no API cost, safe to run frequently.
+
+**What's checked in:** `graph.html`, `graph.json`, `GRAPH_REPORT.md`,
+and the wiki under `graphify-out/wiki/`. Heavy / regeneratable
+artefacts (cache, manifest, per-node Obsidian vault, Cypher dump,
+GraphML / SVG exports) are gitignored — see `.gitignore` for the full
+list.

--- a/.claude/memory/project_polish_harden_roadmap.md
+++ b/.claude/memory/project_polish_harden_roadmap.md
@@ -1,0 +1,45 @@
+---
+name: Polish + harden roadmap pointer
+description: Active pre-1.0 polish + harden roadmap. Combines remediation, CI hardening, complexity ratchet, demo + library seams, tooling.
+type: project
+---
+
+The active pre-1.0 roadmap lives in `docs/plans/`. The current entry
+is `docs/plans/2026-04-25-comprehensive-polish-and-harden.md`, which
+supersedes the earlier `2026-04-24-polish-and-harden.md` and
+`2026-04-24-codebase-review-findings.md` (both kept in git history for
+context).
+
+If the comprehensive plan has been superseded by a newer entry, list
+`docs/plans/` and pick the most recent file matching
+`*polish*harden*.md`.
+
+## Track summary
+
+| Track                     | Purpose                                                                                                                                   |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Already shipped (Track A) | Architectural ESLint guardrails, persistence/restore correctness fixes.                                                                   |
+| 1 — CI hardening          | DRY release workflow, size-limit PR comment, npm audit gate, action SHA pinning, backend + OS matrix.                                     |
+| 2 — Stale docs            | README pre-release banner, changeset baseBranch, JSDoc gaps.                                                                              |
+| 3 — Complexity ratchet    | Cap cyclomatic complexity on outliers (createAgent, Agent.tick, restore, constructor); non-null assertion cleanup.                        |
+| 4 — Demo + library seams  | Loss sparkline, epoch progress, LLM example, TfjsLearner wiring, multi-output softmax, richer features, prediction strip, backend picker. |
+| 5 — Tooling               | Vitest coverage thresholds, peer dep pinning.                                                                                             |
+
+## How to use
+
+1. Read the current plan file before starting a session.
+2. Pick the next row by the recommended sequencing inside the plan.
+3. Follow the per-PR ritual in
+   [`feedback_pr_workflow.md`](./feedback_pr_workflow.md) — independent
+   branch per row, batch open, multi-pass Codex resolve, resolve threads,
+   maintainer merges.
+4. Update the plan in the same PR that lands the row (mark "Shipped
+   (PR #N)" or move under "What's already shipped"). See
+   [`feedback_docs_alongside_pr.md`](./feedback_docs_alongside_pr.md).
+
+## Stop conditions
+
+- Maintainer asks for the 1.0 publish — pause polish, switch to release
+  prep.
+- A row's "Depends on" column is unsatisfied — skip it, do the blocker
+  first.

--- a/.claude/memory/project_v1_release_hold.md
+++ b/.claude/memory/project_v1_release_hold.md
@@ -1,0 +1,37 @@
+---
+name: 1.0 release on hold
+description: Major-bump changesets accumulate but no npm publish until further library + demo polish is done. Ship breaking changes, don't ship 1.0 itself.
+type: project
+---
+
+The 1.0.0 npm publish is deliberately **held** while the library and
+demo get further polished. The 1.0 prep items (rename pass, LLM port,
+narrowed surface, JSDoc audit) have landed on `develop` and queued
+their major-bump changesets in `.changeset/`. The publish step itself
+is paused by maintainer decision.
+
+**Why:** Maintainer wants to keep iterating on library ergonomics and
+the demo before the public 1.0 surface freezes. Premature publish
+locks in shape decisions that will be cheaper to change pre-publish.
+
+**How to apply:**
+
+- Keep opening PRs that would normally land in the 1.0 train (breaking
+  renames, narrowed surface, new ports). They're welcome; the
+  changeset metadata pins them to the major bump that ships whenever
+  1.0 is eventually cut.
+- **Before adding a new major-bump changeset, skim
+  `.changeset/*.md`** so you know what's already queued. The pile is
+  the source of truth for what 1.0 will break — don't duplicate or
+  contradict an existing entry; update the existing one instead.
+- Don't run `changeset version` / `changeset publish` until the
+  maintainer explicitly asks for the 1.0 cut.
+- When opening a major-bump PR, note in the PR body that "1.0 is on
+  hold; this PR queues the breaking change for when we publish" so
+  reviewers don't assume a release is imminent.
+- Prefer polish + demo + vision-forward work over "finalising" the 1.0
+  surface until the maintainer signals go.
+
+**Signal the hold is lifted:** maintainer asks for a release / publish
+PR, asks to run `changeset version`, or opens an explicit 1.0
+milestone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,12 @@
 Project memory for Claude Code. Keep this file terse — details belong in
 `CONTRIBUTING.md`, `STYLE_GUIDE.md`, `PUBLISHING.md`, and the source.
 
+> **Shared project memory lives in [`.claude/memory/`](./.claude/memory/).**
+> Start with [`.claude/memory/MEMORY.md`](./.claude/memory/MEMORY.md) for
+> the index. Those files capture release posture, review workflow, and
+> conventions every contributor (human or agent) should know about — they
+> supplement, not duplicate, this file.
+
 ## What this repo is
 
 `agentonomous` — a TypeScript library for autonomous agents in browser /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,13 @@
 Thanks for helping out. This document captures the workflow we've converged on
 for branches, commits, releases, and local development.
 
+> **Working with an AI coding assistant?** See
+> [`.claude/memory/`](./.claude/memory/) — a checked-in, project-wide
+> memory bank covering release posture, review workflow, and the
+> conventions Codex / maintainer reviews assume. Same baseline for every
+> contributor and every agent. Start with
+> [`.claude/memory/MEMORY.md`](./.claude/memory/MEMORY.md).
+
 ## Branch model
 
 We follow a [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/)–flavored


### PR DESCRIPTION
## Summary

- New `.claude/memory/` directory checked into the repo so every contributor — human or AI agent — works from the same baseline of project facts and workflow rules instead of accumulating them ad-hoc per machine.
- 9 memory files (4 `project_*`, 5 `feedback_*`) plus an `index` (`MEMORY.md`) and a `README.md` explaining what belongs and what does not.
- Cross-linked from `CLAUDE.md` (so Claude Code sessions auto-surface the bundle) and `CONTRIBUTING.md` (so anyone reading contributor docs finds it).

## What's inside `.claude/memory/`

| File                                  | Type     | Topic                                                                  |
| ------------------------------------- | -------- | ---------------------------------------------------------------------- |
| `project_codex_review.md`             | project  | Codex auto-reviews every PR; keep diffs small and focused.             |
| `project_v1_release_hold.md`          | project  | 1.0 publish held; bumps queue in `.changeset/`; skim before adding.    |
| `project_polish_harden_roadmap.md`    | project  | Pointer to the active pre-1.0 plan in `docs/plans/`.                   |
| `project_graphify_usage.md`           | project  | Read `graphify-out/GRAPH_REPORT.md` before architecture / review work. |
| `feedback_pr_hygiene.md`              | feedback | Branch-per-concern, verify green, no `--no-verify`.                    |
| `feedback_pr_workflow.md`             | feedback | Independent branches + batch open + multi-pass Codex sweep loop.       |
| `feedback_prerelease_no_migration.md` | feedback | Pre-1.0: clean-break shape changes, no compat shims.                   |
| `feedback_docs_alongside_pr.md`       | feedback | Plan + doc updates ride with the PR that lands the row.                |
| `feedback_worktrees_required.md`      | feedback | Every topic branch lives in `.worktrees/<slug>`.                       |

## Sanitization vs. the source memory bundle

The original entries lived per-machine under `~/.claude/projects/...`. Migration pass:

- Stripped `originSessionId` frontmatter (machine-local identifier).
- Removed absolute Windows paths (`D:\Projects\agent-library\...` → repo-relative).
- Rewrote first-person ("owner told me", "I shipped X") to "maintainer" / "contributor" voice.
- Dropped the `project_pending_major_changesets.md` snapshot (a per-PR table that rots fast) and folded its surviving rule — _"skim `.changeset/` before adding a new major bump"_ — into `project_v1_release_hold.md`.
- Verified all referenced plan files exist in `docs/plans/`.

## Notes for review

- No library code changes. Pure docs + new directory.
- No changeset (docs-only).
- `npm run verify` green locally (format:check + lint + typecheck + test + build + docs).
- `.claude/` was already partly tracked (`settings.json`, `skills/`); only `.claude/settings.local.json`, `.claude/.last-run`, and `.claude/scheduled_tasks.lock` are gitignored — `.claude/memory/` will commit cleanly.

## Test plan

- [ ] `npm run verify` green on CI.
- [ ] `.claude/memory/README.md`, `MEMORY.md`, and the 9 entries render on GitHub.
- [ ] Cross-links from `CLAUDE.md` and `CONTRIBUTING.md` resolve.
- [ ] `project_graphify_usage.md` link to root `CLAUDE.md` (`../../CLAUDE.md`) resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)