### PR TITLE
fix(persistence): reject invalid inputs (PR #105 review)

### DIFF
--- a/.changeset/persistence-input-validation.md
+++ b/.changeset/persistence-input-validation.md
@@ -1,0 +1,18 @@
+---
+'agentonomous': patch
+---
+
+Reject invalid inputs in three persistence helpers (review findings from
+PR #105):
+
+- `migrateSnapshot()` now throws `SnapshotRestoreError` when
+  `schemaVersion` is `NaN`, `±Infinity`, fractional, or negative instead
+  of silently treating non-integer numbers as a valid version.
+- `AutoSaveTracker.shouldSave()` treats negative, zero, `NaN`, and
+  `±Infinity` values for `everyTicks` / `everyVirtualSeconds` as
+  disabled, preventing the autosave hot-loop that previously fired on
+  every tick when a misconfigured negative threshold slipped through.
+- `runCatchUp()` throws `RangeError` for non-positive or non-finite
+  `chunkVirtualSeconds` and for non-positive / non-integer `maxChunks`
+  instead of returning misleading `truncated: true` summaries with no
+  forward progress.

--- a/src/persistence/AutoSavePolicy.ts
+++ b/src/persistence/AutoSavePolicy.ts
@@ -28,6 +28,10 @@ export const DEFAULT_AUTOSAVE_POLICY: Readonly<Required<Omit<AutoSavePolicy, 'en
   onEvents: ['AgentDied', 'LifeStageChanged'],
 };
 
+function isPositiveFiniteNumber(n: number | undefined): n is number {
+  return n !== undefined && Number.isFinite(n) && n > 0;
+}
+
 /**
  * Stateful auto-save tracker. Agent owns one of these and asks `.shouldSave()`
  * each tick after running the pipeline.
@@ -59,11 +63,14 @@ export class AutoSaveTracker {
   shouldSave(): boolean {
     if (this.policy.enabled === false) return false;
     if (this.eventTriggeredThisTick) return true;
-    if (this.policy.everyTicks && this.ticksSinceSave >= this.policy.everyTicks) {
+    if (
+      isPositiveFiniteNumber(this.policy.everyTicks) &&
+      this.ticksSinceSave >= this.policy.everyTicks
+    ) {
       return true;
     }
     if (
-      this.policy.everyVirtualSeconds &&
+      isPositiveFiniteNumber(this.policy.everyVirtualSeconds) &&
       this.virtualSecondsSinceSave >= this.policy.everyVirtualSeconds
     ) {
       return true;

--- a/src/persistence/migrateSnapshot.ts
+++ b/src/persistence/migrateSnapshot.ts
@@ -31,7 +31,13 @@ export function migrateSnapshot(
     throw new SnapshotRestoreError('Snapshot payload is not an object');
   }
   const versionRaw = (raw as { schemaVersion?: unknown }).schemaVersion;
-  const currentVersion = typeof versionRaw === 'number' ? versionRaw : 0;
+  let currentVersion = 0;
+  if (typeof versionRaw === 'number') {
+    if (!Number.isInteger(versionRaw) || versionRaw < 0) {
+      throw new SnapshotRestoreError(`Invalid schemaVersion: ${String(versionRaw)}`);
+    }
+    currentVersion = versionRaw;
+  }
   if (currentVersion > target) {
     throw new SnapshotRestoreError(
       `Snapshot schemaVersion (${currentVersion}) is newer than supported (${target}). ` +

--- a/src/persistence/offlineCatchUp.ts
+++ b/src/persistence/offlineCatchUp.ts
@@ -39,6 +39,17 @@ export async function runCatchUp(
   const chunkSize = opts.chunkVirtualSeconds ?? OFFLINE_CATCHUP_DEFAULTS.chunkVirtualSeconds;
   const maxChunks = opts.maxChunks ?? OFFLINE_CATCHUP_DEFAULTS.maxChunks;
 
+  if (!Number.isFinite(chunkSize) || chunkSize <= 0) {
+    throw new RangeError(
+      `runCatchUp: chunkVirtualSeconds must be a positive finite number, got ${String(chunkSize)}`,
+    );
+  }
+  if (!Number.isInteger(maxChunks) || maxChunks <= 0) {
+    throw new RangeError(
+      `runCatchUp: maxChunks must be a positive integer, got ${String(maxChunks)}`,
+    );
+  }
+
   if (!(totalVirtualDtSeconds > 0)) {
     return { chunksProcessed: 0, totalVirtualSeconds: 0, truncated: false };
   }

--- a/tests/unit/persistence/AutoSavePolicy.test.ts
+++ b/tests/unit/persistence/AutoSavePolicy.test.ts
@@ -57,4 +57,22 @@ describe('AutoSaveTracker', () => {
     t.advance(1);
     expect(t.shouldSave()).toBe(true);
   });
+
+  it('treats negative / zero / NaN / Infinity everyTicks as disabled', () => {
+    for (const bad of [-1, 0, NaN, Infinity, -Infinity]) {
+      const t = new AutoSaveTracker({ enabled: true, everyTicks: bad });
+      t.advance(1);
+      expect(t.shouldSave()).toBe(false);
+      t.advance(1000);
+      expect(t.shouldSave()).toBe(false);
+    }
+  });
+
+  it('treats negative / zero / NaN / Infinity everyVirtualSeconds as disabled', () => {
+    for (const bad of [-5, 0, NaN, Infinity, -Infinity]) {
+      const t = new AutoSaveTracker({ enabled: true, everyVirtualSeconds: bad });
+      t.advance(10);
+      expect(t.shouldSave()).toBe(false);
+    }
+  });
 });

--- a/tests/unit/persistence/migrateSnapshot.test.ts
+++ b/tests/unit/persistence/migrateSnapshot.test.ts
@@ -29,4 +29,17 @@ describe('migrateSnapshot', () => {
       ),
     ).toThrow(/schemaVersion \(99\)/);
   });
+
+  it('throws on NaN / Infinity / fractional / negative schemaVersion', () => {
+    const base = {
+      snapshotAt: 0,
+      identity: { id: 'x', name: 'x', version: '0.0.0', role: 'npc', species: 'cat' },
+    };
+    for (const bad of [NaN, Infinity, -Infinity, 1.5, -1]) {
+      expect(() => migrateSnapshot({ ...base, schemaVersion: bad })).toThrow(SnapshotRestoreError);
+      expect(() => migrateSnapshot({ ...base, schemaVersion: bad })).toThrow(
+        /Invalid schemaVersion/,
+      );
+    }
+  });
 });

--- a/tests/unit/persistence/offlineCatchUp.test.ts
+++ b/tests/unit/persistence/offlineCatchUp.test.ts
@@ -44,6 +44,22 @@ describe('runCatchUp', () => {
     expect(step).not.toHaveBeenCalled();
   });
 
+  it('throws RangeError on non-positive / non-finite chunkVirtualSeconds', async () => {
+    const step = vi.fn().mockResolvedValue(undefined);
+    for (const bad of [0, -1, NaN, Infinity, -Infinity]) {
+      await expect(runCatchUp(2, step, { chunkVirtualSeconds: bad })).rejects.toThrow(RangeError);
+    }
+    expect(step).not.toHaveBeenCalled();
+  });
+
+  it('throws RangeError on non-positive / non-integer maxChunks', async () => {
+    const step = vi.fn().mockResolvedValue(undefined);
+    for (const bad of [0, -1, 1.5, NaN, Infinity]) {
+      await expect(runCatchUp(2, step, { maxChunks: bad })).rejects.toThrow(RangeError);
+    }
+    expect(step).not.toHaveBeenCalled();
+  });
+
   it('preserves total virtual-dt under long, tiny-chunk catch-up (no float drift)', async () => {
     // Pathological case: 10 000 virtual seconds split into 0.001 s chunks
     // is 10 million iterations of repeated subtraction. We assert the sum


### PR DESCRIPTION
## Summary
Implements the three findings from the library review draft in #105:

- **[MAJOR]** `migrateSnapshot()` now throws `SnapshotRestoreError` on `NaN`, `±Infinity`, fractional, or negative `schemaVersion` instead of returning the snapshot as-is.
- **[MAJOR]** `AutoSaveTracker.shouldSave()` treats negative / zero / `NaN` / `±Infinity` `everyTicks` and `everyVirtualSeconds` as disabled, fixing the per-tick save hot-loop on misconfigured negative thresholds.
- **[MINOR]** `runCatchUp()` throws `RangeError` for non-positive / non-finite `chunkVirtualSeconds` and non-positive / non-integer `maxChunks` instead of returning misleading `truncated: true` summaries.

Each fix has a red-then-green unit test covering the bad-input matrix.

Changeset: `patch` — pure validation hardening, no API surface change.

## Test plan
- [x] `npx vitest run tests/unit/persistence/migrateSnapshot.test.ts tests/unit/persistence/AutoSavePolicy.test.ts tests/unit/persistence/offlineCatchUp.test.ts` (19 / 19)
- [x] `npm run verify` — 508 / 508 pass, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)