### PR TITLE
refactor(cognition): extract weightForRule helper from defaultPersonaBias

### DIFF
--- a/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
+++ b/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
@@ -83,6 +83,7 @@ end-to-end, with each PR Codex-reviewed and resolved before the next.
 | 18  | #96 | `feat/demo-richer-feature-vector`            | 13-dim feature vector (5 needs + 4 mood one-hot + 1 modifier-count + 3 recent-event counts); bundled baseline rebuilt at `[13, 16, 7]`; small library addition (`details.preModifierCount` snapshot). |
 | 19  | TBD | `feat/demo-prediction-strip`                 | SVG strip rendering per-tick softmax distribution + idle-threshold line, selected column highlighted; cognitionSwitcher subscribes to `AgentTicked` while in Learning mode. Demo-only. |
 | 20  | TBD | `feat/tfjs-detect-backend-and-picker`        | `TfjsReasoner.detectBestBackend` + `probeBackend` statics (minor bump); demo backend dropdown (`CPU` / `WASM` / `WebGL`) with localStorage persist + per-option availability probe; backend packages move to optional peer deps; tfjs adapter size budget 7 → 9 KB gzip. |
+| 11  | TBD | `refactor/persona-bias-extract-helper`       | `defaultPersonaBias` arrow's per-rule weight calc lifted into `weightForRule(rule, intentionType, traits)`; main arrow becomes a flat `TRAIT_RULES.reduce(...)`. No public surface change, no changeset. |
 
 ---
 
@@ -333,12 +334,20 @@ similar to row 7's pattern.
 Split queue-mode vs match-or-error strategies into two functions; the
 single 80-line body mixes both.
 
-### 11 — `personaBias` arrow complexity 16
+### 11 — `personaBias` arrow complexity 16 — **shipped**
 
 **Branch:** `refactor/persona-bias-extract-helper`
 
-Extract inner weight calculation as a named helper so the main arrow
-becomes a `map` over scored candidates.
+**As shipped:** the per-rule weight calculation in
+`src/cognition/personaBias.ts` was lifted into a module-level
+`weightForRule(rule, intentionType, traits): number` helper. The
+exported `defaultPersonaBias` arrow now reads as a flat
+`TRAIT_RULES.reduce((bias, rule) => bias + weightForRule(...), 0)` over
+the existing data-driven trait table — the same shape the row description
+called for, with the helper fronting the per-candidate evaluation. Public
+surface (the `defaultPersonaBias` export, the `PersonaBiasFn` type, and
+the `TRAIT_RULES` table) is byte-identical. No test changes (coverage
+flows through the existing `UrgencyReasoner` suite). No changeset.
 
 ### 12 — Non-null assertions cleanup
 

--- a/src/cognition/personaBias.ts
+++ b/src/cognition/personaBias.ts
@@ -50,14 +50,17 @@ const TRAIT_RULES: readonly TraitRule[] = [
   },
 ];
 
+// Per-rule contribution: zero when the matcher misses, otherwise the
+// trait's value scaled by its tuned weight. Pulled out so the dispatcher
+// stays a flat `reduce` and ESLint's complexity rule doesn't need to
+// climb back toward the 15-branch ceiling as new rules land.
+function weightForRule(rule: TraitRule, intentionType: string, traits: Persona['traits']): number {
+  if (!rule.matches(intentionType)) return 0;
+  return (traits[rule.trait] ?? 0) * PERSONA_TRAIT_WEIGHTS[rule.trait];
+}
+
 export const defaultPersonaBias: PersonaBiasFn = (intentionType, persona) => {
   if (!persona) return 0;
   const traits = persona.traits;
-  let bias = 0;
-  for (const rule of TRAIT_RULES) {
-    if (rule.matches(intentionType)) {
-      bias += (traits[rule.trait] ?? 0) * PERSONA_TRAIT_WEIGHTS[rule.trait];
-    }
-  }
-  return bias;
+  return TRAIT_RULES.reduce((bias, rule) => bias + weightForRule(rule, intentionType, traits), 0);
 };


### PR DESCRIPTION
## Summary

Row 11 of the [polish + harden roadmap](../blob/develop/docs/plans/2026-04-25-comprehensive-polish-and-harden.md). The per-rule weight calculation inside `defaultPersonaBias` is lifted into a named module-level helper so the dispatcher stays a flat `reduce` over `TRAIT_RULES` and ESLint's complexity rule has headroom as new rules land.

- Internal-only refactor of `src/cognition/personaBias.ts`. **No public API change** — `defaultPersonaBias` and `PersonaBiasFn` keep their byte-identical shapes; `TRAIT_RULES` (module-internal) is unchanged.
- Cyclomatic complexity stays comfortably below the ESLint cap of 15. (For reference: the file no longer appears in `npm run lint` output at all — the only remaining warnings are the pre-existing `CognitionPipeline.invokeSkillAction` complexity-16 + `scoreFailure` 6-param ones, out of scope here.)
- Tests untouched. The function is exercised through the existing `tests/unit/cognition/reasoning/UrgencyReasoner.test.ts` suite (7 tests in that file, 513 in the full run).
- Plan row 11 marked shipped in the same diff (under "What's already shipped" + the Track 3 section), per `feedback_docs_alongside_pr.md`.

**Bump:** none (internal refactor). **No changeset.**

## Test plan

- [x] `npm run verify` green locally (`format:check` + `lint` + `typecheck` + `test` 513/513 + `build` + `docs`).
- [x] `defaultPersonaBias` callers (`UrgencyReasoner`) untouched; existing tests cover the persona-bias path.
- [x] No new `Date.now()` / `Math.random()` / `setTimeout` introduced.

## Notes for review

- Helper is a `function` (module-level) rather than another `const = (…) => …` so V8 can name it in stack traces and `weightForRule` is hoist-friendly above the export.
- The doc comment on `weightForRule` calls out the explicit reason for the split (keep the dispatcher flat as new rules land) so a future reader doesn't re-inline it without context.