### PR TITLE
chore(review-fix): add no-arg sweep mode

### DIFF
--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -23,8 +23,9 @@ description: Ingests one or all open findings from the rolling daily-code-review
 - **Single-finding mode** — user supplies a finding ID (`682b557.3`).
   Runs steps 1 → 6 once for that ID. Default and primary path.
 - **Sweep mode** — user invokes the skill with no argument. Pull the
-  latest comment on `#87`, parse every `<!-- f:<id> -->` marker, skip
-  ones already rendered `- [x]`, and run steps 2 → 5 once per remaining
+  most recent comment on `#87` that contains finding markers (skip
+  no-op comments), parse every `<!-- f:<id> -->` marker, skip ones
+  already rendered `- [x]`, and run steps 2 → 5 once per remaining
   finding. Each finding still gets its own worktree + branch + plan
   (one finding = one branch = one PR — sweep just batches the _setup_,
   not the findings themselves). At the end, print a single hand-off
@@ -63,8 +64,11 @@ gh api "/repos/${REPO}/issues/87/comments" --paginate \
 
 If no match: hard-fail with `Finding ${ID} not found in #87 comments`.
 
-**Sweep mode (no argument).** Pull only the latest comment, then
-extract every finding ID from it. Two pagination subtleties matter:
+**Sweep mode (no argument).** Pull the most recent comment that
+actually contains finding markers (the review bot is allowed to post
+no-op comments like `YYYY-MM-DD — no-op …` with zero findings; those
+must be skipped, not picked), then extract every finding ID from it.
+Three pagination / shape subtleties matter:
 
 1. Without `--slurp`, `gh api --paginate --jq '... | last'` runs the
    filter once per page and returns one row per page (last-of-each-
@@ -73,12 +77,19 @@ extract every finding ID from it. Two pagination subtleties matter:
    page) rather than a flat list of comments, so `sort_by(.created_at)`
    would be operating on an array-of-arrays. Pipe through `add` first
    to concatenate the pages into a single flat array.
+3. The newest comment may be a no-op summary with no findings. Filter
+   to comments whose body contains `<!-- f:` _before_ taking `last`,
+   so sweep mode picks the most recent comment that has work to do.
 
 ```bash
 REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 LAST_COMMENT="$(gh api "repos/${REPO}/issues/87/comments" \
   --paginate --slurp \
-  --jq 'add | sort_by(.created_at) | last | {id, body}')"
+  --jq 'add
+        | map(select(.body | contains("<!-- f:")))
+        | sort_by(.created_at)
+        | last
+        | {id, body}')"
 echo "${LAST_COMMENT}" | jq -r '.body' \
   | grep -oE '<!-- f:[^ ]+ -->' \
   | sed -E 's/<!-- f:(.+) -->/\1/'
@@ -93,8 +104,9 @@ For each ID returned:
   `Skipping <id> (worktree exists at <path>)` and continue).
 - Otherwise, run steps 2 → 5 for that finding.
 
-If the comment contains zero findings, hard-fail with
-`Last comment on #87 has no findings — nothing to sweep`.
+If `LAST_COMMENT` is empty / `null` (every comment on `#87` is a
+no-op or the issue has no comments at all), hard-fail with
+`No comment on #87 contains findings — nothing to sweep`.
 
 ### 2. Extract finding fields
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: review-fix
-description: Ingests a single finding from the rolling daily-code-review tracker issue (`#87 Daily code review — develop`) and produces a worktree-isolated topic branch + implementation plan. Use when the user says "fix review finding <id>", "pick a finding", "/review-fix <id>", or names a finding-ID like `682b557.3`. Does NOT close the tracker issue — the tracker is append-only and the auto-flip workflow handles shipped state.
+description: Ingests one or all open findings from the rolling daily-code-review tracker issue (`#87 Daily code review — develop`) and produces a worktree-isolated topic branch + implementation plan per finding. Use when the user says "fix review finding <id>", "pick a finding", "/review-fix <id>", names a finding-ID like `682b557.3`, OR invokes `/review-fix` with no argument (sweeps every unshipped finding in the latest tracker comment). Does NOT close the tracker issue — the tracker is append-only and the auto-flip workflow handles shipped state.
 ---
 
-# review-fix — turn one tracker finding into a worktree + plan
+# review-fix — turn tracker finding(s) into worktree(s) + plan(s)
 
 ## Terminology
 
@@ -18,26 +18,40 @@ description: Ingests a single finding from the rolling daily-code-review tracker
   contract between this skill's output and the
   `review-fix-shipped` Action.
 
