### PR TITLE
refactor(ports): split MockLlmProvider.completeSync into named helpers

### DIFF
--- a/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
+++ b/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
@@ -83,6 +83,7 @@ end-to-end, with each PR Codex-reviewed and resolved before the next.
 | 18  | #96 | `feat/demo-richer-feature-vector`            | 13-dim feature vector (5 needs + 4 mood one-hot + 1 modifier-count + 3 recent-event counts); bundled baseline rebuilt at `[13, 16, 7]`; small library addition (`details.preModifierCount` snapshot). |
 | 19  | TBD | `feat/demo-prediction-strip`                 | SVG strip rendering per-tick softmax distribution + idle-threshold line, selected column highlighted; cognitionSwitcher subscribes to `AgentTicked` while in Learning mode. Demo-only. |
 | 20  | TBD | `feat/tfjs-detect-backend-and-picker`        | `TfjsReasoner.detectBestBackend` + `probeBackend` statics (minor bump); demo backend dropdown (`CPU` / `WASM` / `WebGL`) with localStorage persist + per-option availability probe; backend packages move to optional peer deps; tfjs adapter size budget 7 → 9 KB gzip. |
+| 10  | TBD | `refactor/mock-llm-completeSync-split`       | `MockLlmProvider.completeSync` 13 → 4 via `pickFromQueue` / `pickFromMatchOrError` / `runScript` / `abortStub` module-level helpers; no public API change; 19 tests untouched. |
 
 ---
 

--- a/src/ports/MockLlmProvider.ts
+++ b/src/ports/MockLlmProvider.ts
@@ -94,83 +94,135 @@ export class MockLlmProvider implements LlmProviderPort {
     options: LlmCompleteOptions,
   ): LlmCompletion {
     if (options.signal?.aborted === true) {
-      return {
-        text: '',
-        usage: { inputTokens: 0, outputTokens: 0 },
-        model: options.model ?? this.defaultModel,
-        stopReason: 'abort',
-      };
+      return abortStub(options.model ?? this.defaultModel);
     }
 
     const picked = this.pickScript(messages, options);
-    const script = picked.script;
-    const model = script.model ?? options.model ?? this.defaultModel;
-    // Request-side input count used for the budget check — scripts must
-    // not be able to under-report `inputTokens` and sneak an oversize
-    // prompt past `maxInputTokens`. The reported usage on the completion
-    // still honours the script override so tests can pin exact numbers.
-    const requestInputTokens = estimateTokens(messages);
-    const reportedInputTokens = script.usage?.inputTokens ?? requestInputTokens;
-    const outputTokens = script.usage?.outputTokens ?? estimateTokensFor(script.text);
-    const costCents = script.usage?.costCents;
-
-    enforceBudget(options.budget, requestInputTokens, outputTokens, costCents);
-
-    // Only commit the queue cursor once budget checks have passed —
-    // otherwise a budget-rejected request would consume a scripted
-    // entry and make retries non-deterministic.
-    picked.commit();
-
-    return {
-      text: script.text,
-      usage: buildUsage(reportedInputTokens, outputTokens, costCents, script.usage?.cached),
-      model,
-      stopReason: script.stopReason ?? 'stop',
-    };
+    return runScript(picked, messages, options, this.defaultModel);
   }
 
