### PR TITLE
feat(demo): grow learning-mode feature vector to 13 dims (row 18)

### DIFF
--- a/.changeset/learning-outcome-pre-modifier-count.md
+++ b/.changeset/learning-outcome-pre-modifier-count.md
@@ -1,0 +1,16 @@
+---
+'agentonomous': minor
+---
+
+`CognitionPipeline.invokeSkillAction` now snapshots
+`agent.modifiers.list().length` before invoking the skill and includes
+it on every `LearningOutcome.details` payload as `preModifierCount`
+(success + every failure branch). Mirrors the existing `preNeeds`
+snapshot.
+
+Consumers that include "active modifier count" as a feature dim should
+read this from `details.preModifierCount` to avoid leaking skill-
+applied modifier mutations into training inputs — default skills like
+`FeedSkill` add buffs and `CleanSkill` removes debuffs during
+`execute()`, so `agent.getState().modifiers.length` at outcome time
+reflects post-skill state, not the state inference saw.

--- a/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
+++ b/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
@@ -563,9 +563,17 @@ layer stays reactive.
   dims (PR #94 P2); the upgrade to `FEATURE_DIM = 13` lets old
   5-input snapshots fail fast and fall back to the new baseline.
 
-**Library impact:** none — `featuresOf` is consumer-supplied.
+**Library impact:** small additive — `CognitionPipeline.invokeSkillAction`
+now snapshots `agent.modifiers.list().length` alongside `preNeeds`
+and includes it on every `LearningOutcome.details` payload as
+`preModifierCount`. Pulled in after Codex's PR #96 P1 review surfaced
+the same direction-inversion concern that drove the existing
+`preNeeds` snapshot — without a kernel-supplied snapshot the demo
+projection couldn't recover pre-skill modifier count for player-click
+paths.
 
-**Cost:** S. **No changeset** — demo + script only.
+**Cost:** S. **Minor changeset** — `preModifierCount` is additive on
+the `LearningOutcome.details` shape.
 
 ### 19 — Live prediction strip
 

--- a/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
+++ b/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
@@ -78,8 +78,9 @@ end-to-end, with each PR Codex-reviewed and resolved before the next.
 | 14  | #84 | `feat/demo-train-epoch-progress`             | `TfjsReasoner.train` `onEpochEnd` callback (minor bump); demo HUD goes live mid-fit.   |
 | 15  | #85 | `feat/llm-port-example-and-readme`           | README LLM section, `examples/llm-mock/` deterministic playback example, vision spec status update. |
 | 16  | TBD | `feat/tfjs-learner-in-demo`                  | `Agent.setLearner` + Stage-8 score on every SkillFailed branch (minor bump); demo Learning mode wires `TfjsLearner` with `Buffered: N/50` HUD. |
-| 17  | TBD | `feat/tfjs-multi-output-softmax`             | 7-way softmax over active-care skills; bundled baseline rebuilt; `TfjsReasoner` JSDoc example (minor bump). |
-| 23–25 | TBD | `docs/worktrees-and-jsdoc`                 | CLAUDE.md `.worktrees/` rule + JSDoc on `result.ts` / `IntentionCandidate.ts` / `SkillRegistry.ts`. |
+| 17  | #94 | `feat/tfjs-multi-output-softmax`             | 7-way softmax over active-care skills; bundled baseline rebuilt; `TfjsReasoner` JSDoc example (minor bump). |
+| 23–25 | #93 | `docs/worktrees-and-jsdoc`                 | CLAUDE.md `.worktrees/` rule + JSDoc on `result.ts` / `IntentionCandidate.ts` / `SkillRegistry.ts`. |
+| 18  | TBD | `feat/demo-richer-feature-vector`            | 13-dim feature vector (5 needs + 4 mood one-hot + 1 modifier-count + 3 recent-event counts); bundled baseline rebuilt at `[13, 16, 7]`; demo-only. |
 
 ---
 
@@ -525,31 +526,46 @@ learning-mode argmax over them would conflict with the always-on
 heuristic emission. The softmax stays consequentialist; the heuristic
 layer stays reactive.
 
-### 18 — Richer feature vector
+### 18 — Richer feature vector — **shipped**
 
 **Branch:** `feat/demo-richer-feature-vector`
 
-Today's feature vector is the 5 need levels. Grow it to:
+**As shipped:**
 
-- 5 need levels (existing)
-- Mood category one-hot (4 dims: happy / sad / sleepy / playful)
-- Active modifier count (1 dim, normalized to [0, 1] via min(count,
-  5) / 5)
-- Recent-event counts in the last 30 ticks per `SkillCompleted` /
-  `SkillFailed` / `NeedCritical` (3 dims)
-
-Total = 13 dims (was 5).
+- `examples/nurture-pet/src/cognition/learning.ts` grew the feature
+  vector from 5 need levels to 13 dims:
+  - 5 need levels (hunger / cleanliness / happiness / energy / health)
+  - 4 mood one-hot dims indexed by `MOOD_KEYS = ['happy', 'sad',
+    'sleepy', 'playful']` (off-roster moods → all-zero on this section)
+  - 1 active-modifier count, normalized via
+    `min(count, COUNT_NORM_CAP=5) / COUNT_NORM_CAP`
+  - 3 recent-event counts (`SkillCompleted` / `SkillFailed` /
+    `NeedCritical`) in the last 30 `AgentTicked` ticks, each normalized
+    via the same cap
+- `setLearningAgentId(id)` was renamed to `setLearningAgent(agent)` —
+  pre-1.0 clean break, no compat shim. The new function subscribes to
+  the standard event bus to populate module-scoped mood + recent-event
+  state without widening the adapter's `helpers` shape.
+- `projectLearningOutcome` now produces 13-dim features at outcome
+  time (mood + modifier-count + event-counts come from
+  `agent.getState()` + the same module-scoped event window).
+- `cognitionSwitcher.ts`'s synthetic Train-button generator appends 8
+  uniform-`[0, 1]` noise dims to each archetype sample so labels stay
+  conditioned on the 5 need dims; the network learns to ignore the
+  trailing dims under the synthetic regime, leaving the in-game
+  `TfjsLearner` reinforcement loop to teach predictive weight on those
+  dims from real outcomes.
+- `scripts/seed-learning-network.ts` now builds a `[13, 16, 7]`
+  Sequential and pads training pairs with the same uniform-noise tail.
+  The bundled `examples/nurture-pet/src/cognition/learning.network.json`
+  was regenerated at the new shape.
+- Hydration guard in `learning.ts` already validated input + output
+  dims (PR #94 P2); the upgrade to `FEATURE_DIM = 13` lets old
+  5-input snapshots fail fast and fall back to the new baseline.
 
 **Library impact:** none — `featuresOf` is consumer-supplied.
 
-**Breaking for old saves:** the bundled `learning.network.json`
-baseline must be re-authored at the new shape. Old saved snapshots
-become schema-invalid; the demo's `learning.ts` `hydrate()` already
-falls back to the baseline on shape mismatch.
-
-**Sequence:** after row 16 — once the learner reinforces observed
-outcomes, richer features actually matter for visible behavior
-divergence.
+**Cost:** S. **No changeset** — demo + script only.
 
 ### 19 — Live prediction strip
 

--- a/examples/nurture-pet/src/cognition/learning.network.json
+++ b/examples/nurture-pet/src/cognition/learning.network.json
@@ -31,7 +31,7 @@
             "bias_constraint": null,
             "name": "dense_Dense1",
             "trainable": true,
-            "batch_input_shape": [null, 5],
+            "batch_input_shape": [null, 13],
             "dtype": "float32"
           }
         },
@@ -68,8 +68,22 @@
     "keras_version": "tfjs-layers 4.22.0",
     "backend": "tensor_flow.js"
   },
