### PR TITLE
feat: review-fix skill + auto-flip workflow

### DIFF
--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: review-fix
+description: Ingests a single finding from the rolling daily-code-review tracker issue (`#87 Daily code review — develop`) and produces a worktree-isolated topic branch + implementation plan. Use when the user says "fix review finding <id>", "pick a finding", "/review-fix <id>", or names a finding-ID like `682b557.3`. Does NOT close the tracker issue — the tracker is append-only and the auto-flip workflow handles shipped state.
+---
+
+# review-fix — turn one tracker finding into a worktree + plan
+
+## Terminology
+
+- **Tracker issue** — `#87 Daily code review — develop`. Long-lived,
+  one comment per scheduled bot run, body holds the canonical
+  `Last reviewed SHA`. **Never closed by this skill.**
+- **Finding** — one `[BLOCKER] / [MAJOR] / [MINOR] / [NIT]` checklist
+  item inside a bot comment.
+- **Finding ID** — `<head-sha[:7]>.<idx>` (e.g. `682b557.3`). Embedded
+  as an HTML comment on each finding's checklist line.
+- **Magic line** — `Refs #87 finding:<id>` in a PR body. The
+  contract between this skill's output and the
+  `review-fix-shipped` Action.
+
+## Before you start
+
+Confirm with the user:
+
+1. **Finding ID** — exact form `<sha7>.<idx>`. If they paste a free-text
+   description instead, refuse and ask them to grab the ID from
+   `gh issue view 87 --comments`.
+2. **Already shipped?** — if the tracker line for that ID renders
+   `- [x]`, refuse and tell them which PR shipped it (the comment line
+   carries `(shipped in #N)`).
+3. **Worktree clear?** — if `.worktrees/fix-review-<slug>` already
+   exists, refuse with the existing path. Either remove it
+   (`git worktree remove`) or pick a different finding.
+
+## Steps
+
+### 1. Locate the finding
+
+Substitute the user-provided finding ID (e.g. `682b557.3`) for `${ID}`
+below before running:
+
+```bash
+ID="<sha7>.<idx>"            # e.g. 682b557.3
+MARKER="<!-- f:${ID} -->"
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+gh api "/repos/${REPO}/issues/87/comments" --paginate \
+  --jq ".[] | select(.body | contains(\"${MARKER}\")) | {id, body}"
+```
+
+If no match: hard-fail with `Finding ${ID} not found in #87 comments`.
+
+### 2. Extract finding fields
+
+From the matched comment body, locate the line ending with
+`<!-- f:<sha7>.<idx> -->`. Pull:
+
+- **Severity** — the `**[…]**` token (`BLOCKER` / `MAJOR` / `MINOR` /
+  `NIT`).
+- **Path** — the backtick-quoted path immediately after.
+- **Title** — the text between `— ` and the HTML comment.
+- **Body** — the contents of the `<details>` block on the lines below.
+
+If the line shows `- [x]` instead of `- [ ]`: hard-fail
+`Finding <id> already shipped in #<PR>`.
+
+### 3. Compute slug + paths
+
+```text
+slug          = kebab(severity-lowercased + first 4 words of title), trim ≤ 50 chars
+worktree-dir  = .worktrees/fix-review-<slug>
+branch        = fix/review-bot-<slug>
+plan-path     = docs/plans/YYYY-MM-DD-review-bot-<slug>.md   (UTC date)
+```
+
+Example for `682b557.1` (`[BLOCKER]` `LlmProviderPort.ts` interface→type sweep):
+
+```text
+slug          = blocker-llmproviderport-interface-to-type
+worktree-dir  = .worktrees/fix-review-blocker-llmproviderport-interface-to-type
+branch        = fix/review-bot-blocker-llmproviderport-interface-to-type
+plan-path     = docs/plans/2026-04-25-review-bot-blocker-llmproviderport-interface-to-type.md
+```
+
+### 4. Create the worktree + branch
+
+```bash
+git fetch origin develop
+git worktree add <worktree-dir> -b <branch> origin/develop
+cd <worktree-dir>
+npm install
+```
+
+If `git worktree add` fails because the branch already exists (e.g.
+prior aborted run), surface the error verbatim — do **not** retry
+with `-B` (force) since that would silently rewind work.
+
+### 5. Write the plan file
+
+Create `<worktree-dir>/<plan-path>` with frontmatter + finding-quoted
+body. The `tracker` value MUST be quoted — `#` opens a YAML comment.
+
+```markdown
+---
+date: YYYY-MM-DD
+slug: review-bot-<slug>
+finding-id: <sha7>.<idx>
+tracker: '#87'
+severity: <BLOCKER|MAJOR|MINOR|NIT>
+---
+
+# Fix review finding `<id>` — <title>
+
+## Source
+
+From `#87` comment <comment-id>, finding `<id>`:
+
+> **[<SEVERITY>]** `<path>` — <title>
+>
+> <quoted body, including diff blocks, verbatim>
+
+## Acceptance
+
+- Apply the bot's proposed fix (see body above).
+- Add or update tests covering the new code paths.
+- `npm run verify` passes locally.
+- Codex review on the PR is acknowledged or rebutted on each thread.
+
+## Rollout
+
+- Branch: `fix/review-bot-<slug>` (already cut by review-fix skill).
+- PR base: `develop`.
+- PR body MUST contain on its own line: `Refs #87 finding:<id>`.
+- PR body MUST NOT contain `Closes #87` / `Fixes #87`.
+- Changeset required if behavior changes (`npm run changeset`).
+```
+
+### 6. Hand off
+
+Print exactly:
+
+```text
+Plan written to <plan-path> on branch <branch> in <worktree-dir>.
+Next: cd <worktree-dir> && /superpowers:writing-plans <plan-path>
+```
+
+**Do not** invoke `superpowers:writing-plans` automatically. The user
+runs it after reviewing the plan.
+
+## Do not
+
+- Do NOT open the PR. PR creation belongs to the implementation
+  session, not the plan session.
+- Do NOT close the tracker issue. Do NOT add `Closes #87` / `Fixes #87`
+  anywhere.
+- Do NOT edit the tracker comment from the skill — only the
+  `review-fix-shipped` Action edits comments, and only post-merge.
+- Do NOT batch findings. One finding = one branch = one PR.
+- Do NOT use `git worktree add -B` (force). Surface conflicts to the
+  user.

--- a/.github/workflows/review-fix-shipped.yml
+++ b/.github/workflows/review-fix-shipped.yml
@@ -26,7 +26,13 @@ concurrency:
 
 jobs:
   flip-tracker-checkbox:
-    if: github.event.pull_request.merged == true
+    # Only fire on PRs merged INTO develop. The tracker (#87
+    # "Daily code review — develop") is explicitly scoped to that
+    # branch. A hotfix-to-main or demo-promotion PR carrying a copied
+    # `Refs #87 finding:<id>` line would otherwise flip the tracker
+    # even though the fix never landed on develop, creating a false
+    # shipped state.
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
     runs-on: ubuntu-latest
     steps:
       - name: Flip tracker checkbox(es) for shipped finding(s)

--- a/.github/workflows/review-fix-shipped.yml
+++ b/.github/workflows/review-fix-shipped.yml
@@ -9,7 +9,12 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: review-fix-shipped-${{ github.event.pull_request.number }}
+  # Global group across all PRs: every job in this workflow reads + rewrites
+  # the same tracker comment body. Keying by PR number would let two merged
+  # PRs run in parallel, both read a pre-flip body, and the later write
+  # would silently revert the earlier flip. cancel-in-progress: false
+  # preserves the earlier run; the later run queues until it finishes.
+  group: review-fix-shipped
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/review-fix-shipped.yml
+++ b/.github/workflows/review-fix-shipped.yml
@@ -1,0 +1,95 @@
+name: review-fix-shipped
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: review-fix-shipped-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  flip-tracker-checkbox:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flip tracker checkbox(es) for shipped finding(s)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const re = /^Refs #(\d+) finding:([0-9a-f]{7})\.(\d+)\s*$/gm;
+            const matches = [...body.matchAll(re)];
+
+            if (matches.length === 0) {
+              core.info('No "Refs #<n> finding:<sha7>.<idx>" line in PR body. Nothing to flip.');
+              return;
+            }
+
+            const prNumber = context.payload.pull_request.number;
+
+            for (const m of matches) {
+              const [, issueStr, sha7, idxStr] = m;
+              const issueNumber = Number(issueStr);
+              const findingId = `${sha7}.${idxStr}`;
+              const marker = `<!-- f:${findingId} -->`;
+
+              core.info(`Looking for ${marker} in #${issueNumber} comments...`);
+
+              const iterator = github.paginate.iterator(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100,
+                },
+              );
+
+              let hit = null;
+              for await (const { data: page } of iterator) {
+                hit = page.find((c) => c.body && c.body.includes(marker));
+                if (hit) break;
+              }
+
+              if (!hit) {
+                core.warning(`Finding ${findingId} not found in #${issueNumber}. Skipping.`);
+                continue;
+              }
+
+              // Locate the line containing the marker by string ops (no
+              // regex escaping needed). Markers are unique per finding ID,
+              // so a single substring search is sufficient.
+              const markerIdx = hit.body.indexOf(marker);
+              const lineStart = hit.body.lastIndexOf('\n', markerIdx) + 1;
+              const lineEndRaw = hit.body.indexOf('\n', markerIdx);
+              const lineEnd = lineEndRaw === -1 ? hit.body.length : lineEndRaw;
+              const line = hit.body.slice(lineStart, lineEnd);
+
+              if (line.startsWith('- [x] ')) {
+                core.warning(`Finding ${findingId} already shipped. Skipping.`);
+                continue;
+              }
+              if (!line.startsWith('- [ ] ')) {
+                core.warning(`Marker ${marker} found but checklist line shape unexpected: ${line.slice(0, 40)}... Skipping.`);
+                continue;
+              }
+
+              const newLine = line
+                .replace('- [ ] ', '- [x] ')
+                .replace(` ${marker}`, ` (shipped in #${prNumber}) ${marker}`);
+              const newBody = hit.body.slice(0, lineStart) + newLine + hit.body.slice(lineEnd);
+
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: hit.id,
+                body: newBody,
+              });
+
+              core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
+            }

--- a/.github/workflows/review-fix-shipped.yml
+++ b/.github/workflows/review-fix-shipped.yml
@@ -44,12 +44,17 @@ jobs:
 
             const prNumber = context.payload.pull_request.number;
 
-            // Track write-side failures separately so the run fails at the
-            // end if any flip could not be persisted. Read-side failures
-            // (listComments 404, etc.) stay soft — a finding pointing at
-            // a non-existent issue is a content bug in the PR body, not
-            // a problem with the automation.
-            let writeFailures = 0;
+            // Track hard failures across both read and write phases so the
+            // run fails at the end if any flip could not be persisted or
+            // any non-404 API error masked a flip. Only "expected content
+            // misses" stay soft:
+            //   - listComments 404 (target issue does not exist — PR-body
+            //     content bug, not an automation problem),
+            //   - finding not present in the comment body,
+            //   - line already shipped or shape unexpected.
+            // Everything else (403/429/5xx/network on either read or write)
+            // increments hardFailures and triggers core.setFailed at the end.
+            let hardFailures = 0;
 
             for (const m of matches) {
               const [, issueStr, sha7, idxStr] = m;
@@ -116,14 +121,23 @@ jobs:
                   });
                   core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
                 } catch (writeErr) {
-                  writeFailures++;
+                  hardFailures++;
                   core.error(`Failed to write flip for ${findingId} in #${issueNumber}: ${writeErr.message}`);
                 }
               } catch (readErr) {
-                core.warning(`Failed to read comments for #${issueNumber} (finding ${findingId}): ${readErr.message}. Continuing with remaining matches.`);
+                // 404 on listComments = "target issue does not exist" =
+                // soft (PR-body content bug). Anything else (403, 429,
+                // 5xx, network) is a transient/permissions failure that
+                // would silently drop a valid flip — fail loudly.
+                if (readErr.status === 404) {
+                  core.warning(`Issue #${issueNumber} not found (finding ${findingId}). Skipping.`);
+                } else {
+                  hardFailures++;
+                  core.error(`Failed to read comments for #${issueNumber} (finding ${findingId}): ${readErr.message} (status ${readErr.status ?? 'n/a'})`);
+                }
               }
             }
 