+## Modes
+
+- **Single-finding mode** — user supplies a finding ID (`682b557.3`).
+  Runs steps 1 → 6 once for that ID. Default and primary path.
+- **Sweep mode** — user invokes the skill with no argument. Pull the
+  latest comment on `#87`, parse every `<!-- f:<id> -->` marker, skip
+  ones already rendered `- [x]`, and run steps 3 → 5 once per remaining
+  finding. Each finding still gets its own worktree + branch + plan
+  (one finding = one branch = one PR — sweep just batches the _setup_,
+  not the findings themselves). At the end, print a single hand-off
+  summary listing every plan written.
+
 ## Before you start
 
 Confirm with the user:
 
-1. **Finding ID** — exact form `<sha7>.<idx>`. If they paste a free-text
-   description instead, refuse and ask them to grab the ID from
-   `gh issue view 87 --comments`.
-2. **Already shipped?** — if the tracker line for that ID renders
-   `- [x]`, refuse and tell them which PR shipped it (the comment line
-   carries `(shipped in #N)`).
+1. **Finding ID (single mode only)** — exact form `<sha7>.<idx>`. If
+   they paste a free-text description instead, refuse and ask them to
+   grab the ID from `gh issue view 87 --comments`. In sweep mode
+   (no-arg invocation), skip this check.
+2. **Already shipped?** — if the tracker line for the chosen ID renders
+   `- [x]`, refuse (single mode) or silently skip (sweep mode) and tell
+   them which PR shipped it (the comment line carries `(shipped in #N)`).
 3. **Worktree clear?** — if `.worktrees/fix-review-<slug>` already
-   exists, refuse with the existing path. Either remove it
-   (`git worktree remove`) or pick a different finding.
+   exists, refuse (single mode) or skip that finding with a logged
+   warning (sweep mode). The user resolves collisions via
+   `git worktree remove` or by picking a different finding.
 
 ## Steps
 
-### 1. Locate the finding
+### 1. Locate the finding(s)
 
-Substitute the user-provided finding ID (e.g. `682b557.3`) for `${ID}`
-below before running:
+**Single-finding mode.** Substitute the user-provided finding ID
+(e.g. `682b557.3`) for `${ID}` below before running:
 
 ```bash
 ID="<sha7>.<idx>"            # e.g. 682b557.3
@@ -48,6 +62,30 @@ gh api "/repos/${REPO}/issues/87/comments" --paginate \
 ```
 
 If no match: hard-fail with `Finding ${ID} not found in #87 comments`.
+
+**Sweep mode (no argument).** Pull only the latest comment, then
+extract every finding ID from it:
+
+```bash
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+LAST_COMMENT="$(gh api "/repos/${REPO}/issues/87/comments" --paginate \
+  --jq 'sort_by(.created_at) | last | {id, body}')"
+echo "${LAST_COMMENT}" | jq -r '.body' \
+  | grep -oE '<!-- f:[^ ]+ -->' \
+  | sed -E 's/<!-- f:(.+) -->/\1/'
+```
+
+For each ID returned:
+
+- Skip if its checklist line in the same comment body starts with
+  `- [x]` (already shipped — log `Skipping <id> (shipped in #N)` and
+  continue).
+- Skip if `.worktrees/fix-review-<slug>` already exists (log
+  `Skipping <id> (worktree exists at <path>)` and continue).
+- Otherwise, run steps 2 → 5 for that finding.
+
+If the comment contains zero findings, hard-fail with
+`Last comment on #87 has no findings — nothing to sweep`.
 
 ### 2. Extract finding fields
 
@@ -136,15 +174,33 @@ From `#87` comment <comment-id>, finding `<id>`:
 
 ### 6. Hand off
 
-Print exactly:
+**Single-finding mode.** Print exactly:
 
 ```text
 Plan written to <plan-path> on branch <branch> in <worktree-dir>.
 Next: cd <worktree-dir> && /superpowers:writing-plans <plan-path>
 ```
 
+**Sweep mode.** Print one summary block listing every plan written
+plus every finding skipped (and why). Format:
+
+```text
+Sweep of #87 latest comment: <N> findings processed.
+
+Plans written:
+  - <id-1>  →  <plan-path-1>  (branch <branch-1>, worktree <worktree-dir-1>)
+  - <id-2>  →  <plan-path-2>  (branch <branch-2>, worktree <worktree-dir-2>)
+
+Skipped:
+  - <id-3>  (shipped in #N)
+  - <id-4>  (worktree exists at <path>)
+
+Next: pick a worktree and run /superpowers:writing-plans <plan-path>
+inside it. One PR per finding.
+```
+
 **Do not** invoke `superpowers:writing-plans` automatically. The user