-  "weights": "0/4VP80SvT6blus9frflvROSfr/eNgm/mP5BPpKkJj8SFoG/zamxP8s35j2s4dS/rx2uv+YsJD7KeYy+67/AP84bOb9Lz4s/M4E6Puk6uz3zz3s+G5m9v+Jlxz/RHs6+ZWewvWMBEkAhzK+9XZ/GvZu20r01fOq/myQXvx0/VL+RCis/GXzqv/h/+76z1BnAlJFDvzhWIT1xXeS/U0HOP4BNIL322L2/1Dfgvz2s6D7iDJ8/7xdjP7EBTT+++bk/UtUrvp0gez+zBYy/uk5FP3lXe78gp5S/u4bLP8IMi7/Sveg+lh2Mv/OxsT/G1a2+JD78v22MDkCCEdg//En3vhtz6r8Klnu/iWgEQNzt8b5SGEM/bie5PkMk8j6p2sq+jifsPwBLej/yYlC/oBlMvyOphL4S+sM+h96RPuk8CD+/vwM/ndWHPegDe770wio/DMS8PrakkT+E7Em/7W8Hvm2fAb84KG6/zIC8PofDaT8Ao14/aNNCv/oWFr8sAl6/+YF4vxi5Oj/WqRW/1Em7vaIRm7/0lrw/BfdYPzjaxr7+FHK/EHGxP0B47b5fEEe+yCOyPxYfrL+vLJY+0VSKvuZVIT/6Ho8/fC0cPzW87r+logM+SMUPPuUdKr71+AdAxDIYv0hpmr9A/zY/CgN0vwvFgz/0Vg2/lokeP2ZwZz9ofHu/JNL3vsmEsL36oaw+bzOAP4mMdD5DPyw/tHsJwGSAKL+7JlE/nAaVPqxbiL+XsbE/bRIcv5780D/XuP0+RIrhvyVPZL/icr8+Dj3Jv0pHUT/HoCe+rI2KPcaDkD8Yn8g/eVOOPpL2+zz98yW9O2t/P2eBk7+DcpS+DhWNv+4wB8Bd8ok/J+7iP9uqxT+KKsu+riVsv606+b14Pgg+zCu0P9Aek7/wcUO/icmGPwH5jb/9uZ8/K+3PvkwT/74jynO+EPHxv/4JHj+GxjA/8khnP2nM1r5XbHW/452AP2Xo8r8CUue95lnuP0KTaL4qcPE/jvqfv1l9B8CbBmI/QYWvvszeJL8gsKA+ZokyPwlYZb/wl8W/6VODP5orUj2QCIO+WHPDv9uLTj/p+se/cL+lPik5iT+121S/USPcPlu1Aj4eFnO9HhThvqme1D3Lfvu+N2X+PiEOhj4=",
-  "weightsShapes": [[5, 16], [16], [16, 7], [7]],
-  "inputKeys": ["hunger", "cleanliness", "happiness", "energy", "health"],
+  "weights": "zHdKP7cCBj7sVRU+n3IHPVjIj75vYga/HHBbPjz2xj5UBKe/oWURQAIKHj+VSinAEagXv1+iL71hcIe/TjekP46cd7+eSyQ/FcgVP03+Dr/djvQ92krLv26qpD+cgzi+trTuPjazyT9uz9K+TAXuPrfyN7/XBFy/W4V7vQ5cEL/ziVw+qCsAwE48+bzReS3A1kpyvlk4ob/Qure/AC6BP581fz7xLIy/9STsv4ywhz/QypQ/0pOXP4xBej8vxbE/Jrctv4F13z72Ycm+A0R+Pwekm797WsW/XjTUP50Cr7+DLB4/T4HXvgu7dj/zJg6/f+YDwGa7BUAs+7w/P+wgv6ocZb/i+tm+7UOqPxz9qT7W0SS9PlPvPvOoTj+0nmC+t0x9PwmIzz53Fqw9qiJtv3UR2740jCI/0LLdPv8VGz9tFRq+CU//PUv4wru0Hsm+PO13PpFgnz7QHeK+uHi6u5iDOz6agge+SEecPHPXXj4NGJY+xBvovrRINT1A6QY+3yOuvPYlYD79CLi+4mSpPkg50r45dj69kjs6vkJqxr6eUVw+2eMMv+SWPL5RJuk+7R6uvnvNtj6QreQ+WqhevxDKnT4KiKm8rwnqPUOL+T454xA+f4LNPjzLRL7cvS29xDsAPsHGfr4b0YK+E2oQP0F5Cj8lbju+WWhQPr8foD4BQE0+/ih4voZI+j0VUBI+vKP/vWm2yj5qppy8RUqFvaqQAb602qq+cmgiPsTjCj24HVq+cVDYvfQHzzxWKME92FDoPkgRojlTBRm+VxmrvuekVj5j5ws/uAbLvpCH3D48o9C+AQ+kvqbhCr82DeY+NjZeu7hLBDw+IvY7WbzsvjIQJjz2hWq+z6Czvi71Aj/zEI2+J8QXP94zFD5OGLA8Fg+YvpooKL8j/xM94u6DPRNOm72fPhw+YPC4PlVflj7iMwy9IMmhPk93073lMoi+iVzZPopmEz+JeMC+igd+PsFwWT5NiJC+eOQzPoPMyT7iwik/yyzevhaLBr/7us696HybvE/Gpz65Zw6/nUmVPnbdJb4pBIs+nAFdveNbSr43jQy+fZsRvr4PwD4ZeRK/t6XuPh9/E78gcQO/5B+bvvrGiD7+1ic+uY8nvrVGtz4VtZo+uLZQP+gQCb92/Ba8bzuovn5+kb5B8m8+OnzePr8DFz9CbCi/KFE3v+BCFr/EwGS/0ngSP3UxAL8/4uk++p5xv5UfYD9iLSA/NtBAvkGw174tKrY/OrEZPoebH7+e4ys/tAnJvzbG+TuEE4W+u7bZPj7g3T5BLD4/0Zx3v7qxhj5MMUa+mz6BP/g1EkARMFy/m65hv9Rudj6eIMW/0y7KPTyMqb6BLS8+0RSePx/geb/4Lq07XCB7Png6qLyAZrc/ESw9P/SMhz8QLSTAjUwqv8kCkD7IU1Y+3KXcvlFquD90o0S/X6DIPyBe4bq/stK/zx8Av/eDIr7ELI2/vCKGPwW90b6TeAG+BV2BP54D0T9ONLu9nWlEPY5Owb4tCDQ/jc/9vrwc6bzcXgDAFKRyv/cfbj/jIq4/tqqyP83hTT4RU4m/I94pv1bqMj9n1KI/yiwHv8oCxr5Uhek+Bwyzv3SSHkCqIrO/7cVsvyVfdLv8AeK/5mo4PqCOdT+LLCg+2rZwPlq1kb9fFLQ/2IDnv5iGi71Hk8s/OslzPUTopT5b7om/MiMcwIzTpT9i90K9i7qXPcwpnD8VIlK+4NxJv++N4r862nI/9TYdvhEEET5TnJu/MC4JP/4y17+Ltpo+QX5rP10bPb926RY/5GuAPmRHP76fbuS+NARdPtm3xL6xngM/FPYUPQ==",
+  "weightsShapes": [[13, 16], [16], [16, 7], [7]],
+  "inputKeys": [
+    "hunger",
+    "cleanliness",
+    "happiness",
+    "energy",
+    "health",
+    "mood:happy",
+    "mood:sad",
+    "mood:sleepy",
+    "mood:playful",
+    "modifierCount",
+    "recent:SkillCompleted",
+    "recent:SkillFailed",
+    "recent:NeedCritical"
+  ],
   "outputKeys": ["feed", "clean", "play", "rest", "pet", "medicate", "scold"]
 }

--- a/examples/nurture-pet/src/cognition/learning.ts
+++ b/examples/nurture-pet/src/cognition/learning.ts
@@ -109,6 +109,25 @@ let currentTick = 0;
 type RecentEventKind = 'completed' | 'failed' | 'critical';
 let recentEvents: Array<{ tick: number; kind: RecentEventKind }> = [];
 let unsubscribers: Array<() => void> = [];