-            if (writeFailures > 0) {
-              core.setFailed(`${writeFailures} flip write(s) failed; tracker comment is out of sync. Review run logs and re-run after fixing the underlying issue.`);
+            if (hardFailures > 0) {
+              core.setFailed(`${hardFailures} flip(s) failed (read or write); tracker comment is out of sync. Review run logs and re-run after fixing the underlying issue.`);
             }

--- a/.github/workflows/review-fix-shipped.yml
+++ b/.github/workflows/review-fix-shipped.yml
@@ -44,16 +44,19 @@ jobs:
 
             const prNumber = context.payload.pull_request.number;
 
+            // Track write-side failures separately so the run fails at the
+            // end if any flip could not be persisted. Read-side failures
+            // (listComments 404, etc.) stay soft — a finding pointing at
+            // a non-existent issue is a content bug in the PR body, not
+            // a problem with the automation.
+            let writeFailures = 0;
+
             for (const m of matches) {
               const [, issueStr, sha7, idxStr] = m;
               const issueNumber = Number(issueStr);
               const findingId = `${sha7}.${idxStr}`;
               const marker = `<!-- f:${findingId} -->`;
 
-              // Per-match try/catch: a missing/inaccessible target issue
-              // (or any other transient API error) must not abort sibling
-              // matches in the same PR body. Soft-warn and continue so
-              // the rest of the flips still happen.
               try {
                 core.info(`Looking for ${marker} in #${issueNumber} comments...`);
 
@@ -101,15 +104,26 @@ jobs:
                   .replace(` ${marker}`, ` (shipped in #${prNumber}) ${marker}`);
                 const newBody = hit.body.slice(0, lineStart) + newLine + hit.body.slice(lineEnd);
 
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: hit.id,
-                  body: newBody,
-                });
-
-                core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
-              } catch (err) {
-                core.warning(`Failed to process finding ${findingId} in #${issueNumber}: ${err.message}. Continuing with remaining matches.`);
+                // Inner try/catch: write failures (missing perms, rate
+                // limit, 5xx) MUST surface as a failed run; otherwise
+                // shipped-state silently drifts.
+                try {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: hit.id,
+                    body: newBody,
+                  });
+                  core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
+                } catch (writeErr) {
+                  writeFailures++;
+                  core.error(`Failed to write flip for ${findingId} in #${issueNumber}: ${writeErr.message}`);
+                }
+              } catch (readErr) {
+                core.warning(`Failed to read comments for #${issueNumber} (finding ${findingId}): ${readErr.message}. Continuing with remaining matches.`);
               }
+            }
+
+            if (writeFailures > 0) {
+              core.setFailed(`${writeFailures} flip write(s) failed; tracker comment is out of sync. Review run logs and re-run after fixing the underlying issue.`);
             }

--- a/.github/workflows/review-fix-shipped.yml
+++ b/.github/workflows/review-fix-shipped.yml
@@ -1,7 +1,14 @@
 name: review-fix-shipped
 
 on:
-  pull_request:
+  # `pull_request_target` runs in the base-repo context with a write-
+  # capable GITHUB_TOKEN. We need that to PATCH the tracker comment on
+  # merges from fork PRs, where the standard `pull_request` event fires
+  # with a read-only token. This is safe because the workflow does NOT
+  # check out or execute any PR-supplied code — it only reads
+  # `context.payload.pull_request.body` (already present in the event
+  # payload) and calls the GitHub REST API.
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -43,58 +50,66 @@ jobs:
               const findingId = `${sha7}.${idxStr}`;
               const marker = `<!-- f:${findingId} -->`;
 
-              core.info(`Looking for ${marker} in #${issueNumber} comments...`);
+              // Per-match try/catch: a missing/inaccessible target issue
+              // (or any other transient API error) must not abort sibling
+              // matches in the same PR body. Soft-warn and continue so
+              // the rest of the flips still happen.
+              try {
+                core.info(`Looking for ${marker} in #${issueNumber} comments...`);
 
-              const iterator = github.paginate.iterator(
-                github.rest.issues.listComments,
-                {
+                const iterator = github.paginate.iterator(
+                  github.rest.issues.listComments,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    per_page: 100,
+                  },
+                );
+
+                let hit = null;
+                for await (const { data: page } of iterator) {
+                  hit = page.find((c) => c.body && c.body.includes(marker));
+                  if (hit) break;
+                }
+
+                if (!hit) {
+                  core.warning(`Finding ${findingId} not found in #${issueNumber}. Skipping.`);
+                  continue;
+                }
+
+                // Locate the line containing the marker by string ops (no
+                // regex escaping needed). Markers are unique per finding ID,
+                // so a single substring search is sufficient.
+                const markerIdx = hit.body.indexOf(marker);
+                const lineStart = hit.body.lastIndexOf('\n', markerIdx) + 1;
+                const lineEndRaw = hit.body.indexOf('\n', markerIdx);
+                const lineEnd = lineEndRaw === -1 ? hit.body.length : lineEndRaw;
+                const line = hit.body.slice(lineStart, lineEnd);
+
+                if (line.startsWith('- [x] ')) {
+                  core.warning(`Finding ${findingId} already shipped. Skipping.`);
+                  continue;
+                }
+                if (!line.startsWith('- [ ] ')) {
+                  core.warning(`Marker ${marker} found but checklist line shape unexpected: ${line.slice(0, 40)}... Skipping.`);
+                  continue;
+                }
+
+                const newLine = line
+                  .replace('- [ ] ', '- [x] ')
+                  .replace(` ${marker}`, ` (shipped in #${prNumber}) ${marker}`);
+                const newBody = hit.body.slice(0, lineStart) + newLine + hit.body.slice(lineEnd);
+
+                await github.rest.issues.updateComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: issueNumber,
-                  per_page: 100,
-                },
-              );
+                  comment_id: hit.id,
+                  body: newBody,
+                });
 
-              let hit = null;
-              for await (const { data: page } of iterator) {
-                hit = page.find((c) => c.body && c.body.includes(marker));
-                if (hit) break;
+                core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
+              } catch (err) {
+                core.warning(`Failed to process finding ${findingId} in #${issueNumber}: ${err.message}. Continuing with remaining matches.`);
               }
-
-              if (!hit) {
-                core.warning(`Finding ${findingId} not found in #${issueNumber}. Skipping.`);
-                continue;
-              }
-
-              // Locate the line containing the marker by string ops (no
-              // regex escaping needed). Markers are unique per finding ID,
-              // so a single substring search is sufficient.
-              const markerIdx = hit.body.indexOf(marker);
-              const lineStart = hit.body.lastIndexOf('\n', markerIdx) + 1;
-              const lineEndRaw = hit.body.indexOf('\n', markerIdx);
-              const lineEnd = lineEndRaw === -1 ? hit.body.length : lineEndRaw;
-              const line = hit.body.slice(lineStart, lineEnd);
-
-              if (line.startsWith('- [x] ')) {
-                core.warning(`Finding ${findingId} already shipped. Skipping.`);
-                continue;
-              }
-              if (!line.startsWith('- [ ] ')) {
-                core.warning(`Marker ${marker} found but checklist line shape unexpected: ${line.slice(0, 40)}... Skipping.`);
-                continue;
-              }
-
-              const newLine = line
-                .replace('- [ ] ', '- [x] ')
-                .replace(` ${marker}`, ` (shipped in #${prNumber}) ${marker}`);
-              const newBody = hit.body.slice(0, lineStart) + newLine + hit.body.slice(lineEnd);
-
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: hit.id,
-                body: newBody,
-              });
-
-              core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
             }