-runs it after reviewing the plan.
+runs it after reviewing each plan.
 
 ## Do not
 
@@ -154,6 +210,8 @@ runs it after reviewing the plan.
   anywhere.
 - Do NOT edit the tracker comment from the skill — only the
   `review-fix-shipped` Action edits comments, and only post-merge.
-- Do NOT batch findings. One finding = one branch = one PR.
+- Do NOT batch findings into a single branch / PR. One finding = one
+  branch = one PR. Sweep mode produces N branches + N plans, never a
+  combined plan.
 - Do NOT use `git worktree add -B` (force). Surface conflicts to the
   user.

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -64,17 +64,21 @@ gh api "/repos/${REPO}/issues/87/comments" --paginate \
 If no match: hard-fail with `Finding ${ID} not found in #87 comments`.
 
 **Sweep mode (no argument).** Pull only the latest comment, then
-extract every finding ID from it. Use `--paginate --slurp` together so
-`gh api` flattens every page into one JSON array before `jq` sees it
-— without `--slurp`, `gh api --paginate --jq '... | last'` runs the
-filter per page and returns one row per page (i.e. last-of-each-page,
-not the global latest comment):
+extract every finding ID from it. Two pagination subtleties matter:
+
+1. Without `--slurp`, `gh api --paginate --jq '... | last'` runs the
+   filter once per page and returns one row per page (last-of-each-
+   page, not the global latest comment).
+2. With `--slurp`, `gh api` returns an array of pages (one entry per
+   page) rather than a flat list of comments, so `sort_by(.created_at)`
+   would be operating on an array-of-arrays. Pipe through `add` first
+   to concatenate the pages into a single flat array.
 
 ```bash
 REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 LAST_COMMENT="$(gh api "repos/${REPO}/issues/87/comments" \
   --paginate --slurp \
-  --jq 'sort_by(.created_at) | last | {id, body}')"
+  --jq 'add | sort_by(.created_at) | last | {id, body}')"
 echo "${LAST_COMMENT}" | jq -r '.body' \
   | grep -oE '<!-- f:[^ ]+ -->' \
   | sed -E 's/<!-- f:(.+) -->/\1/'

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -24,7 +24,7 @@ description: Ingests one or all open findings from the rolling daily-code-review
   Runs steps 1 → 6 once for that ID. Default and primary path.
 - **Sweep mode** — user invokes the skill with no argument. Pull the
   latest comment on `#87`, parse every `<!-- f:<id> -->` marker, skip
-  ones already rendered `- [x]`, and run steps 3 → 5 once per remaining
+  ones already rendered `- [x]`, and run steps 2 → 5 once per remaining
   finding. Each finding still gets its own worktree + branch + plan
   (one finding = one branch = one PR — sweep just batches the _setup_,
   not the findings themselves). At the end, print a single hand-off

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -80,6 +80,15 @@ Three pagination / shape subtleties matter:
 3. The newest comment may be a no-op summary with no findings. Filter
    to comments whose body contains `<!-- f:` _before_ taking `last`,
    so sweep mode picks the most recent comment that has work to do.
+4. When `last` is applied to an empty array it returns `null`, but a
+   bare `| {id, body}` projection turns that into the misleading
+   `{"id":null,"body":null}` — i.e. truthy JSON. Guard the projection
+   with `if . == null then empty else {id, body} end` so an
+   "everything is no-op" run yields a genuinely empty `LAST_COMMENT`.
+5. Finding-marker text can legitimately appear inside a finding's
+   `<details>` body or diff block (the bot quotes other comments).
+   Parse IDs only from checklist lines (`- [ ]` / `- [x]`) so quoted
+   marker templates inside bodies are not mistaken for real findings.
 
 ```bash
 REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
@@ -89,9 +98,16 @@ LAST_COMMENT="$(gh api "repos/${REPO}/issues/87/comments" \
         | map(select(.body | contains("<!-- f:")))
         | sort_by(.created_at)
         | last
-        | {id, body}')"
+        | if . == null then empty else {id, body} end')"
+
+if [ -z "${LAST_COMMENT}" ] || [ "${LAST_COMMENT}" = "null" ]; then
+  echo "No comment on #87 contains findings — nothing to sweep" >&2
+  exit 1
+fi
+
 echo "${LAST_COMMENT}" | jq -r '.body' \
-  | grep -oE '<!-- f:[^ ]+ -->' \
+  | grep -E '^- \[[ x]\] ' \
+  | grep -oE '<!-- f:[A-Za-z0-9]+\.[0-9]+ -->' \
   | sed -E 's/<!-- f:(.+) -->/\1/'
 ```
 