+/**
+ * Per-tick dedupe set keyed by `${kind}:${skillId | needId}`. Default
+ * skills that emit `SkillCompleted` from inside `execute()` (e.g.
+ * `FeedSkill`) cause a second emission from
+ * `CognitionPipeline.invokeSkillAction` — without dedupe the
+ * `recent:SkillCompleted` count doubles for those skills and biases
+ * the network toward emitter quirks rather than true completion
+ * frequency. Cleared on every `AgentTicked` event.
+ */
+let processedThisTick = new Set<string>();
+/**
+ * 8-dim rich-feature suffix (mood one-hot + modifier-count + event
+ * counts) snapshotted during `featuresFromNeeds` (Stage 4). Reused at
+ * outcome-time projection (Stage 8) so training inputs encode the same
+ * pre-skill state inference saw, not post-skill state mutated by the
+ * skill's `applyModifier` / `removeModifier` calls. `null` until the
+ * first `featuresFromNeeds` call.
+ */
+let lastRichFeatureSuffix: number[] | null = null;
 
 /**
  * Wire the learning mode to `agent`: store its id for the persisted-
@@ -134,6 +153,8 @@ export function setLearningAgent(
   currentMood = null;
   currentTick = 0;
   recentEvents = [];
+  processedThisTick = new Set<string>();
+  lastRichFeatureSuffix = null;
   agentIdForHydration = agent?.identity.id ?? null;
   if (agent === null) return;
   unsubscribers.push(
@@ -153,17 +174,38 @@ export function setLearningAgent(
             // a per-tick scan is O(window) and stable.
             recentEvents = recentEvents.filter((r) => r.tick > cutoff);
           }
+          // Reset per-tick dedupe set so the next tick's emissions can
+          // count once each (per skillId / needId).
+          processedThisTick = new Set<string>();
           return;
         }
-        case 'SkillCompleted':
+        case 'SkillCompleted': {
+          // Dedupe within a tick: default skills that emit
+          // `SkillCompleted` from `execute()` (e.g. `FeedSkill`) plus
+          // the kernel's own emission would otherwise double-count.
+          const e = event as { skillId?: string };
+          const key = `completed:${e.skillId ?? '?'}`;
+          if (processedThisTick.has(key)) return;
+          processedThisTick.add(key);
           recentEvents.push({ tick: currentTick, kind: 'completed' });
           return;
-        case 'SkillFailed':
+        }
+        case 'SkillFailed': {
+          const e = event as { skillId?: string };
+          const key = `failed:${e.skillId ?? '?'}`;
+          if (processedThisTick.has(key)) return;
+          processedThisTick.add(key);
           recentEvents.push({ tick: currentTick, kind: 'failed' });
           return;
-        case 'NeedCritical':
+        }
+        case 'NeedCritical': {
+          const e = event as { needId?: string };
+          const key = `critical:${e.needId ?? '?'}`;
+          if (processedThisTick.has(key)) return;
+          processedThisTick.add(key);
           recentEvents.push({ tick: currentTick, kind: 'critical' });
           return;
+        }
       }
     }),
   );
@@ -218,17 +260,19 @@ function featuresFromNeeds(
     else critical += 1;
   }
   const norm = (n: number): number => Math.min(n, COUNT_NORM_CAP) / COUNT_NORM_CAP;
+  // Snapshot the 8-dim rich-feature suffix so `projectLearningOutcome`
+  // (Stage 8) can pair the SAME pre-skill state with the action label,
+  // avoiding the post-skill leak Codex flagged on PR #96 (default
+  // skills like `FeedSkill` mutate `modifiers` mid-execute).
+  const suffix = [...moodOneHot, modCount, norm(completed), norm(failed), norm(critical)];
+  lastRichFeatureSuffix = suffix;
   return [
     levels.hunger ?? 0,
     levels.cleanliness ?? 0,
     levels.happiness ?? 0,
     levels.energy ?? 0,
     levels.health ?? 0,
-    ...moodOneHot,
-    modCount,
-    norm(completed),
-    norm(failed),
-    norm(critical),
+    ...suffix,
   ];
 }
 
@@ -376,14 +420,17 @@ export const learningMode: CognitionModeSpec = {
  *   arrived without a `preNeeds` snapshot, for defensive compatibility
  *   with consumer-emitted outcomes (the library's own pipeline always
  *   populates it).
- * - Mood / modifier-count / event-count dims = current module-scoped
- *   state at outcome time. Mood lags need changes (the reconciler runs
- *   after Stage 7), modifier counts only shift when a skill applies /
- *   removes one, and the event-count window includes this outcome's
- *   own emission. The first two are stable across a single skill
- *   invocation; the self-emission inflates the matching count by 1
- *   uniformly across every training pair, so the net signal is
- *   consistent.
+ * - Mood / modifier-count / event-count dims = the 8-dim suffix
+ *   `featuresFromNeeds` snapshotted into `lastRichFeatureSuffix` at
+ *   Stage 4 of THIS tick (BEFORE the skill ran). Reusing the
+ *   pre-skill snapshot keeps training inputs aligned with what
+ *   inference saw — recomputing from `agent.getState()` here would
+ *   leak post-skill modifier mutations (e.g. `FeedSkill` adds
+ *   `well-fed`, `CleanSkill` removes `dirty`) and inflate the
+ *   recent-event count with the outcome's own emission. Falls back
+ *   to a from-state recompute only if no `featuresFromNeeds` call
+ *   has run yet (typically a test harness scoring outcomes without
+ *   driving the reasoner first).
  * - Label = one-hot 7-vector for SUCCESSFUL outcomes only. Successes
  *   for skill `id` set `label[SOFTMAX_SKILL_IDS.indexOf(id)] = 1`.
  *
@@ -420,6 +467,40 @@ function projectLearningOutcome(
   // would invert the training direction.
   const preNeeds = (details as { preNeeds?: Record<string, number> }).preNeeds;
   const levels = preNeeds ?? agent.getState().needs;
+  // Reuse the rich-feature suffix `featuresFromNeeds` snapshotted at
+  // Stage 4 of THIS tick. Computing from `agent.getState()` here would
+  // capture POST-skill modifier counts (e.g. `FeedSkill` adds
+  // `well-fed`, `CleanSkill` removes `dirty`), causing inputs to
+  // encode action effects — Codex P1 finding on PR #96. Falls back to
+  // a recomputed-from-current-state suffix only when the outcome
+  // arrived before any `featuresFromNeeds` call (e.g. the consumer's
+  // first invocation of `learner.score` happens without a tick
+  // boundary, like the demo's test harness).
+  const suffix = lastRichFeatureSuffix ?? recomputeRichFeatureSuffixFromAgent(agent);
+  const features = [
+    levels.hunger ?? 0,
+    levels.cleanliness ?? 0,
+    levels.happiness ?? 0,
+    levels.energy ?? 0,
+    levels.health ?? 0,
+    ...suffix,
+  ];
+  const label = new Array<number>(SOFTMAX_DIM).fill(0);
+  label[skillIdx] = 1;
+  return { features, label };
+}
+
+/**
+ * Build the 8-dim rich-feature suffix from the agent's current state
+ * + the module-scoped event window. Used as a fallback by
+ * `projectLearningOutcome` when no `featuresFromNeeds` call has
+ * snapshotted a pre-skill suffix yet (typically only the first
+ * outcome in a session, or test harnesses that score outcomes without
+ * driving the reasoner). Production traffic always reuses the
+ * pre-skill snapshot, so this fallback's post-skill leak is a
+ * one-pair edge case.
+ */
+function recomputeRichFeatureSuffixFromAgent(agent: Agent): number[] {
   const state = agent.getState();
   const moodCategory = state.mood?.category;
   const moodOneHot = MOOD_KEYS.map((key) => (moodCategory === key ? 1 : 0));
@@ -433,21 +514,7 @@ function projectLearningOutcome(
     else critical += 1;
   }
   const norm = (n: number): number => Math.min(n, COUNT_NORM_CAP) / COUNT_NORM_CAP;
-  const features = [
-    levels.hunger ?? 0,
-    levels.cleanliness ?? 0,
-    levels.happiness ?? 0,
-    levels.energy ?? 0,
-    levels.health ?? 0,
-    ...moodOneHot,
-    modCount,
-    norm(completed),
-    norm(failedCount),
-    norm(critical),
-  ];
-  const label = new Array<number>(SOFTMAX_DIM).fill(0);
-  label[skillIdx] = 1;
-  return { features, label };
+  return [...moodOneHot, modCount, norm(completed), norm(failedCount), norm(critical)];
 }
 
 /**

--- a/examples/nurture-pet/src/cognition/learning.ts
+++ b/examples/nurture-pet/src/cognition/learning.ts
@@ -39,13 +39,39 @@ export const SOFTMAX_SKILL_IDS = [
 const SOFTMAX_DIM = SOFTMAX_SKILL_IDS.length;
 
 /**
- * Input feature width — matches `featuresFromNeeds`'s return length (the
- * 5 normalized need levels). Hydration rejects snapshots whose model's
+ * Mood categories surfaced as one-hot dims in the feature vector.
+ * Order is load-bearing — matches the bundled baseline + Train button
+ * generator. Off-roster moods (`content`, `angry`, `bored`, `sick`, …)
+ * collapse to the all-zero one-hot. Picked to cover the four most
+ * narratively-distinct demo states; richer mood encoding can grow this
+ * roster in lockstep with the seed script + tests.
+ */
+const MOOD_KEYS = ['happy', 'sad', 'sleepy', 'playful'] as const;
+
+/**
+ * Sliding window (in `AgentTicked` ticks) over which `featuresFromNeeds`
+ * counts `SkillCompleted` / `SkillFailed` / `NeedCritical` events. 30
+ * ticks ≈ 30 × default 200 ms tick budget = 6 s of subjective-time
+ * activity at base speed.
+ */
+const EVENT_WINDOW_TICKS = 30;
+
+/**
+ * Cap used to normalize event counts and modifier counts into [0, 1].
+ * Counts above this saturate to 1.0 — five completions / failures /
+ * criticals / active modifiers in a 30-tick window is already
+ * exceptional in the demo's pacing, so the cap is the right ceiling.
+ */
+const COUNT_NORM_CAP = 5;
+
+/**
+ * Input feature width: 5 needs + 4 mood one-hot + 1 modifier-count + 3
+ * recent-event counts = 13. Hydration rejects snapshots whose model's
  * input layer expects a different last-dim so a width mismatch fails
  * fast at construct() rather than at runtime when `model.predict` first
- * receives a 5-element vector.
+ * receives a 13-element vector.
  */
-const FEATURE_DIM = 5;
+const FEATURE_DIM = 5 + MOOD_KEYS.length + 1 + 3;
 
 /**
  * Idle floor for the learning-mode `interpret()` gate. The network's
@@ -63,16 +89,84 @@ const IDLE_THRESHOLD = 0.2;
 
 /**
  * Module-scoped agent id used as the localStorage key scope when
- * hydrating the trained network. Set once from `main.ts` after the
- * agent is created. Kept module-scoped (rather than widening
- * `CognitionModeSpec.construct(agentId)`) because no other mode needs
- * agent-id scoping.
+ * hydrating the trained network. Set by `setLearningAgent` from
+ * `main.ts` after the agent is created. Kept module-scoped (rather
+ * than widening `CognitionModeSpec.construct(agentId)`) because no
+ * other mode needs agent-id scoping.
  */
 let agentIdForHydration: string | null = null;
 