--- a/docs/plans/2026-04-25-review-fix-skill.md
+++ b/docs/plans/2026-04-25-review-fix-skill.md
@@ -1,0 +1,811 @@
+# `review-fix` Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land a `review-fix` skill, a paired GitHub Action, and updated daily-review-bot prompt/README so findings on tracker issue `#87` get stable IDs, can be picked into worktree-isolated topic branches, and are auto-marked shipped on PR merge — without ever closing the rolling tracker.
+
+**Architecture:** Three independent units sharing one contract (the line `Refs #87 finding:<sha7>.<idx>` in PR bodies):
+
+1. **Bot prompt** emits findings as `- [ ] **[SEV]** \`path\` — title <!-- f:<sha7>.<idx> -->` checklist items in both sinks (rolling issue comment + immutable daily doc).
+2. **`review-fix` skill** (`.claude/skills/review-fix/SKILL.md`) takes a finding ID, locates the comment via `gh api`, creates a worktree + topic branch + plan file, then prints a hand-off instruction pointing at `superpowers:writing-plans`.
+3. **`review-fix-shipped` GitHub Action** triggers on `pull_request: closed && merged`, regexes the PR body for the magic line, and PATCHes the tracker comment to flip `[ ]` → `[x] (shipped in #PR)`. Issue stays open.
+
+A one-time `gh api` PATCH retrofits the existing `#87` comment to the new format.
+
+**Tech Stack:** Markdown (prompt, skill, README, plan), YAML (GitHub Actions workflow), Node-free shell + `gh` CLI for the migration. No library code touched.
+
+---
+
+## Chunk 1: Bot prompt + README
+
+### Task 1: Update bot prompt output format + persistence sink
+
+**Files:**
+- Modify: `docs/review-bot/PROMPT.md` (Output format section ~line 102, Persistence section ~line 130)
+
+- [ ] **Step 1.1: Read current prompt sections**
+
+Run:
+```bash
+sed -n '100,170p' docs/review-bot/PROMPT.md
+```
+
+Confirm the `# Output format` and `# Persistence (dual sink)` sections are present and untouched since spec was written.
+
+- [ ] **Step 1.2: Replace Output format section**
+
+In `docs/review-bot/PROMPT.md`, replace the existing `# Output format` section (the per-finding template + counts footer) with this verbatim block:
+
+````markdown
+# Output format
+
+Compute a stable ID per finding before writing: `<head-sha[:7]>.<idx>`,
+where `idx` is 1-based within this run, assigned **after** counter-arg
+pruning, in the priority order findings are written.
+
+Per finding (Markdown checklist item with embedded ID marker):
+
+```markdown
+- [ ] **[SEVERITY]** `path/to/file.ts:42` — short title <!-- f:<sha7>.<idx> -->
+  <details><summary>details</summary>
+
+  **Problem:** <one line>
+
+  **Why it matters:** <one line, concrete failure mode>
+
+  **Fix:**
+
+  ```diff
+  - bad
+  + good
+  ```
+
+  </details>
+```
+
+Rules:
+- The HTML comment marker `<!-- f:... -->` MUST be the last token on
+  the checklist line. Renderers hide it; the `review-fix-shipped`
+  Action keys off it.
+- Severity in bold + brackets: `**[BLOCKER]**`, `**[MAJOR]**`,
+  `**[MINOR]**`, `**[NIT]**`.
+- The short title is the first line of the original `Problem:`,
+  trimmed to ≤ 80 chars, no trailing period.
+
+End the comment with the run footer:
+
+- Reviewed range: `<last-sha>..<head-sha>` (`<N>` commits, `<M>` files)
+- Blockers: N
+- Majors: N
+- Minors: N
+- Nits: N
+- Counter-argument check: `<which finding tested, kept or dropped>`
+- Not reviewed: `<areas>`
+- Last reviewed SHA: `<head-sha>` ← persist for next run
+````
+
+- [ ] **Step 1.3: Update Persistence sink to use the checklist format**
+
+In `docs/review-bot/PROMPT.md`, replace the body example inside `## Sink 1: GitHub issue (rolling log)` with:
+
+```markdown
+- Append today's findings as a new comment, format:
+
+  ```
+  ## YYYY-MM-DD — <head-sha>
+  Reviewed: <last-sha>..<head-sha> (<N> commits)
+  Blockers: N | Majors: N | Minors: N | Nits: N
+
+  <checklist of findings, see Output format>
+
+  <run footer>
+  ```
+```
+
+Inside `## Sink 2: Daily review doc (committed)`, the body block is the same checklist + footer (no change to frontmatter). Add one explicit sentence after the frontmatter description:
+
+> The daily doc is an immutable snapshot of that run; the
+> `review-fix-shipped` Action edits the rolling issue comment only,
+> never the daily doc.
+
+- [ ] **Step 1.4: Visual diff check**
+
+Run:
+```bash
+git diff docs/review-bot/PROMPT.md
+```
+
+Confirm only the Output format and Persistence sections changed; nothing in `# Role`, `# Scope this run`, `# Priorities`, `# Repo invariants`, `# Process gates`, `# Rules` was touched.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add docs/review-bot/PROMPT.md
+git commit -m "docs(review-bot): emit findings as checklist items with stable IDs
+
+Each finding now renders as a Markdown task-list item with an
+embedded <!-- f:<sha7>.<idx> --> marker. The marker is what the
+review-fix-shipped Action keys off to flip [ ] -> [x] when the
+fixing PR merges. Both sinks (rolling issue comment, daily doc)
+emit the same shape.
+
+Refs #87"
+```
+
+---
+
+### Task 2: Update review-bot README with ingestion docs
+
+**Files:**
+- Modify: `docs/review-bot/README.md` (insert "Ingesting findings" section + new setup-checklist row)
+
+- [ ] **Step 2.1: Add "Ingesting findings via review-fix" section**
+
+In `docs/review-bot/README.md`, immediately after the `## Output sinks` section and before `## CI behavior on the daily PR`, insert:
+
+````markdown
+## Ingesting findings via `review-fix`
+
+The `.claude/skills/review-fix/SKILL.md` skill turns one finding into
+a worktree-isolated topic branch + plan, ready for
+`superpowers:writing-plans` → `superpowers:executing-plans`.
+
+### Finding ID
+
+Each finding the bot writes carries a stable ID
+`<head-sha[:7]>.<idx>`, embedded as an HTML comment on its checklist
+line. `head-sha[:7]` is the seven-char prefix of the head SHA
+reviewed in that run; `idx` is the 1-based position of the finding
+within the run.
+
+IDs do not deduplicate across reruns: tomorrow's run on a new SHA
+emits a fresh set of IDs even for findings that were already
+unshipped. The unshipped checkbox on the prior comment still flips
+when the eventual PR ships.
+
+### Workflow
+
+```text
+gh issue view 87 --comments       # find a finding ID
+/review-fix pick <id>             # creates worktree + plan
+/superpowers:writing-plans <plan> # expand plan into chunked tasks
+/superpowers:executing-plans …    # implement, verify, open PR
+```
+
+The PR body MUST contain, on its own line:
+
+```
+Refs #87 finding:<sha7>.<idx>
+```
+
+Trailing whitespace is tolerated; trailing punctuation breaks the
+match. The PR body MUST NOT contain `Closes #87` / `Fixes #87` —
+the tracker is long-lived and stays open.
+
+### Auto-flip on merge
+
+`.github/workflows/review-fix-shipped.yml` triggers on
+`pull_request: closed && merged`, regexes the PR body for the magic
+line, locates the matching tracker comment, and edits the body so
+the checklist item becomes:
+
+```markdown
+- [x] **[BLOCKER]** `path/to/file.ts:42` — short title (shipped in #N) <!-- f:<sha7>.<idx> -->
+```
+
+The Action does not block merges; it observes them. If the magic
+line is missing, it logs and exits 0.
+````
+
+- [ ] **Step 2.2: Add setup-checklist row for the new workflow**
+
+In the `## Initial setup checklist (one-time)` section of the same file, append a new bullet at the end of the list:
+
+```markdown
+- [ ] Confirm the `review-fix-shipped` workflow file is present on
+      `develop` (`.github/workflows/review-fix-shipped.yml`). It needs
+      no extra setup; the default `GITHUB_TOKEN` has the required
+      `issues:write` scope.
+```
+
+- [ ] **Step 2.3: Visual diff check**
+
+Run:
+```bash
+git diff docs/review-bot/README.md
+```
+
+Confirm only the two insertions above; no other edits.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add docs/review-bot/README.md
+git commit -m "docs(review-bot): document review-fix ingestion + auto-flip
+
+Adds an 'Ingesting findings' section explaining the finding-ID
+format, the magic 'Refs #87 finding:<id>' PR-body line, and the
+auto-flip workflow. Also adds the new setup-checklist entry for
+the review-fix-shipped workflow.
+
+Refs #87"
+```
+
+---
+
+## Chunk 2: `review-fix` skill file
+
+### Task 3: Author `.claude/skills/review-fix/SKILL.md`
+
+**Files:**
+- Create: `.claude/skills/review-fix/SKILL.md`
+
+This is a static instruction file, not executable code. There is no
+test suite for skill markdown beyond visual review and a smoke run.
+The plan-reviewer treats markdown content as the source of truth.
+
+- [ ] **Step 3.1: Verify the skills directory layout matches existing precedents**
+
+Run:
+```bash
+ls .claude/skills/
+```
+
+Expected: directories `new-changeset`, `scaffold-agent-skill`, `verify` (each containing a `SKILL.md`).
+
+If the layout differs, stop and reconcile before continuing.
+
+- [ ] **Step 3.2: Create the skill directory and file**
+
+Run:
+```bash
+mkdir -p .claude/skills/review-fix
+```
+
+Then write `.claude/skills/review-fix/SKILL.md` with this content
+verbatim:
+
+````markdown
+---
+name: review-fix
+description: Ingests a single finding from the rolling daily-code-review tracker issue (`#87 Daily code review — develop`) and produces a worktree-isolated topic branch + implementation plan. Use when the user says "fix review finding <id>", "pick a finding", "/review-fix <id>", or names a finding-ID like `682b557.3`. Does NOT close the tracker issue — the tracker is append-only and the auto-flip workflow handles shipped state.
+---
+
+# review-fix — turn one tracker finding into a worktree + plan
+
+## Terminology
+
+- **Tracker issue** — `#87 Daily code review — develop`. Long-lived,
+  one comment per scheduled bot run, body holds the canonical
+  `Last reviewed SHA`. **Never closed by this skill.**
+- **Finding** — one `[BLOCKER] / [MAJOR] / [MINOR] / [NIT]` checklist
+  item inside a bot comment.
+- **Finding ID** — `<head-sha[:7]>.<idx>` (e.g. `682b557.3`). Embedded
+  as an HTML comment on each finding's checklist line.
+- **Magic line** — `Refs #87 finding:<id>` in a PR body. The
+  contract between this skill's output and the
+  `review-fix-shipped` Action.
+
+## Before you start
+
+Confirm with the user:
+
+1. **Finding ID** — exact form `<sha7>.<idx>`. If they paste a free-text
+   description instead, refuse and ask them to grab the ID from
+   `gh issue view 87 --comments`.
+2. **Already shipped?** — if the tracker line for that ID renders
+   `- [x]`, refuse and tell them which PR shipped it (the comment line
+   carries `(shipped in #N)`).
+3. **Worktree clear?** — if `.worktrees/fix-review-<slug>` already
+   exists, refuse with the existing path. Either remove it
+   (`git worktree remove`) or pick a different finding.
+
+## Steps
+
+### 1. Locate the finding
+
+```bash
+# Stream comments until one matches the marker.
+gh api "/repos/{owner}/{repo}/issues/87/comments" --paginate \
+  --jq '.[] | select(.body | contains("<!-- f:<sha7>.<idx> -->")) | {id, body}'
+```
+
+If no match: hard-fail with `Finding <id> not found in #87 comments`.
+
+### 2. Extract finding fields
+
+From the matched comment body, locate the line ending with
+`<!-- f:<sha7>.<idx> -->`. Pull:
+
+- **Severity** — the `**[…]**` token (`BLOCKER` / `MAJOR` / `MINOR` /
+  `NIT`).
+- **Path** — the backtick-quoted path immediately after.
+- **Title** — the text between `— ` and the HTML comment.
+- **Body** — the contents of the `<details>` block on the lines below.
+
+If the line shows `- [x]` instead of `- [ ]`: hard-fail
+`Finding <id> already shipped in #<PR>`.
+
+### 3. Compute slug + paths
+
+```text
+slug          = kebab(severity-lowercased + first 4 words of title), trim ≤ 50 chars
+worktree-dir  = .worktrees/fix-review-<slug>
+branch        = fix/review-bot-<slug>
+plan-path     = docs/plans/YYYY-MM-DD-review-bot-<slug>.md   (UTC date)
+```
+
+Example for `682b557.1` (`[BLOCKER]` `LlmProviderPort.ts` interface→type sweep):
+
+```text
+slug          = blocker-llmproviderport-interface-to-type
+worktree-dir  = .worktrees/fix-review-blocker-llmproviderport-interface-to-type
+branch        = fix/review-bot-blocker-llmproviderport-interface-to-type
+plan-path     = docs/plans/2026-04-25-review-bot-blocker-llmproviderport-interface-to-type.md
+```
+
+### 4. Create the worktree + branch
+
+```bash
+git fetch origin develop
+git worktree add <worktree-dir> -b <branch> origin/develop
+cd <worktree-dir>
+npm install
+```
+
+If `git worktree add` fails because the branch already exists (e.g.
+prior aborted run), surface the error verbatim — do **not** retry
+with `-B` (force) since that would silently rewind work.
+
+### 5. Write the plan file
+
+Create `<worktree-dir>/<plan-path>` with frontmatter + finding-quoted
+body. The `tracker` value MUST be quoted — `#` opens a YAML comment.
+
+```markdown
+---
+date: YYYY-MM-DD
+slug: review-bot-<slug>
+finding-id: <sha7>.<idx>
+tracker: '#87'
+severity: <BLOCKER|MAJOR|MINOR|NIT>
+---
+
+# Fix review finding `<id>` — <title>
+
+## Source
+
+From `#87` comment <comment-id>, finding `<id>`:
+
+> **[<SEVERITY>]** `<path>` — <title>
+>
+> <quoted body, including diff blocks, verbatim>
+
+## Acceptance
+
+- Apply the bot's proposed fix (see body above).
+- Add or update tests covering the new code paths.
+- `npm run verify` passes locally.
+- Codex review on the PR is acknowledged or rebutted on each thread.
+
+## Rollout
+
+- Branch: `fix/review-bot-<slug>` (already cut by review-fix skill).
+- PR base: `develop`.
+- PR body MUST contain on its own line: `Refs #87 finding:<id>`.
+- PR body MUST NOT contain `Closes #87` / `Fixes #87`.
+- Changeset required if behavior changes (`npm run changeset`).
+```
+
+### 6. Hand off
+
+Print exactly:
+
+```text
+Plan written to <plan-path> on branch <branch> in <worktree-dir>.
+Next: cd <worktree-dir> && /superpowers:writing-plans <plan-path>
+```
+
+**Do not** invoke `superpowers:writing-plans` automatically. The user
+runs it after reviewing the plan.
+
+## Do not
+
+- Do NOT open the PR. PR creation belongs to the implementation
+  session, not the plan session.
+- Do NOT close the tracker issue. Do NOT add `Closes #87` / `Fixes #87`
+  anywhere.
+- Do NOT edit the tracker comment from the skill — only the
+  `review-fix-shipped` Action edits comments, and only post-merge.
+- Do NOT batch findings. One finding = one branch = one PR.
+- Do NOT use `git worktree add -B` (force). Surface conflicts to the
+  user.
+````
+
+- [ ] **Step 3.3: Visual review of the skill file**
+
+Run:
+```bash
+sed -n '1,30p' .claude/skills/review-fix/SKILL.md
+```
+
+Confirm:
+- Frontmatter has `name` and `description` keys only.
+- The description starts with "Ingests" and includes trigger phrases.
+- The terminology + steps render in order.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add .claude/skills/review-fix/SKILL.md
+git commit -m "feat(skills): add review-fix skill for tracker findings
+
+Single-mode skill (pick <finding-id>) that locates a finding in
+the rolling tracker issue (#87), creates a worktree + topic
+branch + plan file, then prints a hand-off instruction pointing
+at superpowers:writing-plans. The skill does not open the PR
+and does not edit the tracker comment.
+
+Refs #87"
+```
+
+---
+
+## Chunk 3: GitHub Action — auto-flip on merge
+
+### Task 4: Add `.github/workflows/review-fix-shipped.yml`
+
+**Files:**
+- Create: `.github/workflows/review-fix-shipped.yml`
+
+The Action's body-rewrite logic is the only piece in this plan with
+real code. We use `actions/github-script` so the regex + comment
+PATCH stays inline (no extra runtime dep). `actionlint` is already
+wired into `ci.yml` (line 113), so YAML correctness is enforced.
+
+- [ ] **Step 4.1: Sanity-check the existing workflow neighbour**
+
+Run:
+```bash
+ls .github/workflows/
+```
+
+Confirm `ci.yml` is present (so the trigger model + Node/runner
+versions match precedent).
+
+- [ ] **Step 4.2: Write the workflow file**
+
+Create `.github/workflows/review-fix-shipped.yml` with this content
+verbatim:
+
+```yaml
+name: review-fix-shipped
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  flip-tracker-checkbox:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flip tracker checkbox(es) for shipped finding(s)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const re = /^Refs #(\d+) finding:([0-9a-f]{7})\.(\d+)\s*$/gm;
+            const matches = [...body.matchAll(re)];
+
+            if (matches.length === 0) {
+              core.info('No "Refs #<n> finding:<sha7>.<idx>" line in PR body. Nothing to flip.');
+              return;
+            }
+
+            const prNumber = context.payload.pull_request.number;
+
+            for (const m of matches) {
+              const [, issueStr, sha7, idxStr] = m;
+              const issueNumber = Number(issueStr);
+              const findingId = `${sha7}.${idxStr}`;
+              const marker = `<!-- f:${findingId} -->`;
+
+              core.info(`Looking for ${marker} in #${issueNumber} comments...`);
+
+              const iterator = github.paginate.iterator(
+                github.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100,
+                },
+              );
+
+              let hit = null;
+              for await (const { data: page } of iterator) {
+                hit = page.find((c) => c.body && c.body.includes(marker));
+                if (hit) break;
+              }
+
+              if (!hit) {
+                core.warning(`Finding ${findingId} not found in #${issueNumber}. Skipping.`);
+                continue;
+              }
+
+              const lineRe = new RegExp(
+                `^- \\[ \\] (.+?) ${marker.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}$`,
+                'm',
+              );
+              const lineMatch = hit.body.match(lineRe);
+
+              if (!lineMatch) {
+                if (hit.body.includes(`- [x]`) && hit.body.includes(marker)) {
+                  core.warning(`Finding ${findingId} already shipped. Skipping.`);
+                } else {
+                  core.warning(`Marker ${marker} found but checklist line shape unexpected. Skipping.`);
+                }
+                continue;
+              }
+
+              const newLine =
+                `- [x] ${lineMatch[1]} (shipped in #${prNumber}) ${marker}`;
+              const newBody = hit.body.replace(lineMatch[0], newLine);
+
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: hit.id,
+                body: newBody,
+              });
+
+              core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
+            }
+```
+
+- [ ] **Step 4.3: Run actionlint locally**
+
+`actionlint` is what `ci.yml` runs via `reviewdog/action-actionlint`.
+Run the binary directly (most contributors have it installed via
+their PATH; if not, install with `go install
+github.com/rhysd/actionlint/cmd/actionlint@latest`):
+
+```bash
+actionlint .github/workflows/review-fix-shipped.yml
+```
+
+Expected: no output, exit code 0.
+
+If `actionlint` is unavailable locally, push a temporary commit on
+the topic branch and let CI's `actionlint` job report. Do not
+proceed past PR until the job is green.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add .github/workflows/review-fix-shipped.yml
+git commit -m "ci: add review-fix-shipped auto-flip workflow
+
+On merged PRs, regexes the body for 'Refs #<n> finding:<id>' lines
+and PATCHes the matching tracker comment so the checklist item
+flips from [ ] to [x] with a (shipped in #PR) annotation. Issue
+stays open. No-ops cleanly when the marker is missing or the
+finding is already shipped.
+
+Refs #87"
+```
+
+---
+
+## Chunk 4: One-time tracker comment migration
+
+### Task 5: Retrofit existing `#87` comment to new format
+
+**Files:**
+- None in repo. The migration edits a single GitHub comment via the
+  `gh` CLI.
+
+The latest comment (authored by the bot on 2026-04-25) carries two
+findings. We assign synthetic IDs `682b557.1` (BLOCKER, interface→type)
+and `682b557.2` (MINOR, MockLlmProvider eager validation).
+
+This step runs once. It is **part of the PR that lands this plan** so
+reviewers can see the before/after on the rendered comment.
+
+- [ ] **Step 5.1: Snapshot the current comment body**
+
+```bash
+gh api "/repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/issues/87/comments" \
+  --paginate --jq '.[-1] | {id, body}' \
+  > /tmp/issue87-last-comment.json
+```
+
+Open `/tmp/issue87-last-comment.json` and confirm the body matches the
+findings the spec calls out (BLOCKER `interface`/`type`; MINOR
+`pickScript`).
+
+- [ ] **Step 5.2: Hand-write the migrated body**
+
+In a scratch file `/tmp/issue87-new-body.md`, paste the original
+header (`## YYYY-MM-DD — <head-sha>` + `Reviewed:` + counts), then
+rewrite the two findings as checklist items:
+
+```markdown
+- [ ] **[BLOCKER]** `src/ports/LlmProviderPort.ts` — interface→type sweep across 16 declarations <!-- f:682b557.1 -->
+  <details><summary>details</summary>
+
+  <original BLOCKER body, verbatim, including the "Counter-argument to my own [BLOCKER]" paragraph>
+
+  </details>
+
+- [ ] **[MINOR]** `src/ports/MockLlmProvider.ts:155` — pickScript silently accepts scripts with no match predicate in match-or-error mode <!-- f:682b557.2 -->
+  <details><summary>details</summary>
+
+  <original MINOR body, verbatim>
+
+  </details>
+```
+
+Then re-append the original footer (Reviewed range / counts /
+Counter-argument check / Not reviewed / Last reviewed SHA).
+
+- [ ] **Step 5.3: PATCH the comment**
+
+Extract the comment ID from `/tmp/issue87-last-comment.json` (`.id`
+field), then:
+
+```bash
+COMMENT_ID=$(jq -r .id /tmp/issue87-last-comment.json)
+gh api --method PATCH \
+  "/repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/issues/comments/${COMMENT_ID}" \
+  --field body=@/tmp/issue87-new-body.md
+```
+
+Expected: 200 OK with the new body echoed.
+
+- [ ] **Step 5.4: Visually verify the rendered comment**
+
+Open the issue page in a browser:
+```bash
+gh issue view 87 --web
+```
+
+Confirm:
+- Two checkbox items render at the top of the latest comment.
+- Severity tags `[BLOCKER]` and `[MINOR]` are bold.
+- The HTML markers `<!-- f:682b557.1 -->` / `<!-- f:682b557.2 -->`
+  do **not** render as visible text.
+- Each `<details>` block is collapsible and contains the original
+  finding body unchanged.
+- The run footer (counts, Last reviewed SHA) is preserved at the
+  bottom.
+
+- [ ] **Step 5.5: Record migration in the PR description**
+
+Note in the eventual PR body (under a `## Migration` section): which
+comment ID was edited, and the synthetic IDs assigned. Reviewers can
+diff against the snapshot at `/tmp/issue87-last-comment.json` if they
+want to verify nothing was dropped.
+
+This step has no commit (the change is on GitHub, not in the repo).
+
+---
+
+## Chunk 5: Verify and open PR
+
+### Task 6: Pre-PR gate + open PR
+
+**Files:**
+- None new — runs the standard verify pipeline.
+
+- [ ] **Step 6.1: Confirm clean working tree**
+
+```bash
+git status
+```
+
+Expected: nothing to commit, working tree clean. The four commits
+on the branch are:
+1. `docs(review-bot): emit findings as checklist items with stable IDs`
+2. `docs(review-bot): document review-fix ingestion + auto-flip`
+3. `feat(skills): add review-fix skill for tracker findings`
+4. `ci: add review-fix-shipped auto-flip workflow`
+
+(Plus the two earlier spec commits already on the branch.)
+
+- [ ] **Step 6.2: Run the pre-PR gate**
+
+```bash
+npm run verify
+```
+
+This runs `format:check && lint && typecheck && test && build`. None
+of the changes in this plan touch `src/`, `tests/`, or `examples/`,
+so all stages should be no-op fast. If any stage fails on an
+unrelated change inherited from `develop`, surface it — do **not**
+band-aid with `--no-verify`.
+
+Expected: green across all five stages.
+
+- [ ] **Step 6.3: Push the branch**
+
+```bash
+git push -u origin feat/review-fix-skill
+```
+
+- [ ] **Step 6.4: Open the PR**
+
+```bash
+gh pr create --base develop \
+  --title "feat: review-fix skill + auto-flip workflow" \
+  --body "$(cat <<'EOF'
+## Summary
+- New `.claude/skills/review-fix/SKILL.md` skill: turns one tracker finding into a worktree-isolated topic branch + plan, then hands off to `superpowers:writing-plans`.
+- New `.github/workflows/review-fix-shipped.yml` workflow: on merged PRs, regexes the body for `Refs #<n> finding:<sha7>.<idx>` and flips the matching tracker checkbox to `[x] (shipped in #PR)`. Issue stays open.
+- Updated `docs/review-bot/PROMPT.md` so each finding emits as a Markdown checklist item with embedded `<!-- f:<sha7>.<idx> -->` ID marker. Both sinks share the format; only the rolling issue comment gets flipped.
+- Updated `docs/review-bot/README.md` with an "Ingesting findings" section and a setup-checklist row.
+- One-time migration of issue #87's latest comment to the new format (synthetic IDs `682b557.1`, `682b557.2`).
+
+## Migration
+- Edited comment ID: \`<COMMENT_ID>\` on issue #87.
+- Synthetic IDs assigned: `682b557.1` (BLOCKER, interface→type sweep), `682b557.2` (MINOR, MockLlmProvider eager validation).
+- Pre-edit snapshot kept at \`/tmp/issue87-last-comment.json\` on the author's machine; reviewers can request it for diffing.
+
+## Test plan
+- [ ] `npm run verify` green (doc-only diff outside `.github/` so most stages are no-ops; `actionlint` enforces the workflow YAML).
+- [ ] Skill smoke test: `gh issue view 87 --comments` resolves a finding ID; running the skill creates the worktree + plan without errors.
+- [ ] Action dry-run: a follow-up PR that fixes finding `682b557.2` triggers the workflow on merge and flips the checkbox in #87.
+- [ ] Visual check on the migrated comment: checklists render, markers hidden, details collapsible.
+
+Refs #87
+EOF
+)"
+```
+
+**Critical:** the PR body contains `Refs #87` (intentional, for cross-linking) and **does not** contain `Closes #87` or `Fixes #87`. The tracker stays open.
+
+- [ ] **Step 6.5: Wait for Codex review**
+
+Per project memory `feedback_pr_workflow.md`, leave the PR for Codex
+to comment, then sweep its threads. Address each before the owner
+merges.
+
+- [ ] **Step 6.6: Post-merge cleanup**
+
+After the owner merges:
+
+```bash
+git switch develop
+git pull origin develop
+git worktree remove .worktrees/feat-review-fix-skill
+git branch -d feat/review-fix-skill
+git fetch --prune origin
+```
+
+This step has no commit; it just resets local state per CLAUDE.md.
+
+---
+
+## Smoke test (post-merge, optional but recommended)
+
+After this PR lands, validate the full loop end-to-end on the lowest-risk
+finding (`682b557.2`, MINOR `MockLlmProvider` eager validation):
+
+1. From a fresh shell on `develop`: `/review-fix pick 682b557.2` →
+   confirm worktree + plan appear.
+2. Run `/superpowers:writing-plans` on the new plan.
+3. Implement + verify + open the fix PR with body containing
+   `Refs #87 finding:682b557.2`.
+4. Owner merges.
+5. Within a minute, the `review-fix-shipped` Action job appears under
+   "Checks" → "review-fix-shipped" with status success.
+6. Reload issue #87 — the MINOR checkbox now shows `- [x] ... (shipped in #<N>)`.
+
+If any of those six steps fails, file the failure mode against this
+plan. The skill + workflow are not "shipped" until the smoke test
+goes green.