@@ -103,10 +119,6 @@ For each ID returned:
 - Skip if `.worktrees/fix-review-<slug>` already exists (log
   `Skipping <id> (worktree exists at <path>)` and continue).
 - Otherwise, run steps 2 → 5 for that finding.
-
-If `LAST_COMMENT` is empty / `null` (every comment on `#87` is a
-no-op or the issue has no comments at all), hard-fail with
-`No comment on #87 contains findings — nothing to sweep`.
 
 ### 2. Extract finding fields
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -136,8 +136,15 @@ If the line shows `- [x]` instead of `- [ ]`: hard-fail
 
 ### 3. Compute slug + paths
 
+The slug always ends with the finding's `<sha7>-<idx>` so two
+findings in the same tracker comment that happen to share a
+severity + first-4-title-words prefix get distinct paths. Without
+that suffix, sweep mode would create the worktree for finding A,
+then silently skip finding B as an "existing worktree" collision.
+
 ```text
-slug          = kebab(severity-lowercased + first 4 words of title), trim ≤ 50 chars
+slug-base     = kebab(severity-lowercased + first 4 words of title), trim ≤ 38 chars
+slug          = <slug-base>-<sha7>-<idx>
 worktree-dir  = .worktrees/fix-review-<slug>
 branch        = fix/review-bot-<slug>
 plan-path     = docs/plans/YYYY-MM-DD-review-bot-<slug>.md   (UTC date)
@@ -146,10 +153,11 @@ plan-path     = docs/plans/YYYY-MM-DD-review-bot-<slug>.md   (UTC date)
 Example for `682b557.1` (`[BLOCKER]` `LlmProviderPort.ts` interface→type sweep):
 
 ```text
-slug          = blocker-llmproviderport-interface-to-type
-worktree-dir  = .worktrees/fix-review-blocker-llmproviderport-interface-to-type
-branch        = fix/review-bot-blocker-llmproviderport-interface-to-type
-plan-path     = docs/plans/2026-04-25-review-bot-blocker-llmproviderport-interface-to-type.md
+slug-base     = blocker-llmproviderport-interface-to-type
+slug          = blocker-llmproviderport-interface-to-type-682b557-1
+worktree-dir  = .worktrees/fix-review-blocker-llmproviderport-interface-to-type-682b557-1
+branch        = fix/review-bot-blocker-llmproviderport-interface-to-type-682b557-1
+plan-path     = docs/plans/2026-04-25-review-bot-blocker-llmproviderport-interface-to-type-682b557-1.md
 ```
 
 ### 4. Create the worktree + branch

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -64,11 +64,16 @@ gh api "/repos/${REPO}/issues/87/comments" --paginate \
 If no match: hard-fail with `Finding ${ID} not found in #87 comments`.
 
 **Sweep mode (no argument).** Pull only the latest comment, then
-extract every finding ID from it:
+extract every finding ID from it. Use `--paginate --slurp` together so
+`gh api` flattens every page into one JSON array before `jq` sees it
+— without `--slurp`, `gh api --paginate --jq '... | last'` runs the
+filter per page and returns one row per page (i.e. last-of-each-page,
+not the global latest comment):
 
 ```bash
 REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
-LAST_COMMENT="$(gh api "/repos/${REPO}/issues/87/comments" --paginate \
+LAST_COMMENT="$(gh api "repos/${REPO}/issues/87/comments" \
+  --paginate --slurp \
   --jq 'sort_by(.created_at) | last | {id, body}')"
 echo "${LAST_COMMENT}" | jq -r '.body' \
   | grep -oE '<!-- f:[^ ]+ -->' \


### PR DESCRIPTION
## Summary

- Adds a no-argument sweep mode to the `review-fix` skill: pulls the latest comment on tracker issue `#87`, parses every `<!-- f:<id> -->` marker, skips findings already shipped (`- [x]`) or with an existing worktree, and runs the worktree + plan steps once per remaining finding.
- Single-finding mode (`/review-fix <id>`) is unchanged. Each swept finding still gets its own branch + plan — the one-finding-per-PR rule still applies.
- Updates description, adds a `## Modes` section, splits step 1 into single + sweep blocks, and adds a sweep-mode hand-off summary format.

## Test plan

- [ ] Invoke `/review-fix` with no argument against a tracker comment containing 2+ open findings; confirm N branches + N plan files are created.
- [ ] Invoke `/review-fix <shipped-id>` and confirm single-finding refusal still works.
- [ ] Invoke `/review-fix` no-arg when one finding's worktree already exists — confirm it logs a skip and continues with the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)