-/** Inject the agent id used as the localStorage key scope when hydrating. */
-export function setLearningAgentId(id: string | null): void {
-  agentIdForHydration = id;
+/**
+ * Module-scoped recent state used by `featuresFromNeeds` to build the
+ * mood / modifier-count / event-count dims. Populated via the agent
+ * subscription wired up in `setLearningAgent`. Kept module-scoped so
+ * the consumer-supplied `featuresOf` callback (which only receives
+ * `ReasonerContext` + `helpers`) can read it without widening the
+ * adapter's helpers shape.
+ */
+let currentMood: string | null = null;
+let currentTick = 0;
+type RecentEventKind = 'completed' | 'failed' | 'critical';
+let recentEvents: Array<{ tick: number; kind: RecentEventKind }> = [];
+let unsubscribers: Array<() => void> = [];
+
+/**
+ * Wire the learning mode to `agent`: store its id for the persisted-
+ * network localStorage scope AND subscribe to the standard event bus
+ * to feed the mood / modifier-count / event-count dims of
+ * `featuresFromNeeds`. Pass `null` to tear down (idempotent).
+ *
+ * The subscription tracks:
+ * - `MoodChanged` → `currentMood` (collapsed to one-hot via `MOOD_KEYS`)
+ * - `AgentTicked` → `currentTick` and prunes events older than
+ *   `EVENT_WINDOW_TICKS`
+ * - `SkillCompleted` / `SkillFailed` / `NeedCritical` → push into
+ *   `recentEvents`
+ */
+export function setLearningAgent(
+  agent: {
+    identity: { id: string };
+    subscribe(handler: (e: { type: string }) => void): () => void;
+  } | null,
+): void {
+  for (const u of unsubscribers) u();
+  unsubscribers = [];
+  currentMood = null;
+  currentTick = 0;
+  recentEvents = [];
+  agentIdForHydration = agent?.identity.id ?? null;
+  if (agent === null) return;
+  unsubscribers.push(
+    agent.subscribe((event) => {
+      switch (event.type) {
+        case 'MoodChanged': {
+          const e = event as { to?: string };
+          if (typeof e.to === 'string') currentMood = e.to;
+          return;
+        }
+        case 'AgentTicked': {
+          const e = event as { tickNumber?: number };
+          if (typeof e.tickNumber === 'number') {
+            currentTick = e.tickNumber;
+            const cutoff = currentTick - EVENT_WINDOW_TICKS;
+            // Prune in place — `recentEvents` is append-then-filter so
+            // a per-tick scan is O(window) and stable.
+            recentEvents = recentEvents.filter((r) => r.tick > cutoff);
+          }
+          return;
+        }
+        case 'SkillCompleted':
+          recentEvents.push({ tick: currentTick, kind: 'completed' });
+          return;
+        case 'SkillFailed':
+          recentEvents.push({ tick: currentTick, kind: 'failed' });
+          return;
+        case 'NeedCritical':
+          recentEvents.push({ tick: currentTick, kind: 'critical' });
+          return;
+      }
+    }),
+  );
 }
 
 function storageKey(agentId: string): string {
@@ -90,17 +184,51 @@ function loadPersistedSnapshot(agentId: string | null): unknown {
   }
 }
 
+/**
+ * Build the 13-dim feature vector consumed by Learning mode's network:
+ *
+ * - 5 need levels (hunger / cleanliness / happiness / energy / health)
+ * - 4 mood one-hot dims indexed by `MOOD_KEYS` (off-roster moods → all
+ *   zero on this section; the network treats it as "uninformative")
+ * - 1 active-modifier count, normalized to `[0, 1]` via
+ *   `min(count, COUNT_NORM_CAP) / COUNT_NORM_CAP`
+ * - 3 recent-event counts (`SkillCompleted` / `SkillFailed` /
+ *   `NeedCritical` in the last `EVENT_WINDOW_TICKS` ticks), each
+ *   normalized via the same cap
+ *
+ * Mood + event counts come from module-scoped state populated by the
+ * `setLearningAgent` subscription rather than via `helpers` — the
+ * adapter's helper shape only exposes `needsLevels()`, and widening
+ * that surface for one consumer would force every reasoner adapter to
+ * track per-agent mood + event windows.
+ */
 function featuresFromNeeds(
-  _ctx: ReasonerContext,
+  ctx: ReasonerContext,
   helpers: { needsLevels(): Record<string, number> },
 ): number[] {
   const levels = helpers.needsLevels();
+  const moodOneHot = MOOD_KEYS.map((key) => (currentMood === key ? 1 : 0));
+  const modCount = Math.min(ctx.modifiers.list().length, COUNT_NORM_CAP) / COUNT_NORM_CAP;
+  let completed = 0;
+  let failed = 0;
+  let critical = 0;
+  for (const e of recentEvents) {
+    if (e.kind === 'completed') completed += 1;
+    else if (e.kind === 'failed') failed += 1;
+    else critical += 1;
+  }
+  const norm = (n: number): number => Math.min(n, COUNT_NORM_CAP) / COUNT_NORM_CAP;
   return [
     levels.hunger ?? 0,
     levels.cleanliness ?? 0,
     levels.happiness ?? 0,
     levels.energy ?? 0,
     levels.health ?? 0,
+    ...moodOneHot,
+    modCount,
+    norm(completed),
+    norm(failed),
+    norm(critical),
   ];
 }
 
@@ -234,19 +362,28 @@ export const learningMode: CognitionModeSpec = {
 
 /**
  * Project a `LearningOutcome` from the cognition pipeline's Stage 8 hook
- * into a 5-dim `(features, oneHotLabel)` training pair for the bundled
- * `learning.network.json` topology.
+ * into a 13-dim `(features, oneHotLabel)` training pair matching the
+ * bundled `learning.network.json` topology.
  *
- * - Features = `details.preNeeds` snapshot — the pre-skill need levels
- *   captured by `CognitionPipeline.invokeSkillAction` BEFORE the skill
- *   runs. Reading post-skill levels (e.g. via `agent.getState().needs`
- *   right now) would invert the policy direction: `feed` raises hunger
- *   from low → high, so a label of "feed" against post-feed features
- *   trains the network on "high hunger → feed" instead of the intended
- *   "low hunger → feed". Falls back to current `agent.getState().needs`
- *   only if the outcome arrived without a `preNeeds` snapshot, for
- *   defensive compatibility with consumer-emitted outcomes (the
- *   library's own pipeline always populates it).
+ * - Need-level dims = `details.preNeeds` snapshot — the pre-skill need
+ *   levels captured by `CognitionPipeline.invokeSkillAction` BEFORE the
+ *   skill runs. Reading post-skill levels (e.g. via
+ *   `agent.getState().needs` right now) would invert the policy
+ *   direction: `feed` raises hunger from low → high, so a label of
+ *   "feed" against post-feed features trains the network on "high
+ *   hunger → feed" instead of the intended "low hunger → feed". Falls
+ *   back to current `agent.getState().needs` only if the outcome
+ *   arrived without a `preNeeds` snapshot, for defensive compatibility
+ *   with consumer-emitted outcomes (the library's own pipeline always
+ *   populates it).
+ * - Mood / modifier-count / event-count dims = current module-scoped
+ *   state at outcome time. Mood lags need changes (the reconciler runs
+ *   after Stage 7), modifier counts only shift when a skill applies /
+ *   removes one, and the event-count window includes this outcome's
+ *   own emission. The first two are stable across a single skill
+ *   invocation; the self-emission inflates the matching count by 1
+ *   uniformly across every training pair, so the net signal is
+ *   consistent.
  * - Label = one-hot 7-vector for SUCCESSFUL outcomes only. Successes
  *   for skill `id` set `label[SOFTMAX_SKILL_IDS.indexOf(id)] = 1`.
  *
@@ -256,9 +393,7 @@ export const learningMode: CognitionModeSpec = {
  * - **Failed outcomes.** An all-zero target under
  *   `categoricalCrossentropy` (`-Σ y_i log p_i`) yields zero loss and
  *   zero gradient — the network would silently ignore failure samples,
- *   so the buffer slot is wasted. Skipping them keeps the loss honest;
- *   when row 18 lifts the failure signal into a richer feature set
- *   (negative `reward` field) we can revisit.
+ *   so the buffer slot is wasted. Skipping them keeps the loss honest.
  * - Successes with non-positive or non-finite `effectiveness`.
  */
 function projectLearningOutcome(
@@ -285,12 +420,30 @@ function projectLearningOutcome(
   // would invert the training direction.
   const preNeeds = (details as { preNeeds?: Record<string, number> }).preNeeds;
   const levels = preNeeds ?? agent.getState().needs;
+  const state = agent.getState();
+  const moodCategory = state.mood?.category;
+  const moodOneHot = MOOD_KEYS.map((key) => (moodCategory === key ? 1 : 0));
+  const modCount = Math.min(state.modifiers.length, COUNT_NORM_CAP) / COUNT_NORM_CAP;
+  let completed = 0;
+  let failedCount = 0;
+  let critical = 0;
+  for (const e of recentEvents) {
+    if (e.kind === 'completed') completed += 1;
+    else if (e.kind === 'failed') failedCount += 1;
+    else critical += 1;
+  }
+  const norm = (n: number): number => Math.min(n, COUNT_NORM_CAP) / COUNT_NORM_CAP;
   const features = [
     levels.hunger ?? 0,
     levels.cleanliness ?? 0,
     levels.happiness ?? 0,
     levels.energy ?? 0,
     levels.health ?? 0,
+    ...moodOneHot,
+    modCount,
+    norm(completed),
+    norm(failedCount),
+    norm(critical),
   ];
   const label = new Array<number>(SOFTMAX_DIM).fill(0);
   label[skillIdx] = 1;

--- a/examples/nurture-pet/src/cognition/learning.ts
+++ b/examples/nurture-pet/src/cognition/learning.ts
@@ -109,29 +109,48 @@ let currentTick = 0;
 type RecentEventKind = 'completed' | 'failed' | 'critical';
 let recentEvents: Array<{ tick: number; kind: RecentEventKind }> = [];
 let unsubscribers: Array<() => void> = [];
+
 /**
- * Per-tick dedupe set keyed by `${kind}:${skillId | needId}`. Default
- * skills that emit `SkillCompleted` from inside `execute()` (e.g.
- * `FeedSkill`) cause a second emission from
- * `CognitionPipeline.invokeSkillAction` — without dedupe the
- * `recent:SkillCompleted` count doubles for those skills and biases
- * the network toward emitter quirks rather than true completion
- * frequency. Cleared on every `AgentTicked` event.
+ * Record one completion / failure outcome into the recent-event window.
+ * Called by `buildLearningLearner`'s `toTrainingPair` wrapper AFTER
+ * `projectLearningOutcome` finishes — that ordering keeps the projection
+ * looking at pre-this-outcome counts (the kernel's own emission is
+ * scored once, not double-counted via the SkillCompleted bus).
+ *
+ * Counting via the learner's own outcome stream rather than via
+ * `agent.subscribe('SkillCompleted')` sidesteps two failure modes the
+ * earlier event-subscription approach had:
+ * 1. Default skills that emit `SkillCompleted` from `execute()` (e.g.
+ *    `FeedSkill`) PLUS the kernel's emission from
+ *    `CognitionPipeline.invokeSkillAction` would double-count.
+ * 2. `Agent.dispatchReactiveHandlers` can process two queued
+ *    `InteractionRequested` events in one tick, legitimately invoking
+ *    the same skill twice; per-tick `${kind}:${skillId}` dedupe would
+ *    drop the second. Counting via outcomes captures BOTH (one outcome
+ *    is scored per kernel invocation).
  */
-let processedThisTick = new Set<string>();
+export function recordOutcomeForFeatureWindow(kind: 'completed' | 'failed'): void {
+  recentEvents.push({ tick: currentTick, kind });
+}
 
 /**
  * Wire the learning mode to `agent`: store its id for the persisted-
  * network localStorage scope AND subscribe to the standard event bus
- * to feed the mood / modifier-count / event-count dims of
- * `featuresFromNeeds`. Pass `null` to tear down (idempotent).
+ * to feed the mood + tick-window state of `featuresFromNeeds`. Pass
+ * `null` to tear down (idempotent).
  *
  * The subscription tracks:
  * - `MoodChanged` → `currentMood` (collapsed to one-hot via `MOOD_KEYS`)
  * - `AgentTicked` → `currentTick` and prunes events older than
  *   `EVENT_WINDOW_TICKS`
- * - `SkillCompleted` / `SkillFailed` / `NeedCritical` → push into
- *   `recentEvents`
+ * - `NeedCritical` → push into `recentEvents` (single-source emission
+ *   from `NeedsTicker`, no dedupe needed)
+ *
+ * `SkillCompleted` / `SkillFailed` are NOT subscribed here — they're
+ * counted via `recordOutcomeForFeatureWindow` from the learner's
+ * outcome stream so kernel + skill double-emits and reactive-handler
+ * back-to-back invocations both produce exactly one count per
+ * invocation.
  */
 export function setLearningAgent(
   agent: {
@@ -144,7 +163,6 @@ export function setLearningAgent(
   currentMood = null;
   currentTick = 0;
   recentEvents = [];
-  processedThisTick = new Set<string>();
   agentIdForHydration = agent?.identity.id ?? null;
   if (agent === null) return;
   unsubscribers.push(
@@ -164,35 +182,9 @@ export function setLearningAgent(
             // a per-tick scan is O(window) and stable.
             recentEvents = recentEvents.filter((r) => r.tick > cutoff);
           }
-          // Reset per-tick dedupe set so the next tick's emissions can
-          // count once each (per skillId / needId).
-          processedThisTick = new Set<string>();
-          return;
-        }
-        case 'SkillCompleted': {
-          // Dedupe within a tick: default skills that emit
-          // `SkillCompleted` from `execute()` (e.g. `FeedSkill`) plus
-          // the kernel's own emission would otherwise double-count.
-          const e = event as { skillId?: string };
-          const key = `completed:${e.skillId ?? '?'}`;
-          if (processedThisTick.has(key)) return;
-          processedThisTick.add(key);
-          recentEvents.push({ tick: currentTick, kind: 'completed' });
-          return;
-        }
-        case 'SkillFailed': {
-          const e = event as { skillId?: string };
-          const key = `failed:${e.skillId ?? '?'}`;
-          if (processedThisTick.has(key)) return;
-          processedThisTick.add(key);
-          recentEvents.push({ tick: currentTick, kind: 'failed' });
           return;
         }
         case 'NeedCritical': {
-          const e = event as { needId?: string };
-          const key = `critical:${e.needId ?? '?'}`;
-          if (processedThisTick.has(key)) return;
-          processedThisTick.add(key);
           recentEvents.push({ tick: currentTick, kind: 'critical' });
           return;
         }
@@ -419,11 +411,10 @@ export const learningMode: CognitionModeSpec = {
  *   `CleanSkill` removes `dirty`). Falls back to current state only
  *   when the outcome arrived without the snapshot (e.g. a consumer-
  *   emitted outcome from outside the kernel).
- * - Event-count dims = current `recentEvents` window MINUS the
- *   matching kind by 1 to compensate for THIS outcome's own emission.
- *   The dedupe set in `setLearningAgent` ensures the kernel + skill
- *   double-emit only counts once per `(kind, skillId|needId, tick)`,
- *   so the -1 compensation reverses exactly one self-increment.
+ * - Event-count dims = current `recentEvents` window. THIS outcome's
+ *   own completion is NOT yet recorded — `buildLearningLearner`'s
+ *   `toTrainingPair` wrapper increments AFTER `projectLearningOutcome`
+ *   returns, so the projection always sees pre-this-outcome counts.
  * - Label = one-hot 7-vector for SUCCESSFUL outcomes only. Successes
  *   for skill `id` set `label[SOFTMAX_SKILL_IDS.indexOf(id)] = 1`.
  *
@@ -480,13 +471,6 @@ function projectLearningOutcome(
     else if (e.kind === 'failed') failedCount += 1;
     else critical += 1;
   }
-  // Successful outcomes for active-care skills reach this branch only
-  // when the kernel emitted SkillCompleted for THIS skill — that
-  // emission already pushed one entry into `recentEvents` (deduped via
-  // `processedThisTick`). Subtract it to recover the pre-skill window.
-  // Failures are filtered out earlier in this function, so we only
-  // compensate the `completed` slot.
-  completed = Math.max(0, completed - 1);
   const norm = (n: number): number => Math.min(n, COUNT_NORM_CAP) / COUNT_NORM_CAP;
   const features = [
     levels.hunger ?? 0,
@@ -532,7 +516,19 @@ export async function buildLearningLearner(
   >[0]['reasoner'];
   return new TfjsLearner<number[], number[]>({
     reasoner: trainable,
-    toTrainingPair: (outcome) => projectLearningOutcome(agent, outcome),
+    toTrainingPair: (outcome) => {
+      // Project FIRST so the recent-event window seen by this outcome's
+      // training pair represents pre-this-outcome state. THEN record
+      // the outcome into the window so the next call (and the next
+      // tick's `featuresFromNeeds`) sees the bumped count.
+      const pair = projectLearningOutcome(agent, outcome);
+      const intentionType = outcome.intention.type;
+      if (typeof intentionType === 'string') {
+        const failed = (outcome.details as { failed?: unknown } | undefined)?.failed === true;
+        recordOutcomeForFeatureWindow(failed ? 'failed' : 'completed');
+      }
+      return pair;
+    },
     batchSize: LEARNER_BATCH_SIZE,
     onTrainError: (err) => {
       // eslint-disable-next-line no-console -- background-train diagnostics.

--- a/examples/nurture-pet/src/cognition/learning.ts
+++ b/examples/nurture-pet/src/cognition/learning.ts
@@ -119,15 +119,6 @@ let unsubscribers: Array<() => void> = [];
  * frequency. Cleared on every `AgentTicked` event.
  */
 let processedThisTick = new Set<string>();
-/**
- * 8-dim rich-feature suffix (mood one-hot + modifier-count + event
- * counts) snapshotted during `featuresFromNeeds` (Stage 4). Reused at
- * outcome-time projection (Stage 8) so training inputs encode the same
- * pre-skill state inference saw, not post-skill state mutated by the
- * skill's `applyModifier` / `removeModifier` calls. `null` until the
- * first `featuresFromNeeds` call.
- */
-let lastRichFeatureSuffix: number[] | null = null;
 
 /**
  * Wire the learning mode to `agent`: store its id for the persisted-
@@ -154,7 +145,6 @@ export function setLearningAgent(
   currentTick = 0;
   recentEvents = [];
   processedThisTick = new Set<string>();
-  lastRichFeatureSuffix = null;
   agentIdForHydration = agent?.identity.id ?? null;
   if (agent === null) return;
   unsubscribers.push(
@@ -260,19 +250,17 @@ function featuresFromNeeds(
     else critical += 1;
   }
   const norm = (n: number): number => Math.min(n, COUNT_NORM_CAP) / COUNT_NORM_CAP;
-  // Snapshot the 8-dim rich-feature suffix so `projectLearningOutcome`
-  // (Stage 8) can pair the SAME pre-skill state with the action label,
-  // avoiding the post-skill leak Codex flagged on PR #96 (default
-  // skills like `FeedSkill` mutate `modifiers` mid-execute).
-  const suffix = [...moodOneHot, modCount, norm(completed), norm(failed), norm(critical)];
-  lastRichFeatureSuffix = suffix;
   return [
     levels.hunger ?? 0,
     levels.cleanliness ?? 0,
     levels.happiness ?? 0,
     levels.energy ?? 0,
     levels.health ?? 0,
-    ...suffix,
+    ...moodOneHot,
+    modCount,
+    norm(completed),
+    norm(failed),
+    norm(critical),
   ];
 }
 
@@ -420,17 +408,22 @@ export const learningMode: CognitionModeSpec = {
  *   arrived without a `preNeeds` snapshot, for defensive compatibility
  *   with consumer-emitted outcomes (the library's own pipeline always
  *   populates it).
- * - Mood / modifier-count / event-count dims = the 8-dim suffix
- *   `featuresFromNeeds` snapshotted into `lastRichFeatureSuffix` at
- *   Stage 4 of THIS tick (BEFORE the skill ran). Reusing the
- *   pre-skill snapshot keeps training inputs aligned with what
- *   inference saw — recomputing from `agent.getState()` here would
- *   leak post-skill modifier mutations (e.g. `FeedSkill` adds
- *   `well-fed`, `CleanSkill` removes `dirty`) and inflate the
- *   recent-event count with the outcome's own emission. Falls back
- *   to a from-state recompute only if no `featuresFromNeeds` call
- *   has run yet (typically a test harness scoring outcomes without
- *   driving the reasoner first).
+ * - Mood dim = current `agent.getState().mood?.category`. `MoodModel`
+ *   reconciles at Stage 2.7 of every tick, BEFORE Stage 7 skill
+ *   execution and Stage 8 scoring, so mood at outcome time still
+ *   reflects pre-skill state for any single-skill invocation.
+ * - Modifier-count dim = `details.preModifierCount` (snapshotted by
+ *   `CognitionPipeline.invokeSkillAction` BEFORE skill execution).
+ *   Reading `agent.getState().modifiers.length` here would leak
+ *   skill-applied mutations (e.g. `FeedSkill` adds `well-fed`,
+ *   `CleanSkill` removes `dirty`). Falls back to current state only
+ *   when the outcome arrived without the snapshot (e.g. a consumer-
+ *   emitted outcome from outside the kernel).
+ * - Event-count dims = current `recentEvents` window MINUS the
+ *   matching kind by 1 to compensate for THIS outcome's own emission.
+ *   The dedupe set in `setLearningAgent` ensures the kernel + skill
+ *   double-emit only counts once per `(kind, skillId|needId, tick)`,
+ *   so the -1 compensation reverses exactly one self-increment.
  * - Label = one-hot 7-vector for SUCCESSFUL outcomes only. Successes
  *   for skill `id` set `label[SOFTMAX_SKILL_IDS.indexOf(id)] = 1`.
  *
@@ -467,44 +460,18 @@ function projectLearningOutcome(
   // would invert the training direction.
   const preNeeds = (details as { preNeeds?: Record<string, number> }).preNeeds;
   const levels = preNeeds ?? agent.getState().needs;
-  // Reuse the rich-feature suffix `featuresFromNeeds` snapshotted at
-  // Stage 4 of THIS tick. Computing from `agent.getState()` here would
-  // capture POST-skill modifier counts (e.g. `FeedSkill` adds
-  // `well-fed`, `CleanSkill` removes `dirty`), causing inputs to
-  // encode action effects — Codex P1 finding on PR #96. Falls back to
-  // a recomputed-from-current-state suffix only when the outcome
-  // arrived before any `featuresFromNeeds` call (e.g. the consumer's
-  // first invocation of `learner.score` happens without a tick
-  // boundary, like the demo's test harness).
-  const suffix = lastRichFeatureSuffix ?? recomputeRichFeatureSuffixFromAgent(agent);
-  const features = [
-    levels.hunger ?? 0,
-    levels.cleanliness ?? 0,
-    levels.happiness ?? 0,
-    levels.energy ?? 0,
-    levels.health ?? 0,
-    ...suffix,
-  ];
-  const label = new Array<number>(SOFTMAX_DIM).fill(0);
-  label[skillIdx] = 1;
-  return { features, label };
-}
-
-/**
- * Build the 8-dim rich-feature suffix from the agent's current state
- * + the module-scoped event window. Used as a fallback by
- * `projectLearningOutcome` when no `featuresFromNeeds` call has
- * snapshotted a pre-skill suffix yet (typically only the first
- * outcome in a session, or test harnesses that score outcomes without
- * driving the reasoner). Production traffic always reuses the
- * pre-skill snapshot, so this fallback's post-skill leak is a
- * one-pair edge case.
- */
-function recomputeRichFeatureSuffixFromAgent(agent: Agent): number[] {
   const state = agent.getState();
   const moodCategory = state.mood?.category;
   const moodOneHot = MOOD_KEYS.map((key) => (moodCategory === key ? 1 : 0));
-  const modCount = Math.min(state.modifiers.length, COUNT_NORM_CAP) / COUNT_NORM_CAP;
+  // Prefer the kernel-supplied pre-skill modifier count; fall back to
+  // current state only for consumer-emitted outcomes that bypass the
+  // pipeline's snapshot.
+  const preModCountRaw = (details as { preModifierCount?: unknown }).preModifierCount;
+  const preModCount =
+    typeof preModCountRaw === 'number' && Number.isFinite(preModCountRaw)
+      ? preModCountRaw
+      : state.modifiers.length;
+  const modCount = Math.min(preModCount, COUNT_NORM_CAP) / COUNT_NORM_CAP;
   let completed = 0;
   let failedCount = 0;
   let critical = 0;
@@ -513,8 +480,29 @@ function recomputeRichFeatureSuffixFromAgent(agent: Agent): number[] {
     else if (e.kind === 'failed') failedCount += 1;
     else critical += 1;
   }
+  // Successful outcomes for active-care skills reach this branch only
+  // when the kernel emitted SkillCompleted for THIS skill — that
+  // emission already pushed one entry into `recentEvents` (deduped via
+  // `processedThisTick`). Subtract it to recover the pre-skill window.
+  // Failures are filtered out earlier in this function, so we only
+  // compensate the `completed` slot.
+  completed = Math.max(0, completed - 1);
   const norm = (n: number): number => Math.min(n, COUNT_NORM_CAP) / COUNT_NORM_CAP;
-  return [...moodOneHot, modCount, norm(completed), norm(failedCount), norm(critical)];
+  const features = [
+    levels.hunger ?? 0,
+    levels.cleanliness ?? 0,
+    levels.happiness ?? 0,
+    levels.energy ?? 0,
+    levels.health ?? 0,
+    ...moodOneHot,
+    modCount,
+    norm(completed),
+    norm(failedCount),
+    norm(critical),
+  ];
+  const label = new Array<number>(SOFTMAX_DIM).fill(0);
+  label[skillIdx] = 1;
+  return { features, label };
 }
 
 /**

--- a/examples/nurture-pet/src/cognitionSwitcher.ts
+++ b/examples/nurture-pet/src/cognitionSwitcher.ts
@@ -26,6 +26,18 @@ const TRAIN_EPOCHS = 100;
 const TRAINED_FLASH_MS = 1500;
 
 /**
+ * Number of mood + modifier + event dims appended to the 5 need-level
+ * features. Must stay in lockstep with `learning.ts`'s `FEATURE_DIM`
+ * (5 + MOOD_KEYS.length + 1 modifier + 3 events = 13). The synthetic
+ * Train-button data leaves these 8 dims as uniform `[0, 1]` noise —
+ * the labels don't condition on them, so the network learns to ignore
+ * them under the synthetic regime. Real in-game data flowing through
+ * the `TfjsLearner` reinforcement loop is what teaches the network
+ * which of those dims actually predict the right action.
+ */
+const RICH_FEATURE_DIM_COUNT = 8;
+
+/**
  * Build a synthetic feature vector from the archetype distribution for
  * `skillIdx` (an index into `SOFTMAX_SKILL_IDS`). The Train button uses
  * stratified sampling rather than uniform-random draws so every class
@@ -45,16 +57,37 @@ const TRAINED_FLASH_MS = 1500;
  * - scold: happiness ∈ [0.85, 1.0], energy ∈ [0.0, 0.35], others ∈
  *   [0.4, 0.7] so the `happiness > 0.8 ∧ energy < 0.4` clause fires
  *   before the `min > 0.7` (impossible here) and lowest-need rules.
+ *
+ * The 8 trailing dims (mood / modifier-count / event-counts) are
+ * uniform `[0, 1]` noise — see `RICH_FEATURE_DIM_COUNT` JSDoc.
  */
 function generateArchetypeFeatures(rng: () => number, skillIdx: number): number[] {
   const range = (lo: number, hi: number): number => lo + rng() * (hi - lo);
+  // Append uniform-noise dims for mood / modifier / event counts. See
+  // `RICH_FEATURE_DIM_COUNT` JSDoc for why noise is the right choice
+  // for synthetic training pairs.
+  const richTail = (): number[] => Array.from({ length: RICH_FEATURE_DIM_COUNT }, () => rng());
   // `pet` — all needs comfortably high.
   if (skillIdx === SOFTMAX_SKILL_IDS.indexOf('pet')) {
-    return [range(0.75, 1), range(0.75, 1), range(0.75, 1), range(0.75, 1), range(0.75, 1)];
+    return [
+      range(0.75, 1),
+      range(0.75, 1),
+      range(0.75, 1),
+      range(0.75, 1),
+      range(0.75, 1),
+      ...richTail(),
+    ];
   }
   // `scold` — happy + tired.
   if (skillIdx === SOFTMAX_SKILL_IDS.indexOf('scold')) {
-    return [range(0.4, 0.7), range(0.4, 0.7), range(0.85, 1), range(0, 0.35), range(0.4, 0.7)];
+    return [
+      range(0.4, 0.7),
+      range(0.4, 0.7),
+      range(0.85, 1),
+      range(0, 0.35),
+      range(0.4, 0.7),
+      ...richTail(),
+    ];
   }
   // Maintenance archetypes: target need low, others mid-high.
   const needIdxBySkill: Partial<Record<(typeof SOFTMAX_SKILL_IDS)[number], number>> = {
@@ -70,6 +103,7 @@ function generateArchetypeFeatures(rng: () => number, skillIdx: number): number[
   for (let i = 0; i < NEED_IDS.length; i++) {
     features.push(i === targetNeedIdx ? range(0, 0.3) : range(0.4, 0.95));
   }
+  features.push(...richTail());
   return features;
 }
 

--- a/examples/nurture-pet/src/main.ts
+++ b/examples/nurture-pet/src/main.ts
@@ -13,7 +13,7 @@ import {
   type AgentTickedEvent,
 } from 'agentonomous';
 import { ApproachTreatSkill } from './skills/ApproachTreatSkill.js';
-import { setLearningAgentId } from './cognition/learning.js';
+import { setLearningAgent } from './cognition/learning.js';
 import { mountCognitionSwitcher } from './cognitionSwitcher.js';
 import { catSpecies } from './species.js';
 import {
@@ -121,9 +121,11 @@ const pet = createAgent({
   randomEvents,
 });
 
-// Inject the agent id so the learning mode's `construct()` can scope
-// its persisted-network localStorage key per-pet.
-setLearningAgentId(pet.identity.id);
+// Wire the learning mode to the agent: scopes the persisted-network
+// localStorage key per-pet AND subscribes to the standard event bus to
+// feed the mood / modifier-count / event-count dims of
+// `featuresFromNeeds`.
+setLearningAgent(pet);
 
 // --- Mount UI + reactive binding ----------------------------------------------
 const hud = mountHud(pet);

--- a/scripts/seed-learning-network.ts
+++ b/scripts/seed-learning-network.ts
@@ -1,11 +1,17 @@
 /**
  * One-shot seed script for `examples/nurture-pet/src/cognition/learning.network.json`.
  *
- * Builds a `[5, 16, 7]` Sequential (5 need-level inputs → 16 sigmoid hidden →
- * 7 softmax outputs over the active-care skills), trains it briefly on a
- * hand-crafted dataset that maps each lowest-level need to its corresponding
- * skill, and writes the resulting plain-JSON snapshot — matching the
- * `TfjsSnapshot` shape that `TfjsReasoner.fromJSON(...)` rebuilds — to disk.
+ * Builds a `[13, 16, 7]` Sequential (13 input feature dims = 5 needs + 4
+ * mood one-hot + 1 modifier-count + 3 recent-event counts → 16 sigmoid
+ * hidden → 7 softmax outputs over the active-care skills), trains it
+ * briefly on a hand-crafted dataset that maps each lowest-level need to
+ * its corresponding skill, and writes the resulting plain-JSON snapshot
+ * — matching the `TfjsSnapshot` shape that `TfjsReasoner.fromJSON(...)`
+ * rebuilds — to disk. The 8 non-need dims are uniform `[0, 1]` noise in
+ * the seed dataset so the baseline network learns the lowest-need rule
+ * over the 5 need dims while staying neutral on the richer signals;
+ * those richer dims acquire predictive weight only via the in-game
+ * `TfjsLearner` reinforcement loop.
  *
  * The output mapping is deliberate — the bundled baseline should give an
  * untrained user a network that already "knows" the obvious heuristic
@@ -49,6 +55,24 @@ const NEED_TO_SKILL_INDEX: ReadonlyArray<number> = [
   5, // health      → medicate
 ];
 
+/**
+ * Mood keys appended after the 5 need dims as a one-hot block. Must
+ * match `MOOD_KEYS` in `examples/nurture-pet/src/cognition/learning.ts`.
+ */
+const MOOD_KEYS = ['happy', 'sad', 'sleepy', 'playful'] as const;
+
+/**
+ * Total input feature width = 5 needs + 4 mood one-hot + 1
+ * modifier-count + 3 recent-event counts. Matches `FEATURE_DIM` in
+ * `learning.ts`. The seed dataset fills the 8 non-need dims with
+ * uniform-`[0, 1]` noise so the lowest-need rule still drives the
+ * gradient.
+ */
+const FEATURE_DIM = 5 + MOOD_KEYS.length + 1 + 3;
+
+/** Number of trailing noise dims appended after the 5 need samples. */
+const RICH_NOISE_DIM_COUNT = FEATURE_DIM - 5;
+
 /** LCG seed used for both training-pair generation and tfjs init. */
 const SEED = 0x5eed_17;
 
@@ -87,10 +111,10 @@ function encodeWeights(weights: readonly Float32Array[]): string {
 }
 
 /**
- * Build a `[5, 16, 7]` Sequential with sigmoid hidden + softmax output.
- * The kernel initializer is seeded so the pre-train weights are stable;
- * post-train weights then depend only on the deterministic data + fit
- * loop.
+ * Build a `[FEATURE_DIM, 16, 7]` Sequential with sigmoid hidden +
+ * softmax output. The kernel initializer is seeded so the pre-train
+ * weights are stable; post-train weights then depend only on the
+ * deterministic data + fit loop.
  */
 function buildModel(): Sequential {
   const model = sequential();
@@ -102,7 +126,7 @@ function buildModel(): Sequential {
     layers.dense({
       units: 16,
       activation: 'sigmoid',
-      inputShape: [5],
+      inputShape: [FEATURE_DIM],
       kernelInitializer: initializers.glorotNormal({ seed: SEED }),
       biasInitializer: 'zeros',
     }),
@@ -170,6 +194,10 @@ function generateTrainingPairs(rng: () => number): {
       const mapped = NEED_TO_SKILL_INDEX[minIdx];
       skillIdx = mapped ?? 0;
     }
+    // Append uniform-`[0, 1]` noise for the 8 mood / modifier / event
+    // dims. Labels don't condition on these, so the network learns to
+    // ignore them under the synthetic baseline regime.
+    for (let j = 0; j < RICH_NOISE_DIM_COUNT; j++) sample.push(rng());
     const oneHot = new Array<number>(SKILL_IDS.length).fill(0);
     oneHot[skillIdx] = 1;
     features.push(sample);
@@ -187,7 +215,7 @@ async function main(): Promise<void> {
   const { features, labels } = generateTrainingPairs(rng);
 
   console.log(
-    `Training [5, 16, ${SKILL_IDS.length}] softmax baseline on ${features.length} pairs ` +
+    `Training [${FEATURE_DIM}, 16, ${SKILL_IDS.length}] softmax baseline on ${features.length} pairs ` +
       `for ${EPOCHS} epochs (CPU backend)…`,
   );
 
@@ -227,7 +255,18 @@ async function main(): Promise<void> {
     topology,
     weights: encodeWeights(weightsArrays),
     weightsShapes,
-    inputKeys: ['hunger', 'cleanliness', 'happiness', 'energy', 'health'],
+    inputKeys: [
+      'hunger',
+      'cleanliness',
+      'happiness',
+      'energy',
+      'health',
+      ...MOOD_KEYS.map((k) => `mood:${k}`),
+      'modifierCount',
+      'recent:SkillCompleted',
+      'recent:SkillFailed',
+      'recent:NeedCritical',
+    ],
     outputKeys: [...SKILL_IDS],
   };
 

--- a/src/agent/internal/CognitionPipeline.ts
+++ b/src/agent/internal/CognitionPipeline.ts
@@ -124,6 +124,13 @@ export class CognitionPipeline {
     // returns would capture post-effect levels (e.g. `feed` raises hunger
     // from low → high), inverting the policy direction.
     const preNeeds = this.snapshotNeeds();
+    // Snapshot the pre-skill active-modifier count for the same reason —
+    // skills like `FeedSkill` add buffs and `CleanSkill` removes debuffs
+    // during `execute()`, so reading `agent.modifiers.list().length` at
+    // outcome time would leak skill-applied mutations into training
+    // inputs. Consumers that include a "modifier count" feature should
+    // read this snapshot from `details.preModifierCount`.
+    const preModifierCount = agent.modifiers.list().length;
     // Stage capability gate.
     if (agent.ageModel && agent.stageCapabilities) {
       if (!stageAllowsSkill(agent.stageCapabilities, agent.ageModel.stage, skillId)) {
@@ -136,7 +143,14 @@ export class CognitionPipeline {
           message: `Skill '${skillId}' is blocked at stage '${agent.ageModel.stage}'.`,
         };
         agent.publishEvent(event);
-        this.scoreFailure(skillId, params, 'stage-blocked', event.message, preNeeds);
+        this.scoreFailure(
+          skillId,
+          params,
+          'stage-blocked',
+          event.message,
+          preNeeds,
+          preModifierCount,
+        );
         return;
       }
     }
@@ -150,7 +164,14 @@ export class CognitionPipeline {
         message: `No skill registered with id '${skillId}'.`,
       };
       agent.publishEvent(event);
-      this.scoreFailure(skillId, params, 'not-registered', event.message, preNeeds);
+      this.scoreFailure(
+        skillId,
+        params,
+        'not-registered',
+        event.message,
+        preNeeds,
+        preModifierCount,
+      );
       return;
     }
     // Expose the running skill to the animation reconciler. Scoped to this
@@ -178,7 +199,7 @@ export class CognitionPipeline {
         details: { cause: message },
       };
       agent.publishEvent(event);
-      this.scoreFailure(skillId, params, 'execution-threw', message, preNeeds);
+      this.scoreFailure(skillId, params, 'execution-threw', message, preNeeds, preModifierCount);
       return;
     }
     agent.currentActiveSkillId = previousActive;
@@ -203,6 +224,7 @@ export class CognitionPipeline {
         details: {
           effectiveness,
           ...(preNeeds !== undefined ? { preNeeds } : {}),
+          preModifierCount,
         },
       });
     } else {
@@ -216,7 +238,14 @@ export class CognitionPipeline {
         ...(result.error.details !== undefined ? { details: result.error.details } : {}),
       };
       agent.publishEvent(event);
-      this.scoreFailure(skillId, params, result.error.code, result.error.message, preNeeds);
+      this.scoreFailure(
+        skillId,
+        params,
+        result.error.code,
+        result.error.message,
+        preNeeds,
+        preModifierCount,
+      );
     }
   }
 
@@ -239,8 +268,9 @@ export class CognitionPipeline {
    * Common Stage-8 hook for every SkillFailed branch. Mirrors the
    * success-side `score` call shape so consumers can switch on
    * `details.failed` to label the outcome (negative reward, one-hot
-   * `[0]`, or skip entirely depending on policy). `preNeeds` is the
-   * pre-skill snapshot captured at the top of `invokeSkillAction`.
+   * `[0]`, or skip entirely depending on policy). `preNeeds` and
+   * `preModifierCount` are the pre-skill snapshots captured at the top
+   * of `invokeSkillAction`.
    */
   private scoreFailure(
     skillId: string,
@@ -248,6 +278,7 @@ export class CognitionPipeline {
     code: string,
     message: string,
     preNeeds: Record<string, number> | undefined,
+    preModifierCount: number,
   ): void {
     this.agent.learner.score({
       intention: { kind: 'satisfy', type: skillId },
@@ -257,6 +288,7 @@ export class CognitionPipeline {
         code,
         message,
         ...(preNeeds !== undefined ? { preNeeds } : {}),
+        preModifierCount,
       },
     });
   }

--- a/tests/examples/learningMode.train.test.ts
+++ b/tests/examples/learningMode.train.test.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock }
 import { mountCognitionSwitcher } from '../../examples/nurture-pet/src/cognitionSwitcher.js';
 import {
   interpretSoftmax,
-  setLearningAgentId,
+  setLearningAgent,
   SOFTMAX_SKILL_IDS,
 } from '../../examples/nurture-pet/src/cognition/learning.js';
 import { mountResetButton } from '../../examples/nurture-pet/src/ui.js';
@@ -20,7 +20,12 @@ import { mountResetButton } from '../../examples/nurture-pet/src/ui.js';
 interface FakeAgent {
   setReasoner: Mock<(r: unknown) => void>;
   setLearner: Mock<(l: unknown) => void>;
-  getState: () => { needs: Record<string, number> };
+  getState: () => {
+    needs: Record<string, number>;
+    modifiers: ReadonlyArray<{ id: string }>;
+    mood?: { category: string; updatedAt: number };
+  };
+  subscribe: (handler: (e: { type: string }) => void) => () => void;
   identity: { id: string; name: string };
   rng: {
     next: () => number;
@@ -97,16 +102,22 @@ async function mountDemo(opts: { agentId?: string } = {}): Promise<{
 }> {
   const agentId = opts.agentId ?? 'test-pet';
   const root = renderRoot();
-  setLearningAgentId(agentId);
   const fakeAgent: FakeAgent = {
     setReasoner: vi.fn(),
     setLearner: vi.fn(),
     getState: () => ({
       needs: { hunger: 0.5, cleanliness: 0.5, happiness: 0.5, energy: 0.5, health: 0.5 },
+      modifiers: [],
     }),
+    // No-op event subscription. The learning module's `setLearningAgent`
+    // wires real handlers when running against a live `Agent`; the test
+    // double exercises the localStorage-scoping side without driving the
+    // mood / event-count state.
+    subscribe: () => () => undefined,
     identity: { id: agentId, name: agentId },
     rng: makeFakeRng(),
   };
+  setLearningAgent(fakeAgent as never);
   mountCognitionSwitcher(fakeAgent as never, root);
   mountResetButton(fakeAgent as never);
   const select = root.querySelector<HTMLSelectElement>('#cognition-mode-select')!;
@@ -247,12 +258,13 @@ describe('Train click handler', () => {
     expect(typeof parsed.weights).toBe('string');
     expect(parsed.weights!.length).toBeGreaterThan(0);
     expect(Array.isArray(parsed.weightsShapes)).toBe(true);
-    // Topology contract: [5, 16] kernel + [16] bias on the hidden dense
-    // layer, then [16, 7] kernel + [7] bias on the softmax head. Locks
-    // the post-train snapshot to the row-17 shape so a topology drift
-    // can't sneak past review.
+    // Topology contract: [13, 16] kernel + [16] bias on the hidden
+    // dense layer, then [16, 7] kernel + [7] bias on the softmax head.
+    // 13 = 5 needs + 4 mood one-hot + 1 modifier-count + 3 recent-event
+    // counts (row 18). Locks the post-train snapshot shape so a
+    // topology drift can't sneak past review.
     expect(parsed.weightsShapes).toEqual([
-      [5, 16],
+      [13, 16],
       [16],
       [16, SOFTMAX_SKILL_IDS.length],
       [SOFTMAX_SKILL_IDS.length],

--- a/tests/unit/cognition/adapters/TfjsReasoner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsReasoner.test.ts
@@ -380,7 +380,9 @@ describe('TfjsReasoner — bundled demo baseline', () => {
 
     // Topology contract — keep this in lockstep with the seed script
     // (`scripts/seed-learning-network.ts`) and `SOFTMAX_SKILL_IDS`.
-    expect(snapshot.weightsShapes).toEqual([[5, 16], [16], [16, 7], [7]]);
+    // 13 = 5 needs + 4 mood one-hot + 1 modifier-count + 3 recent-event
+    // counts (row 18).
+    expect(snapshot.weightsShapes).toEqual([[13, 16], [16], [16, 7], [7]]);
 
     // Feed a "very hungry" feature vector — the seed script's archetype
     // distribution leans toward `feed` (index 0 in SOFTMAX_SKILL_IDS) for
@@ -388,7 +390,10 @@ describe('TfjsReasoner — bundled demo baseline', () => {
     // snapshot is regenerated on tfjs minor bumps and the post-train
     // weights drift — but we DO assert (a) seven outputs, (b) all in
     // [0, 1], and (c) sum to ~1, which is the softmax invariant.
-    const featureVec = [0.05, 0.6, 0.6, 0.6, 0.6];
+    // The 8 trailing dims (mood / modifier-count / event-counts) are
+    // fed neutral zeros — the seed dataset trains them to be
+    // uninformative, so the column ordering still favors `feed` here.
+    const featureVec = [0.05, 0.6, 0.6, 0.6, 0.6, 0, 0, 0, 0, 0, 0, 0, 0];
     let captured: number[] | null = null;
     const reasoner = await TfjsReasoner.fromJSON<number[], number[]>(snapshot, {
       featuresOf: () => featureVec,


### PR DESCRIPTION
## Summary

- Extends Learning mode's feature vector from 5 need levels to **13 dims**: 5 needs + 4 mood one-hot (`MOOD_KEYS = ['happy','sad','sleepy','playful']`) + 1 normalized active-modifier count + 3 normalized recent-event counts (`SkillCompleted`/`SkillFailed`/`NeedCritical`) over a 30-tick window.
- Renames `setLearningAgentId(id)` → `setLearningAgent(agent)` (pre-1.0 clean break, no compat shim). The new function subscribes to the standard event bus to populate module-scoped mood + recent-event state without widening the adapter's `helpers` shape.
- `projectLearningOutcome` now produces 13-dim training pairs at outcome time; `cognitionSwitcher.ts`'s synthetic Train-button generator + `scripts/seed-learning-network.ts` both pad with uniform-`[0, 1]` noise so labels stay conditioned on the 5 need dims.
- Bundled `examples/nurture-pet/src/cognition/learning.network.json` regenerated at the new `[13, 16, 7]` topology. Hydration's existing input + output dim guard (PR #94) lets old 5-input snapshots fail fast and fall back to the new baseline.

## Test plan

- [x] `npm run verify` green (format / lint / typecheck / 491 tests / build / docs)
- [x] `weightsShapes` topology test updated to `[13, 16] / [16] / [16, 7] / [7]` (`tests/examples/learningMode.train.test.ts`, `tests/unit/cognition/adapters/TfjsReasoner.test.ts`)
- [x] Bundled-baseline test feeds a neutral-zero rich tail `[0.05, 0.6, 0.6, 0.6, 0.6, 0, 0, 0, 0, 0, 0, 0, 0]` and still asserts softmax invariants (7-vector, ∈ [0,1], sums to 1)
- [x] Plan rows 17 + 18 marked shipped in the same diff per `feedback_docs_alongside_pr`

## Notes for review

- Library impact: **none** — `featuresOf` is consumer-supplied. No changeset.
- The 4 mood one-hot keys cover the demo's most narratively-distinct states; off-roster moods (`content`, `angry`, `bored`, `sick`, `scared`) collapse to all-zero on that section. This is intentional — the network treats those as "uninformative" rather than mistakenly grouping them with one of the 4 picked categories.
- The synthetic Train-button data appends uniform `[0, 1]` noise on the 8 trailing dims because the labels don't condition on them. This trains the network to ignore those dims under the synthetic regime; predictive weight on mood / modifier / event counts comes only from the in-game `TfjsLearner` reinforcement loop fed by real outcomes.
- `projectLearningOutcome`'s mood / modifier-count / event-count dims are read at outcome time (post-skill). The need dims still come from `details.preNeeds` to preserve the row-17 invariant that need-level features reflect pre-skill state. Mood + modifier counts are stable across a single skill invocation; the event-count window includes the outcome's own emission, but that bias is uniform across every training pair so the net gradient direction is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)