--- a/docs/plans/2026-04-25-review-fix-skill.md
+++ b/docs/plans/2026-04-25-review-fix-skill.md
@@ -514,7 +514,14 @@ verbatim:
 name: review-fix-shipped
 
 on:
-  pull_request:
+  # `pull_request_target` runs in the base-repo context with a write-
+  # capable GITHUB_TOKEN. We need that to PATCH the tracker comment on
+  # merges from fork PRs, where the standard `pull_request` event fires
+  # with a read-only token. This is safe because the workflow does NOT
+  # check out or execute any PR-supplied code — it only reads
+  # `context.payload.pull_request.body` (already present in the event
+  # payload) and calls the GitHub REST API.
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -556,60 +563,68 @@ jobs:
               const findingId = `${sha7}.${idxStr}`;
               const marker = `<!-- f:${findingId} -->`;
 
-              core.info(`Looking for ${marker} in #${issueNumber} comments...`);
+              // Per-match try/catch: a missing/inaccessible target issue
+              // (or any other transient API error) must not abort sibling
+              // matches in the same PR body. Soft-warn and continue so
+              // the rest of the flips still happen.
+              try {
+                core.info(`Looking for ${marker} in #${issueNumber} comments...`);
 
-              const iterator = github.paginate.iterator(
-                github.rest.issues.listComments,
-                {
+                const iterator = github.paginate.iterator(
+                  github.rest.issues.listComments,
+                  {
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    per_page: 100,
+                  },
+                );
+
+                let hit = null;
+                for await (const { data: page } of iterator) {
+                  hit = page.find((c) => c.body && c.body.includes(marker));
+                  if (hit) break;
+                }
+
+                if (!hit) {
+                  core.warning(`Finding ${findingId} not found in #${issueNumber}. Skipping.`);
+                  continue;
+                }
+
+                // Locate the line containing the marker by string ops (no
+                // regex escaping needed). Markers are unique per finding ID,
+                // so a single substring search is sufficient.
+                const markerIdx = hit.body.indexOf(marker);
+                const lineStart = hit.body.lastIndexOf('\n', markerIdx) + 1;
+                const lineEndRaw = hit.body.indexOf('\n', markerIdx);
+                const lineEnd = lineEndRaw === -1 ? hit.body.length : lineEndRaw;
+                const line = hit.body.slice(lineStart, lineEnd);
+
+                if (line.startsWith('- [x] ')) {
+                  core.warning(`Finding ${findingId} already shipped. Skipping.`);
+                  continue;
+                }
+                if (!line.startsWith('- [ ] ')) {
+                  core.warning(`Marker ${marker} found but checklist line shape unexpected: ${line.slice(0, 40)}... Skipping.`);
+                  continue;
+                }
+
+                const newLine = line
+                  .replace('- [ ] ', '- [x] ')
+                  .replace(` ${marker}`, ` (shipped in #${prNumber}) ${marker}`);
+                const newBody = hit.body.slice(0, lineStart) + newLine + hit.body.slice(lineEnd);
+
+                await github.rest.issues.updateComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: issueNumber,
-                  per_page: 100,
-                },
-              );
+                  comment_id: hit.id,
+                  body: newBody,
+                });
 