-  private pickScript(
-    messages: readonly LlmMessage[],
-    options: LlmCompleteOptions,
-  ): { script: MockLlmScript; commit: () => void } {
-    if (this.dispatch === 'match-or-error') {
-      // Strict dispatch must fail fast on both zero and multi-match — the
-      // whole point is that each request resolves to exactly one scripted
-      // response. Silently taking the first match would mask misconfigured
-      // scripts and produce the wrong completion in replay tests.
-      const hits = this.scripts.filter((s) => s.match?.(messages, options) === true);
-      if (hits.length === 0) {
-        throw new Error('MockLlmProvider: no script matched the request.');
-      }
-      if (hits.length > 1) {
-        throw new Error(
-          `MockLlmProvider: ${hits.length} scripts matched the request (match-or-error requires exactly one).`,
-        );
-      }
-      // match-or-error has no queue state to advance; commit is a no-op.
-      const [only] = hits;
-      if (!only) throw new Error('MockLlmProvider: no script matched the request.');
-      return { script: only, commit: () => undefined };
-    }
-    // Queue mode: honour a `match` predicate if it's set; otherwise take
-    // the next positional script. Exhausted queue throws. The returned
-    // `commit` advances the queue cursor; callers defer it until after
-    // budget checks so a rejected request doesn't consume an entry.
-    for (let i = this.cursor; i < this.scripts.length; i++) {
-      const candidate = this.scripts[i];
-      if (!candidate) continue;
-      if (candidate.match === undefined || candidate.match(messages, options)) {
-        const advanceTo = i + 1;
-        return {
-          script: candidate,
-          commit: () => {
-            this.cursor = advanceTo;
-          },
-        };
-      }
-    }
-    throw new Error('MockLlmProvider: script queue exhausted.');
+  private pickScript(messages: readonly LlmMessage[], options: LlmCompleteOptions): PickedScript {
+    return this.dispatch === 'match-or-error'
+      ? pickFromMatchOrError(this.scripts, messages, options)
+      : pickFromQueue(this.scripts, this.cursor, messages, options, (next) => {
+          this.cursor = next;
+        });
   }
+}
+
+/**
+ * Selected script plus a `commit` thunk the caller invokes once the
+ * request has passed budget checks. Deferring the commit keeps queue
+ * mode deterministic across retries (a budget-rejected request must
+ * not consume a queued script).
+ */
+type PickedScript = {
+  readonly script: MockLlmScript;
+  readonly commit: () => void;
+};
+
+/**
+ * Build the `'abort'` stub completion returned when an already-aborted
+ * `AbortSignal` is passed in. Kept as its own helper so `completeSync`
+ * stays a flat dispatcher.
+ */
+function abortStub(model: string): LlmCompletion {
+  return {
+    text: '',
+    usage: { inputTokens: 0, outputTokens: 0 },
+    model,
+    stopReason: 'abort',
+  };
+}
+
+/**
+ * Apply budget checks then construct the completion. Mutating the
+ * cursor (in queue mode) is deferred to `picked.commit()` so a
+ * budget-rejected request leaves queue state untouched.
+ */
+function runScript(
+  picked: PickedScript,
+  messages: readonly LlmMessage[],
+  options: LlmCompleteOptions,
+  defaultModel: string,
+): LlmCompletion {
+  const { script } = picked;
+  const model = script.model ?? options.model ?? defaultModel;
+  // Request-side input count used for the budget check — scripts must
+  // not be able to under-report `inputTokens` and sneak an oversize
+  // prompt past `maxInputTokens`. The reported usage on the completion
+  // still honours the script override so tests can pin exact numbers.
+  const requestInputTokens = estimateTokens(messages);
+  const reportedInputTokens = script.usage?.inputTokens ?? requestInputTokens;
+  const outputTokens = script.usage?.outputTokens ?? estimateTokensFor(script.text);
+  const costCents = script.usage?.costCents;
+
+  enforceBudget(options.budget, requestInputTokens, outputTokens, costCents);
+
+  // Only commit the queue cursor once budget checks have passed —
+  // otherwise a budget-rejected request would consume a scripted
+  // entry and make retries non-deterministic.
+  picked.commit();
+
+  return {
+    text: script.text,
+    usage: buildUsage(reportedInputTokens, outputTokens, costCents, script.usage?.cached),
+    model,
+    stopReason: script.stopReason ?? 'stop',
+  };
+}
+
+/**
+ * Strict dispatch: every request must resolve to exactly one matching
+ * script. Zero-match and multi-match both throw — silently taking the
+ * first match would mask misconfigured scripts and produce the wrong
+ * completion under replay. No queue state to advance, so `commit` is
+ * a no-op.
+ */
+function pickFromMatchOrError(
+  scripts: readonly MockLlmScript[],
+  messages: readonly LlmMessage[],
+  options: LlmCompleteOptions,
+): PickedScript {
+  const hits = scripts.filter((s) => s.match?.(messages, options) === true);
+  if (hits.length === 0) {
+    throw new Error('MockLlmProvider: no script matched the request.');
+  }
+  if (hits.length > 1) {
+    throw new Error(
+      `MockLlmProvider: ${hits.length} scripts matched the request (match-or-error requires exactly one).`,
+    );
+  }
+  const [only] = hits;
+  if (!only) throw new Error('MockLlmProvider: no script matched the request.');
+  return { script: only, commit: () => undefined };
+}
+
+/**
+ * Queue dispatch: honour a `match` predicate when set; otherwise take
+ * the next positional script. Exhausted queue throws. The returned
+ * `commit` thunk advances the cursor via `setCursor`, deferred until
+ * after budget checks so rejected requests don't consume an entry.
+ */
+function pickFromQueue(
+  scripts: readonly MockLlmScript[],
+  cursor: number,
+  messages: readonly LlmMessage[],
+  options: LlmCompleteOptions,
+  setCursor: (next: number) => void,
+): PickedScript {
+  for (let i = cursor; i < scripts.length; i++) {
+    const candidate = scripts[i];
+    if (!candidate) continue;
+    if (candidate.match === undefined || candidate.match(messages, options)) {
+      const advanceTo = i + 1;
+      return {
+        script: candidate,
+        commit: () => setCursor(advanceTo),
+      };
+    }
+  }
+  throw new Error('MockLlmProvider: script queue exhausted.');
 }
 
 function enforceBudget(


### PR DESCRIPTION
## Summary

Row 10 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md`.

`MockLlmProvider.completeSync` mixed three concerns in one body: queue-mode dispatch, match-or-error dispatch, the abort-signal early return, and budget enforcement. Pulled each strategy into a module-level helper so the dispatcher reads as a 5-line guard:

- `abortStub(model)` — builds the `'abort'` stub completion.
- `pickFromQueue(scripts, cursor, messages, options, setCursor)` — positional dispatch with deferred cursor commit.
- `pickFromMatchOrError(scripts, messages, options)` — strict zero/one/many match resolution.
- `runScript(picked, messages, options, defaultModel)` — budget check + completion build, shared by both modes.

## Complexity (eslint `complexity` rule, configured at 15)

Before → After:
- `completeSync` 13 → 4
- `pickScript` 9 → 2
- new `runScript` 10
- new `pickFromMatchOrError` 4
- new `pickFromQueue` 5
- new `abortStub` 1

All under the 15 ceiling.

> Note: the roadmap row quotes the original complexity as 25; the actual eslint number was 13. The split still removes the strategy mixing the row called out, so the refactor is worth doing on its own merits.

## No public API change

`MockLlmProvider`'s constructor, `complete`, `MockLlmProviderOptions`, and `MockLlmScript` are byte-identical. All 19 existing `tests/unit/ports/MockLlmProvider.test.ts` cases pass without modification. Error message text preserved verbatim.

## Out of scope

The `!` non-null assertion on the `match-or-error` `[only]` destructure (now in `pickFromMatchOrError`) is left in place — row 12 (`refactor/non-null-assertion-cleanups`) owns those sites.

## Test plan

- [x] `npx vitest run tests/unit/ports/MockLlmProvider` — 19/19 green
- [x] `npm run verify` — format / lint / typecheck / test (513) / build / docs all green
- [x] eslint `complexity` rule no longer flags any function in this file at default `max: 15`
- [x] No changeset (internal refactor, no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)