-              let hit = null;
-              for await (const { data: page } of iterator) {
-                hit = page.find((c) => c.body && c.body.includes(marker));
-                if (hit) break;
+                core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
+              } catch (err) {
+                core.warning(`Failed to process finding ${findingId} in #${issueNumber}: ${err.message}. Continuing with remaining matches.`);
               }
-
-              if (!hit) {
-                core.warning(`Finding ${findingId} not found in #${issueNumber}. Skipping.`);
-                continue;
-              }
-
-              // Locate the line containing the marker by string ops (no
-              // regex escaping needed). Markers are unique per finding ID,
-              // so a single substring search is sufficient.
-              const markerIdx = hit.body.indexOf(marker);
-              const lineStart = hit.body.lastIndexOf('\n', markerIdx) + 1;
-              const lineEndRaw = hit.body.indexOf('\n', markerIdx);
-              const lineEnd = lineEndRaw === -1 ? hit.body.length : lineEndRaw;
-              const line = hit.body.slice(lineStart, lineEnd);
-
-              if (line.startsWith('- [x] ')) {
-                core.warning(`Finding ${findingId} already shipped. Skipping.`);
-                continue;
-              }
-              if (!line.startsWith('- [ ] ')) {
-                core.warning(`Marker ${marker} found but checklist line shape unexpected: ${line.slice(0, 40)}... Skipping.`);
-                continue;
-              }
-
-              const newLine = line
-                .replace('- [ ] ', '- [x] ')
-                .replace(` ${marker}`, ` (shipped in #${prNumber}) ${marker}`);
-              const newBody = hit.body.slice(0, lineStart) + newLine + hit.body.slice(lineEnd);
-
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: hit.id,
-                body: newBody,
-              });
-
-              core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
             }
 ```
 

--- a/docs/plans/2026-04-25-review-fix-skill.md
+++ b/docs/plans/2026-04-25-review-fix-skill.md
@@ -16,6 +16,33 @@ A one-time `gh api` PATCH retrofits the existing `#87` comment to the new format
 
 ---
 
+## Preconditions (run once before any chunk)
+
+- [ ] **P1: Confirm working directory and branch.**
+
+```bash
+pwd                # expect: .../.worktrees/feat-review-fix-skill
+git rev-parse --abbrev-ref HEAD  # expect: feat/review-fix-skill
+git log --oneline -3
+# expect the two prior spec commits at the top:
+#   docs(specs): address spec-reviewer recommendations
+#   docs(specs): review-fix skill design
+```
+
+If any check fails, stop. The plan must run inside the worktree on
+the topic branch, not on `develop` directly.
+
+- [ ] **P2: Confirm tools available.**
+
+```bash
+gh --version           # gh CLI present (used in Tasks 5 + 6)
+jq --version           # jq present (used in Task 5)
+node --version         # for the workflow's `actions/github-script` semantics during local mental-checks
+actionlint --version   # optional locally; required green via CI
+```
+
+---
+
 ## Chunk 1: Bot prompt + README
 
 ### Task 1: Update bot prompt output format + persistence sink
@@ -304,13 +331,18 @@ Confirm with the user:
 
 ### 1. Locate the finding
 
+Substitute the user-provided finding ID (e.g. `682b557.3`) for `${ID}`
+below before running:
+
 ```bash
-# Stream comments until one matches the marker.
-gh api "/repos/{owner}/{repo}/issues/87/comments" --paginate \
-  --jq '.[] | select(.body | contains("<!-- f:<sha7>.<idx> -->")) | {id, body}'
+ID="<sha7>.<idx>"            # e.g. 682b557.3
+MARKER="<!-- f:${ID} -->"
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+gh api "/repos/${REPO}/issues/87/comments" --paginate \
+  --jq ".[] | select(.body | contains(\"${MARKER}\")) | {id, body}"
 ```
 
-If no match: hard-fail with `Finding <id> not found in #87 comments`.
+If no match: hard-fail with `Finding ${ID} not found in #87 comments`.
 
 ### 2. Extract finding fields
 
@@ -489,6 +521,10 @@ permissions:
   issues: write
   pull-requests: read
 
+concurrency:
+  group: review-fix-shipped-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   flip-tracker-checkbox:
     if: github.event.pull_request.merged == true
@@ -538,24 +574,28 @@ jobs:
                 continue;
               }
 
-              const lineRe = new RegExp(
-                `^- \\[ \\] (.+?) ${marker.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}$`,
-                'm',
-              );
-              const lineMatch = hit.body.match(lineRe);
+              // Locate the line containing the marker by string ops (no
+              // regex escaping needed). Markers are unique per finding ID,
+              // so a single substring search is sufficient.
+              const markerIdx = hit.body.indexOf(marker);
+              const lineStart = hit.body.lastIndexOf('\n', markerIdx) + 1;
+              const lineEndRaw = hit.body.indexOf('\n', markerIdx);
+              const lineEnd = lineEndRaw === -1 ? hit.body.length : lineEndRaw;
+              const line = hit.body.slice(lineStart, lineEnd);
 
-              if (!lineMatch) {
-                if (hit.body.includes(`- [x]`) && hit.body.includes(marker)) {
-                  core.warning(`Finding ${findingId} already shipped. Skipping.`);
-                } else {
-                  core.warning(`Marker ${marker} found but checklist line shape unexpected. Skipping.`);
-                }
+              if (line.startsWith('- [x] ')) {
+                core.warning(`Finding ${findingId} already shipped. Skipping.`);
+                continue;
+              }
+              if (!line.startsWith('- [ ] ')) {
+                core.warning(`Marker ${marker} found but checklist line shape unexpected: ${line.slice(0, 40)}... Skipping.`);
                 continue;
               }
 
-              const newLine =
-                `- [x] ${lineMatch[1]} (shipped in #${prNumber}) ${marker}`;
-              const newBody = hit.body.replace(lineMatch[0], newLine);
+              const newLine = line
+                .replace('- [ ] ', '- [x] ')
+                .replace(` ${marker}`, ` (shipped in #${prNumber}) ${marker}`);
+              const newBody = hit.body.slice(0, lineStart) + newLine + hit.body.slice(lineEnd);
 
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
@@ -631,6 +671,12 @@ findings the spec calls out (BLOCKER `interface`/`type`; MINOR
 
 - [ ] **Step 5.2: Hand-write the migrated body**
 
+Open `/tmp/issue87-last-comment.json`. Copy the `body` field
+verbatim. Each `<details>` block below MUST contain the bot's
+finding body byte-for-byte — no paraphrasing, no reflowing, no
+cosmetic edits. The point of the migration is structural (add
+checklist + ID markers) only; content stays as the bot wrote it.
+
 In a scratch file `/tmp/issue87-new-body.md`, paste the original
 header (`## YYYY-MM-DD — <head-sha>` + `Reviewed:` + counts), then
 rewrite the two findings as checklist items:
@@ -657,13 +703,18 @@ Counter-argument check / Not reviewed / Last reviewed SHA).
 - [ ] **Step 5.3: PATCH the comment**
 
 Extract the comment ID from `/tmp/issue87-last-comment.json` (`.id`
-field), then:
+field). `gh api --field body=@file` is unreliable across `gh` versions
+for free-form Markdown bodies (newlines, backticks, dollar signs);
+build the JSON payload explicitly via `jq`:
 
 ```bash
 COMMENT_ID=$(jq -r .id /tmp/issue87-last-comment.json)
-gh api --method PATCH \
-  "/repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/issues/comments/${COMMENT_ID}" \
-  --field body=@/tmp/issue87-new-body.md
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+
+jq -Rs '{body: .}' < /tmp/issue87-new-body.md \
+  | gh api --method PATCH \
+      "/repos/${REPO}/issues/comments/${COMMENT_ID}" \
+      --input -
 ```
 
 Expected: 200 OK with the new body echoed.
@@ -767,7 +818,10 @@ EOF
 )"
 ```
 
-**Critical:** the PR body contains `Refs #87` (intentional, for cross-linking) and **does not** contain `Closes #87` or `Fixes #87`. The tracker stays open.
+**Critical:**
+- The PR body contains `Refs #87` (intentional, for cross-linking) and **does not** contain `Closes #87` or `Fixes #87`. The tracker stays open.
+- The placeholders `\`<COMMENT_ID>\`` inside the PR body heredoc are NOT literals — substitute the actual edited comment ID (from `/tmp/issue87-last-comment.json`) before running `gh pr create`.
+- The magic line `Refs #87 finding:<id>` belongs in the **PR body only**, not in commit messages. The Action reads `pull_request.body`, not commit messages, so a misplaced line will silently fail to flip.
 
 - [ ] **Step 6.5: Wait for Codex review**
 

--- a/docs/plans/2026-04-25-review-fix-skill.md
+++ b/docs/plans/2026-04-25-review-fix-skill.md
@@ -539,7 +539,13 @@ concurrency:
 
 jobs:
   flip-tracker-checkbox:
-    if: github.event.pull_request.merged == true
+    # Only fire on PRs merged INTO develop. The tracker (#87
+    # "Daily code review — develop") is explicitly scoped to that
+    # branch. A hotfix-to-main or demo-promotion PR carrying a copied
+    # `Refs #87 finding:<id>` line would otherwise flip the tracker
+    # even though the fix never landed on develop, creating a false
+    # shipped state.
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
     runs-on: ubuntu-latest
     steps:
       - name: Flip tracker checkbox(es) for shipped finding(s)

--- a/docs/plans/2026-04-25-review-fix-skill.md
+++ b/docs/plans/2026-04-25-review-fix-skill.md
@@ -557,16 +557,19 @@ jobs:
 
             const prNumber = context.payload.pull_request.number;
 
+            // Track write-side failures separately so the run fails at the
+            // end if any flip could not be persisted. Read-side failures
+            // (listComments 404, etc.) stay soft — a finding pointing at
+            // a non-existent issue is a content bug in the PR body, not
+            // a problem with the automation.
+            let writeFailures = 0;
+
             for (const m of matches) {
               const [, issueStr, sha7, idxStr] = m;
               const issueNumber = Number(issueStr);
               const findingId = `${sha7}.${idxStr}`;
               const marker = `<!-- f:${findingId} -->`;
 
-              // Per-match try/catch: a missing/inaccessible target issue
-              // (or any other transient API error) must not abort sibling
-              // matches in the same PR body. Soft-warn and continue so
-              // the rest of the flips still happen.
               try {
                 core.info(`Looking for ${marker} in #${issueNumber} comments...`);
 
@@ -614,17 +617,28 @@ jobs:
                   .replace(` ${marker}`, ` (shipped in #${prNumber}) ${marker}`);
                 const newBody = hit.body.slice(0, lineStart) + newLine + hit.body.slice(lineEnd);
 
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: hit.id,
-                  body: newBody,
-                });
-
-                core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
-              } catch (err) {
-                core.warning(`Failed to process finding ${findingId} in #${issueNumber}: ${err.message}. Continuing with remaining matches.`);
+                // Inner try/catch: write failures (missing perms, rate
+                // limit, 5xx) MUST surface as a failed run; otherwise
+                // shipped-state silently drifts.
+                try {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: hit.id,
+                    body: newBody,
+                  });
+                  core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
+                } catch (writeErr) {
+                  writeFailures++;
+                  core.error(`Failed to write flip for ${findingId} in #${issueNumber}: ${writeErr.message}`);
+                }
+              } catch (readErr) {
+                core.warning(`Failed to read comments for #${issueNumber} (finding ${findingId}): ${readErr.message}. Continuing with remaining matches.`);
               }
+            }
+
+            if (writeFailures > 0) {
+              core.setFailed(`${writeFailures} flip write(s) failed; tracker comment is out of sync. Review run logs and re-run after fixing the underlying issue.`);
             }
 ```
 

--- a/docs/plans/2026-04-25-review-fix-skill.md
+++ b/docs/plans/2026-04-25-review-fix-skill.md
@@ -677,6 +677,13 @@ finding body byte-for-byte — no paraphrasing, no reflowing, no
 cosmetic edits. The point of the migration is structural (add
 checklist + ID markers) only; content stays as the bot wrote it.
 
+One safety check: scan the verbatim bodies for any stray
+`<!-- f:...-->` token. The Action's marker search would match the
+first occurrence in the comment, so a nested marker (highly
+unlikely, but possible if the bot ever quoted itself) would point
+the flip at the wrong line. If you find one, escape it (e.g.
+`<!-- f-quoted:... -->`) before pasting.
+
 In a scratch file `/tmp/issue87-new-body.md`, paste the original
 header (`## YYYY-MM-DD — <head-sha>` + `Reviewed:` + counts), then
 rewrite the two findings as checklist items:
@@ -717,7 +724,8 @@ jq -Rs '{body: .}' < /tmp/issue87-new-body.md \
       --input -
 ```
 
-Expected: 200 OK with the new body echoed.
+Expected: `gh` prints the updated comment JSON (no error). HTTP
+errors surface as non-zero exit.
 
 - [ ] **Step 5.4: Visually verify the rendered comment**
 
@@ -803,9 +811,9 @@ gh pr create --base develop \
 - One-time migration of issue #87's latest comment to the new format (synthetic IDs `682b557.1`, `682b557.2`).
 
 ## Migration
-- Edited comment ID: \`<COMMENT_ID>\` on issue #87.
+- Edited comment ID: `<COMMENT_ID>` on issue #87.
 - Synthetic IDs assigned: `682b557.1` (BLOCKER, interface→type sweep), `682b557.2` (MINOR, MockLlmProvider eager validation).
-- Pre-edit snapshot kept at \`/tmp/issue87-last-comment.json\` on the author's machine; reviewers can request it for diffing.
+- Pre-edit snapshot kept at `/tmp/issue87-last-comment.json` on the author's machine; reviewers can request it for diffing.
 
 ## Test plan
 - [ ] `npm run verify` green (doc-only diff outside `.github/` so most stages are no-ops; `actionlint` enforces the workflow YAML).

--- a/docs/plans/2026-04-25-review-fix-skill.md
+++ b/docs/plans/2026-04-25-review-fix-skill.md
@@ -557,12 +557,17 @@ jobs:
 
             const prNumber = context.payload.pull_request.number;
 
-            // Track write-side failures separately so the run fails at the
-            // end if any flip could not be persisted. Read-side failures
-            // (listComments 404, etc.) stay soft — a finding pointing at
-            // a non-existent issue is a content bug in the PR body, not
-            // a problem with the automation.
-            let writeFailures = 0;
+            // Track hard failures across both read and write phases so the
+            // run fails at the end if any flip could not be persisted or
+            // any non-404 API error masked a flip. Only "expected content
+            // misses" stay soft:
+            //   - listComments 404 (target issue does not exist — PR-body
+            //     content bug, not an automation problem),
+            //   - finding not present in the comment body,
+            //   - line already shipped or shape unexpected.
+            // Everything else (403/429/5xx/network on either read or write)
+            // increments hardFailures and triggers core.setFailed at the end.
+            let hardFailures = 0;
 
             for (const m of matches) {
               const [, issueStr, sha7, idxStr] = m;
@@ -629,16 +634,25 @@ jobs:
                   });
                   core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
                 } catch (writeErr) {
-                  writeFailures++;
+                  hardFailures++;
                   core.error(`Failed to write flip for ${findingId} in #${issueNumber}: ${writeErr.message}`);
                 }
               } catch (readErr) {
-                core.warning(`Failed to read comments for #${issueNumber} (finding ${findingId}): ${readErr.message}. Continuing with remaining matches.`);
+                // 404 on listComments = "target issue does not exist" =
+                // soft (PR-body content bug). Anything else (403, 429,
+                // 5xx, network) is a transient/permissions failure that
+                // would silently drop a valid flip — fail loudly.
+                if (readErr.status === 404) {
+                  core.warning(`Issue #${issueNumber} not found (finding ${findingId}). Skipping.`);
+                } else {
+                  hardFailures++;
+                  core.error(`Failed to read comments for #${issueNumber} (finding ${findingId}): ${readErr.message} (status ${readErr.status ?? 'n/a'})`);
+                }
               }
             }
 
-            if (writeFailures > 0) {
-              core.setFailed(`${writeFailures} flip write(s) failed; tracker comment is out of sync. Review run logs and re-run after fixing the underlying issue.`);
+            if (hardFailures > 0) {
+              core.setFailed(`${hardFailures} flip(s) failed (read or write); tracker comment is out of sync. Review run logs and re-run after fixing the underlying issue.`);
             }
 ```
 

--- a/docs/plans/2026-04-25-review-fix-skill.md
+++ b/docs/plans/2026-04-25-review-fix-skill.md
@@ -522,7 +522,12 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: review-fix-shipped-${{ github.event.pull_request.number }}
+  # Global group across all PRs: every job in this workflow reads + rewrites
+  # the same tracker comment body. Keying by PR number would let two merged
+  # PRs run in parallel, both read a pre-flip body, and the later write
+  # would silently revert the earlier flip. cancel-in-progress: false
+  # preserves the earlier run; the later run queues until it finishes.
+  group: review-fix-shipped
   cancel-in-progress: false
 
 jobs:

--- a/docs/review-bot/PROMPT.md
+++ b/docs/review-bot/PROMPT.md
@@ -100,23 +100,40 @@ git diff <last-sha>..origin/develop
 
 # Output format
 
-Per finding:
+Compute a stable ID per finding before writing: `<head-sha[:7]>.<idx>`,
+where `idx` is 1-based within this run, assigned **after** counter-arg
+pruning, in the priority order findings are written.
 
-```
-[SEVERITY] path/to/file.ts:42
-Problem: <one line>
-Why it matters: <one line, concrete failure mode>
-Fix:
-```
+Per finding (Markdown checklist item with embedded ID marker):
 
+````markdown
+- [ ] **[SEVERITY]** `path/to/file.ts:42` — short title <!-- f:<sha7>.<idx> -->
+  <details><summary>details</summary>
+
+  **Problem:** <one line>
+
+  **Why it matters:** <one line, concrete failure mode>
+
+  **Fix:**
+
+  ```diff
+  - bad
+  + good
+  ```
+
+  </details>
 ````
-```diff
-- bad
-+ good
-```
-````
 
-End with:
+Rules:
+- The HTML comment marker `<!-- f:... -->` MUST be the last token on
+  the checklist line. Renderers hide it; the `review-fix-shipped`
+  Action keys off it.
+- Severity in bold + brackets: `**[BLOCKER]**`, `**[MAJOR]**`,
+  `**[MINOR]**`, `**[NIT]**`.
+- The short title is the first line of the original `Problem:`,
+  trimmed to ≤ 80 chars, no trailing period.
+
+End the comment with the run footer:
 
 - Reviewed range: `<last-sha>..<head-sha>` (`<N>` commits, `<M>` files)
 - Blockers: N
@@ -140,7 +157,9 @@ End with:
   Reviewed: <last-sha>..<head-sha> (<N> commits)
   Blockers: N | Majors: N | Minors: N | Nits: N
 
-  <full findings block>
+  <checklist of findings, see Output format>
+
+  <run footer>
   ```
 
 - If no new commits: append a one-line comment
@@ -165,7 +184,11 @@ End with:
   ---
   ```
 
-- Body: full findings block (same content as the issue comment).
+- Body: full findings block (same content as the issue comment —
+  checklist of findings + run footer).
+- The daily doc is an immutable snapshot of that run; the
+  `review-fix-shipped` Action edits the rolling issue comment only,
+  never the daily doc.
 - If no new commits: skip file creation. Do NOT commit an empty doc.
 
 ## Commit + PR flow (NEVER push direct to develop)

--- a/docs/review-bot/README.md
+++ b/docs/review-bot/README.md
@@ -21,6 +21,58 @@ per weekday and persists findings to two sinks.
    `develop` via an automated PR `chore/daily-review-YYYY-MM-DD`,
    never a direct push.
 
+## Ingesting findings via `review-fix`
+
+The `.claude/skills/review-fix/SKILL.md` skill turns one finding into
+a worktree-isolated topic branch + plan, ready for
+`superpowers:writing-plans` → `superpowers:executing-plans`.
+
+### Finding ID
+
+Each finding the bot writes carries a stable ID
+`<head-sha[:7]>.<idx>`, embedded as an HTML comment on its checklist
+line. `head-sha[:7]` is the seven-char prefix of the head SHA
+reviewed in that run; `idx` is the 1-based position of the finding
+within the run.
+
+IDs do not deduplicate across reruns: tomorrow's run on a new SHA
+emits a fresh set of IDs even for findings that were already
+unshipped. The unshipped checkbox on the prior comment still flips
+when the eventual PR ships.
+
+### Workflow
+
+```text
+gh issue view 87 --comments       # find a finding ID
+/review-fix pick <id>             # creates worktree + plan
+/superpowers:writing-plans <plan> # expand plan into chunked tasks
+/superpowers:executing-plans …    # implement, verify, open PR
+```
+
+The PR body MUST contain, on its own line:
+
+```
+Refs #87 finding:<sha7>.<idx>
+```
+
+Trailing whitespace is tolerated; trailing punctuation breaks the
+match. The PR body MUST NOT contain `Closes #87` / `Fixes #87` —
+the tracker is long-lived and stays open.
+
+### Auto-flip on merge
+
+`.github/workflows/review-fix-shipped.yml` triggers on
+`pull_request: closed && merged`, regexes the PR body for the magic
+line, locates the matching tracker comment, and edits the body so
+the checklist item becomes:
+
+```markdown
+- [x] **[BLOCKER]** `path/to/file.ts:42` — short title (shipped in #N) <!-- f:<sha7>.<idx> -->
+```
+
+The Action does not block merges; it observes them. If the magic
+line is missing, it logs and exits 0.
+
 ## CI behavior on the daily PR
 
 `.github/workflows/ci.yml` short-circuits doc-only PRs:
@@ -71,6 +123,10 @@ invariants, or output-format pain. To change it:
 - [ ] Dry-run twice manually before scheduling. Set `DRY_RUN=1` in the
       routine's env to print intended commands without pushing or
       calling `gh`.
+- [ ] Confirm the `review-fix-shipped` workflow file is present on
+      `develop` (`.github/workflows/review-fix-shipped.yml`). It needs
+      no extra setup; the default `GITHUB_TOKEN` has the required
+      `issues:write` scope.
 
 ## Cadence
 

--- a/docs/specs/2026-04-25-review-fix-skill.md
+++ b/docs/specs/2026-04-25-review-fix-skill.md
@@ -121,15 +121,19 @@ Steps the skill performs:
    origin/develop`. Run `npm install` inside.
 5. **Plan.** Write `docs/plans/2026-04-25-review-bot-<slug>.md` with:
    - Frontmatter (`date`, `slug`, `finding-id`, `tracker: '#87'`).
+     The `tracker` value MUST be quoted — `#` opens a YAML comment
+     and would otherwise drop the issue reference silently.
    - The finding body verbatim, quoted.
    - Acceptance criteria mirroring the bot's proposed fix (apply +
      tests + `npm run verify` green).
    - Rollout: PR to `develop`, body line `Refs #87 finding:<id>`,
      no `Closes` / `Fixes` keyword.
-6. **Hand off.** Invoke `superpowers:writing-plans` to expand the plan
-   into chunked tasks. The skill stops here — actual implementation
-   runs in a separate `superpowers:executing-plans` session, by
-   project convention.
+6. **Hand off.** The skill prints a single-line instruction:
+   "Plan written to `<path>`. Run `/superpowers:writing-plans <path>`
+   to expand into chunked tasks." The skill itself does **not**
+   invoke `writing-plans`; the user runs it explicitly so they can
+   review the plan first. Implementation then runs in a separate
+   `superpowers:executing-plans` session, by project convention.
 
 The skill does **not** open the PR. PR creation happens at the end of
 the implementation session, not at plan time, since plans can be
@@ -166,9 +170,10 @@ Job runs only when `github.event.pull_request.merged == true`.
 
 Steps:
 
-1. Read PR body. Match `/^Refs #(\d+) finding:([0-9a-f]{7})\.(\d+)$/m`.
-   Loop over all matches (a single PR may, in rare cases, ship two
-   findings).
+1. Read PR body. Match `/^Refs #(\d+) finding:([0-9a-f]{7})\.(\d+)\s*$/m`.
+   Trailing whitespace is tolerated; trailing punctuation is not — PR
+   authors must keep the marker line clean. Loop over all matches (a
+   single PR may, in rare cases, ship two findings).
 2. For each match:
    - `gh api /repos/{owner}/{repo}/issues/comments` paginated until a
      comment containing `<!-- f:<sha7>.<idx> -->` is found.
@@ -265,6 +270,12 @@ against a sample diff.
   check" drops a finding mid-run, the indices of subsequent findings
   shift. Mitigation: bot computes IDs only after counter-arg pruning,
   immediately before writing the comment — locked at write time.
+- **IDs do not de-duplicate across runs.** The same unfixed finding
+  re-emitted in tomorrow's run gets a new ID (different `head-sha`).
+  This is intentional: each run's IDs reference that run's snapshot.
+  The unshipped checkbox on the prior comment still flips when the
+  eventual PR ships; future maintainers should not try to reconcile
+  IDs across runs.
 - **Comment rewrite race.** Bot writes a fresh comment same day the
   Action tries to flip a prior one. Different comments → no race in
   practice; both go through the GitHub API serially.
@@ -293,7 +304,10 @@ against a sample diff.
 - [ ] `review-fix` skill file present, documented, lints clean.
 - [ ] `.github/workflows/review-fix-shipped.yml` present and
       `actionlint`-clean.
-- [ ] Existing `#87` comment migrated to new format.
+- [ ] Existing `#87` comment migrated to new format. Visually
+      verified post-PATCH that the markers (`<!-- f:682b557.1 -->`
+      etc.) do not render and the checklist items render as
+      checkboxes.
 - [ ] Implementation plan exists at
       `docs/plans/2026-04-25-review-fix-skill.md`.
 - [ ] No `Closes #87` / `Fixes #87` anywhere in this PR's body.

--- a/docs/specs/2026-04-25-review-fix-skill.md
+++ b/docs/specs/2026-04-25-review-fix-skill.md
@@ -1,0 +1,299 @@
+---
+date: 2026-04-25
+slug: review-fix-skill
+status: approved
+related-issue: '#87'
+---
+
+# `review-fix` skill — ingest daily-review findings into PRs
+
+## Problem
+
+The daily code-review routine (`docs/review-bot/`) appends findings to a
+rolling tracker issue (`#87 Daily code review — develop`) once per
+weekday. Each comment lists `[BLOCKER] / [MAJOR] / [MINOR] / [NIT]`
+findings against `develop`. Today there is no ergonomic, reproducible
+workflow to:
+
+1. Pick a finding from the tracker.
+2. Turn it into a worktree-isolated topic branch + implementation plan.
+3. Open a PR that links the finding without closing the tracker issue
+   (the tracker is long-lived; the daily run keeps appending).
+4. Mark the finding as shipped on the tracker comment after the PR
+   merges, so progress is visible in-place rather than via a separate
+   spreadsheet.
+
+Manual handling drifts: people fix the loud blockers, forget the
+minors, and the tracker becomes an append-only graveyard with no
+shipped/unshipped distinction.
+
+## Goals
+
+- One canonical ID per finding, computable by the bot at write time
+  (no post-write rewrite step).
+- Skill that takes a finding ID and produces a topic branch +
+  worktree + plan + PR, ready for `executing-plans`.
+- Automatic checkbox flip on the tracker comment when the PR merges.
+- Tracker issue stays **open** — no PR closes or auto-closes it.
+- Daily-review docs (`docs/daily-reviews/YYYY-MM-DD.md`) remain
+  immutable snapshots; only the rolling issue's comments mutate.
+
+## Non-goals
+
+- Auto-implementing the fix. Skill stops after the plan is written;
+  the user (or a separate executing-plans session) does the code.
+- Bundling multiple findings into one PR. One finding = one PR (matches
+  the existing "never stack branches" rule in `feedback_pr_hygiene.md`).
+- Replacing the daily-review routine itself; this consumes its output.
+- Per-finding state machine beyond `unshipped` / `shipped`. No
+  `in-review` / `blocked` states — the PR's own status carries that.
+
+## Design
+
+### Finding ID
+
+Format: `<head-sha[:7]>.<idx>`.
+
+- `head-sha[:7]` — first seven chars of the head SHA the bot reviewed.
+  Already present in the per-run footer (`Last reviewed SHA:`).
+- `idx` — 1-based position of the finding within that run's output.
+  Stable: the bot writes findings in priority order (severity, then
+  source order) and never re-orders post-write.
+
+Example: `682b557.3` = third finding of the run that ended at HEAD
+`682b557…`.
+
+The ID is embedded as an HTML comment so it does not render:
+
+```markdown
+- [ ] **[BLOCKER]** `src/ports/LlmProviderPort.ts` — interface→type sweep <!-- f:682b557.3 -->
+```
+
+### Bot output format change (`docs/review-bot/PROMPT.md`)
+
+Each finding is rendered as a checklist item with marker + collapsible
+details. Concrete shape:
+
+```markdown
+- [ ] **[BLOCKER]** `path/to/file.ts:42` — short title <!-- f:<sha7>.<idx> -->
+  <details><summary>details</summary>
+
+  **Problem:** ...
+
+  **Why it matters:** ...
+
+  **Fix:**
+
+  ```diff
+  - bad
+  + good
+  ```
+
+  </details>
+```
+
+Both sinks (rolling issue comment and `docs/daily-reviews/<date>.md`)
+emit the same format. The daily doc is immutable history; only the
+rolling issue's comment is a flip target.
+
+The current `Output format` block in `PROMPT.md` is replaced. The
+`Persistence` block is updated so the per-run header (date, range,
+counts) precedes the checklist instead of free-form findings.
+
+The "Counter-argument check" line stays in the footer; it operates on
+findings before they are written, so it does not need an ID.
+
+### Skill: `.claude/skills/review-fix/SKILL.md`
+
+One mode, one argument: `pick <finding-id>`.
+
+Steps the skill performs:
+
+1. **Locate.** `gh api /repos/{owner}/{repo}/issues/87/comments` →
+   stream comments, find the one containing `<!-- f:<id> -->`.
+   Fail-fast if missing or already shipped (`- [x]`).
+2. **Extract.** Parse the checklist line + the `<details>` block
+   beneath it. Pull severity, file path, title, body markdown.
+3. **Slug.** `kebab(severity + first-4-words-of-title)`, trimmed to
+   ≤ 50 chars. Example: `blocker-llmproviderport-interface-to-type`.
+4. **Worktree + branch.** `git worktree add
+   .worktrees/fix-review-<slug> -b fix/review-bot-<slug>
+   origin/develop`. Run `npm install` inside.
+5. **Plan.** Write `docs/plans/2026-04-25-review-bot-<slug>.md` with:
+   - Frontmatter (`date`, `slug`, `finding-id`, `tracker: '#87'`).
+   - The finding body verbatim, quoted.
+   - Acceptance criteria mirroring the bot's proposed fix (apply +
+     tests + `npm run verify` green).
+   - Rollout: PR to `develop`, body line `Refs #87 finding:<id>`,
+     no `Closes` / `Fixes` keyword.
+6. **Hand off.** Invoke `superpowers:writing-plans` to expand the plan
+   into chunked tasks. The skill stops here — actual implementation
+   runs in a separate `superpowers:executing-plans` session, by
+   project convention.
+
+The skill does **not** open the PR. PR creation happens at the end of
+the implementation session, not at plan time, since plans can be
+revised before code lands.
+
+### PR body convention
+
+Implementation sessions end with a PR whose body contains, on its own
+line:
+
+```
+Refs #87 finding:<sha7>.<idx>
+```
+
+This line is what the GitHub Action keys off. It is the only contract
+between the skill output and the merge-time flip.
+
+The PR body MUST NOT contain `Closes #87`, `Fixes #87`, or any other
+GitHub auto-close keyword targeting the tracker. The PR may close
+unrelated issues (e.g. a regression issue filed separately) using
+those keywords; only the tracker is protected.
+
+### GitHub Action: `.github/workflows/review-fix-shipped.yml`
+
+Trigger:
+
+```yaml
+on:
+  pull_request:
+    types: [closed]
+```
+
+Job runs only when `github.event.pull_request.merged == true`.
+
+Steps:
+
+1. Read PR body. Match `/^Refs #(\d+) finding:([0-9a-f]{7})\.(\d+)$/m`.
+   Loop over all matches (a single PR may, in rare cases, ship two
+   findings).
+2. For each match:
+   - `gh api /repos/{owner}/{repo}/issues/comments` paginated until a
+     comment containing `<!-- f:<sha7>.<idx> -->` is found.
+   - In that comment body, locate the unique line ending with
+     `<!-- f:<sha7>.<idx> -->`.
+   - Replace `- [ ]` with `- [x]` on that line and append
+     ` (shipped in #<PR>)` immediately before the HTML comment.
+   - PATCH the comment with the new body.
+3. If no matches: exit 0, log a single-line warning. Do not fail the
+   merge.
+4. If a match cannot be located (comment not found / line not found /
+   already shipped): log warning, exit 0. Idempotent re-runs are
+   safe.
+
+Permissions: `issues: write`, `pull-requests: read`. Token: default
+`GITHUB_TOKEN`. No PAT needed — the tracker issue lives in the same
+repo.
+
+The action runs in its own workflow file so its failures cannot block
+unrelated CI. It does not block merges; it observes them.
+
+### One-time migration
+
+The current `#87` comment authored on 2026-04-25 by the bot pre-dates
+this format. Two findings exist:
+
+- `[BLOCKER]` `interface` → `type` sweep across 16 declarations.
+- `[MINOR]` `MockLlmProvider.pickScript` eager validation.
+
+Migration: a single `gh api -X PATCH` call rewrites that comment body
+to the new checklist format with synthetic IDs `682b557.1` and
+`682b557.2`. Performed manually as part of the PR that lands this
+spec; not part of the skill itself.
+
+Older `no-op (head still <sha>)` comments need no migration — they
+have no findings.
+
+### README addition (`docs/review-bot/README.md`)
+
+A new section, "Ingesting findings via `review-fix`", added after
+"Output sinks":
+
+- Explains the finding-ID format.
+- Points at `.claude/skills/review-fix/SKILL.md`.
+- Documents the magic `Refs #87 finding:<id>` PR-body line.
+- Documents the auto-flip workflow.
+
+The `Initial setup checklist` gets one new entry: enable the
+`review-fix-shipped` workflow (no extra setup beyond the workflow
+file existing on `develop`).
+
+## Component boundaries
+
+| Unit | Responsibility | Inputs | Outputs |
+|------|---------------|--------|---------|
+| Bot prompt | Emit findings with stable IDs | diff, last-SHA | issue comment + daily doc, both with markers |
+| `review-fix` skill | Turn one finding ID into a worktree + plan | finding ID | worktree path, plan file, branch ready for impl |
+| `writing-plans` (existing) | Expand plan into tasks | spec/plan markdown | task list |
+| Implementation session | Apply fix + verify + open PR | plan, branch | PR with magic body line |
+| `review-fix-shipped` action | Flip tracker checkbox on merge | merged PR | PATCHed tracker comment |
+
+Each unit is independently testable: the skill against fixture
+comments, the action against fixture PR bodies, the bot prompt
+against a sample diff.
+
+## Error handling
+
+| Case | Behavior |
+|------|----------|
+| Skill: ID not found in any comment | Hard error, suggest `gh issue view 87 --comments` to verify ID |
+| Skill: comment found but already `[x]` | Hard error: "finding already shipped in #N" |
+| Skill: worktree already exists | Hard error, point at existing path |
+| Action: PR body lacks magic line | Soft no-op, log warning |
+| Action: comment fetched but line missing | Soft no-op, log warning, exit 0 |
+| Action: PATCH 4xx (rate limit, perm) | Action exits non-zero — surfaces in Actions UI; merge already done |
+| Bot: head-SHA collides with prior run (rebase reset) | Possible in theory; mitigated by index. If a true collision happens, manual re-tag |
+
+## Testing
+
+- **Skill:** unit-level — feed fixture comment markdown, assert
+  extracted finding fields, slug, plan content. The git/`gh` calls
+  are described but not exercised in this repo's test runner; manual
+  smoke once on the live tracker.
+- **Action:** snapshot-test the body-rewrite step against a fixture
+  comment + fixture PR body. Live integration test = first PR that
+  ships a finding.
+- **Bot prompt:** no automated test (it's a prompt). Manual: run the
+  bot once on a small diff after the prompt change, eyeball both
+  sinks for correct IDs and checklist format.
+
+## Risks
+
+- **Bot index drift across reruns.** If the bot's "Counter-argument
+  check" drops a finding mid-run, the indices of subsequent findings
+  shift. Mitigation: bot computes IDs only after counter-arg pruning,
+  immediately before writing the comment — locked at write time.
+- **Comment rewrite race.** Bot writes a fresh comment same day the
+  Action tries to flip a prior one. Different comments → no race in
+  practice; both go through the GitHub API serially.
+- **Finding split into multiple files post-fix.** A `[BLOCKER]` that
+  the user splits across two PRs cannot easily flip the same checkbox
+  twice. Mitigation: don't split. If you must, the second PR's flip is
+  a no-op (already `[x]`); add a manual edit to record the second PR
+  reference if it matters.
+- **Auto-flip touches an issue comment authored by another user.**
+  GitHub allows it via API for repo collaborators. Edit history is
+  preserved. Acceptable.
+
+## Out of scope (future work, not blocking)
+
+- Severity-filtered batch ingest (e.g. "give me a worktree per
+  unshipped BLOCKER").
+- Stats panel / dashboard summarising shipped vs unshipped per
+  severity.
+- Cross-issue rollover when `#87` is rotated at 500 comments — the
+  Action will need to learn the active tracker issue number, probably
+  via a label query.
+
+## Acceptance for this spec landing
+
+- [ ] Bot prompt + README updated.
+- [ ] `review-fix` skill file present, documented, lints clean.
+- [ ] `.github/workflows/review-fix-shipped.yml` present and
+      `actionlint`-clean.
+- [ ] Existing `#87` comment migrated to new format.
+- [ ] Implementation plan exists at
+      `docs/plans/2026-04-25-review-fix-skill.md`.
+- [ ] No `Closes #87` / `Fixes #87` anywhere in this PR's body.


### PR DESCRIPTION
## Summary
- New `.claude/skills/review-fix/SKILL.md` skill: turns one tracker finding into a worktree-isolated topic branch + plan, then hands off to `superpowers:writing-plans`.
- New `.github/workflows/review-fix-shipped.yml` workflow: on merged PRs, regexes the body for `Refs #<n> finding:<sha7>.<idx>` and flips the matching tracker checkbox to `[x] (shipped in #PR)`. Issue stays open.
- Updated `docs/review-bot/PROMPT.md` so each finding emits as a Markdown checklist item with embedded `<!-- f:<sha7>.<idx> -->` ID marker. Both sinks share the format; only the rolling issue comment gets flipped.
- Updated `docs/review-bot/README.md` with an "Ingesting findings" section and a setup-checklist row.
- One-time migration of issue #87's latest comment to the new format (synthetic IDs `682b557.1`, `682b557.2`).

## Migration
- Edited comment ID: `4319403042` on issue #87.
- Synthetic IDs assigned: `682b557.1` (BLOCKER, interface→type sweep), `682b557.2` (MINOR, MockLlmProvider eager validation).
- Body content preserved byte-for-byte inside the `<details>` blocks; only structural wrapping (checklist + ID markers) was added.

## Test plan
- [ ] `npm run verify` green locally (already confirmed before push; doc-only diff outside `.github/`, so most stages no-op).
- [ ] `actionlint` job in CI green for `.github/workflows/review-fix-shipped.yml`.
- [ ] Skill smoke test: `gh issue view 87 --comments` resolves a finding ID; running the skill creates the worktree + plan without errors.
- [ ] Action dry-run: a follow-up PR that fixes finding `682b557.2` triggers the workflow on merge and flips the checkbox in #87.
- [ ] Visual check on the migrated comment: checklists render, markers hidden, details collapsible.

Refs #87