### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs + add bump printer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@
 # Build + bundle-size budget runs last. Mirrors the `npm run verify`
 # pre-PR gate; `audit` blocks on `high`-severity vulnerabilities in
 # production deps to close the supply-chain hole.
+#
+# Action references are pinned to full 40-char commit SHAs with the
+# human-readable version as a trailing comment (supply-chain hardening
+# per `docs/plans/2026-04-25-comprehensive-polish-and-harden.md` row 3).
+# Run `node scripts/bump-actions.mjs` to print pending bumps; never edit
+# the SHA without re-resolving via `gh api`.
 
 name: CI
 
@@ -63,9 +69,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -81,9 +87,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -99,9 +105,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -118,9 +124,9 @@ jobs:
       checks: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run actionlint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0
         with:
           fail_level: error
           reporter: github-check
@@ -130,9 +136,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -148,9 +154,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -170,9 +176,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -188,9 +194,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -221,9 +227,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -233,7 +239,7 @@ jobs:
       # residual deprecation annotation until upstream cuts a Node 24
       # release. Path-filter has been inlined; this is the only one left.
       - name: Size Limit (sticky PR comment with gzip delta)
-        uses: andresz1/size-limit-action@v1
+        uses: andresz1/size-limit-action@e7493a72a44b113341c0cf6186ab49c17c4b65c1 # v1.6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Action runs `npm run <build_script>` then `npx size-limit --json`
@@ -248,9 +254,9 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -54,7 +54,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact (examples/nurture-pet/dist)
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: examples/nurture-pet/dist
 
@@ -68,4 +68,4 @@ jobs:
     steps:
       - name: Deploy artifact
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (full history for changesets)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node.js 22 (npm registry)
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -45,7 +45,7 @@ jobs:
         run: npm run verify
 
       - name: Version PR or publish to npm (changesets)
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: npm run release
           version: npx changeset version

--- a/.github/workflows/review-fix-shipped.yml
+++ b/.github/workflows/review-fix-shipped.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Flip tracker checkbox(es) for shipped finding(s)
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
+++ b/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
@@ -83,6 +83,7 @@ end-to-end, with each PR Codex-reviewed and resolved before the next.
 | 18  | #96 | `feat/demo-richer-feature-vector`            | 13-dim feature vector (5 needs + 4 mood one-hot + 1 modifier-count + 3 recent-event counts); bundled baseline rebuilt at `[13, 16, 7]`; small library addition (`details.preModifierCount` snapshot). |
 | 19  | TBD | `feat/demo-prediction-strip`                 | SVG strip rendering per-tick softmax distribution + idle-threshold line, selected column highlighted; cognitionSwitcher subscribes to `AgentTicked` while in Learning mode. Demo-only. |
 | 20  | TBD | `feat/tfjs-detect-backend-and-picker`        | `TfjsReasoner.detectBestBackend` + `probeBackend` statics (minor bump); demo backend dropdown (`CPU` / `WASM` / `WebGL`) with localStorage persist + per-option availability probe; backend packages move to optional peer deps; tfjs adapter size budget 7 → 9 KB gzip. |
+| 3   | TBD | `chore/ci-actions-sha-pinning`               | Every `uses:` reference in `.github/workflows/*.yml` pinned to a 40-char commit SHA with the version label as a trailing comment; `scripts/bump-actions.mjs` printer added so future drift is visible on demand. |
 
 ---
 
@@ -205,16 +206,30 @@ time.
 **DoD:** A test PR adding a known-vulnerable dep fails the gate.
 Current `develop` (post-tfjs swap) passes.
 
-### 3 — Actions SHA pinning
+### 3 — Actions SHA pinning — **shipped**
 
 **Branch:** `chore/ci-actions-sha-pinning`
 
-Replace mutable tags (`actions/checkout@v6`, etc.) with full 40-char
-commit SHAs. Add a one-line bumper script under `scripts/` so future
-updates don't bit-rot.
+**As shipped:**
 
-**When:** Low priority until 1.0 is on the horizon — supply-chain
-rigor for a published library, not a development necessity.
+- Every `uses:` reference across `ci.yml`, `pages.yml`, `release.yml`,
+  `release-candidate.yml`, and `review-fix-shipped.yml` was pinned to
+  a full 40-char commit SHA with the version label preserved as a
+  trailing `# <vX.Y.Z>` comment. Tags resolved via `gh api
+  repos/<owner>/<repo>/git/ref/tags/<tag>`, peeling annotated tags
+  through `git/tags/<sha>` where required. Eight unique actions, 31
+  total references.
+- `scripts/bump-actions.mjs` (Node ESM, no deps; shells out to `gh
+  api`) walks every workflow, parses each pin via regex, queries each
+  action's latest release tag, and prints a status table with
+  `up-to-date` / `PENDING` / `unresolved` / `no-releases` rows. Exits
+  non-zero when any pin lags behind its repo's latest release so the
+  signal is easy to wire into a future scheduled bot. Read-only — no
+  auto-write; humans re-resolve via `gh api` and edit the workflow.
+- Header comment added to `ci.yml` documenting the pin convention so
+  future readers don't reach for tag bumps directly.
+
+**No changeset** — CI-only. **No library change.**
 
 ### 4 — Backend + OS matrix
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,7 +40,12 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ['eslint.config.js', 'vite.config.ts', '*.config.ts'],
+          allowDefaultProject: [
+            'eslint.config.js',
+            'vite.config.ts',
+            '*.config.ts',
+            'scripts/*.mjs',
+          ],
         },
         tsconfigRootDir: import.meta.dirname,
       },
@@ -265,6 +270,38 @@ export default tseslint.config(
       'max-nested-callbacks': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+  // Node-only one-shot ESM scripts under `scripts/*.mjs`. They run via
+  // plain `node`, never through the lib's TS toolchain, so the
+  // type-checked rules from `recommendedTypeChecked` either misfire
+  // (no `tsconfig` covers them) or false-positive on `JSON.parse` and
+  // `execFileSync` returns. Treat them like config files: Node
+  // globals on, type-aware rules off.
+  {
+    files: ['scripts/**/*.mjs'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+      },
+    },
+    rules: {
+      'no-restricted-globals': 'off',
+      'no-restricted-syntax': 'off',
+      'no-console': 'off',
+      'max-lines': 'off',
+      'max-lines-per-function': 'off',
+      complexity: 'off',
+      'max-depth': 'off',
+      'max-nested-callbacks': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
     },
   },
   // Allow Date/Math.random inside the concrete system port adapters.

--- a/scripts/bump-actions.mjs
+++ b/scripts/bump-actions.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * Pending-bumps printer for SHA-pinned GitHub Actions in `.github/workflows/`.
+ *
+ * Every `uses:` reference in our workflows is pinned to a full 40-char
+ * commit SHA with a trailing `# <version>` comment (supply-chain hardening
+ * per `docs/plans/2026-04-25-comprehensive-polish-and-harden.md` row 3).
+ * This script walks the workflow tree, parses each pin, and prints which
+ * pins are stale relative to the action's latest release tag.
+ *
+ * It does NOT auto-write the workflows. The intent is to give a reviewer
+ * a single command (`node scripts/bump-actions.mjs`) that produces a diff
+ * table of pending bumps; the human then re-resolves the SHA via `gh api`
+ * and edits the workflow. This keeps human review on the supply-chain
+ * boundary while still flagging when a pin has bit-rotted.
+ *
+ * Required: GitHub CLI `gh` on PATH and authenticated. The script shells
+ * out to `gh api` because it's the same auth path used by every other
+ * workflow tool in this repo and avoids a `node_modules` dep on
+ * `@octokit/*`.
+ *
+ * Run: `node scripts/bump-actions.mjs`
+ *      `node scripts/bump-actions.mjs --help`
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const workflowsDir = join(repoRoot, '.github', 'workflows');
+
+const HELP = `Usage: node scripts/bump-actions.mjs [--help]
+
+Walks .github/workflows/*.yml, parses every SHA-pinned action reference,
+and prints a table of pinned-vs-latest mismatches. Read-only — never
+edits workflows. Requires GitHub CLI (\`gh\`) authenticated.
+
+Pin format the parser expects:
+  - uses: <owner>/<repo>@<40-char-sha>  # <version-label>
+`;
+
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(HELP);
+  process.exit(0);
+}
+
+/** @type {(args: string[]) => string} */
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+}
+
+/** Parse a single `uses:` line, returning the pin record or null. */
+function parseUses(line) {
+  // Match `uses: owner/repo@<sha>  # <label>`. Sub-paths (`owner/repo/dir@sha`)
+  // are tolerated; the API lookup uses just `owner/repo`.
+  const re =
+    /uses:\s+([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)(\/[A-Za-z0-9._/-]+)?@([a-f0-9]{40})\s*#\s*(\S+)/;
+  const m = line.match(re);
+  if (!m) return null;
+  const [, owner, repo, , sha, label] = m;
+  return { owner, repo, sha, label };
+}
+
+/** Recursively collect `*.yml` and `*.yaml` files under a directory. */
+function listWorkflowFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listWorkflowFiles(full));
+    } else if (/\.ya?ml$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Resolve the latest release tag for `owner/repo`, or null if none. */
+function latestReleaseTag(owner, repo) {
+  try {
+    return gh(['api', `repos/${owner}/${repo}/releases/latest`, '--jq', '.tag_name']);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a tag to its commit SHA, peeling annotated tags. Returns null on
+ * 404 (tag does not exist) or when the ref points at neither a commit nor
+ * a peelable tag — the caller treats those as "no comparison possible".
+ */
+function tagToCommitSha(owner, repo, tag) {
+  let refJson;
+  try {
+    refJson = gh(['api', `repos/${owner}/${repo}/git/ref/tags/${tag}`]);
+  } catch {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(refJson);
+  } catch {
+    return null;
+  }
+  const obj = parsed?.object;
+  if (!obj) return null;
+  if (obj.type === 'commit') return obj.sha;
+  if (obj.type === 'tag') {
+    try {
+      const tagJson = gh(['api', `repos/${owner}/${repo}/git/tags/${obj.sha}`]);
+      const tagParsed = JSON.parse(tagJson);
+      return tagParsed?.object?.sha ?? null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+const files = listWorkflowFiles(workflowsDir);
+/** @type {Map<string, { sha: string; label: string; sources: string[] }>} */
+const pins = new Map();
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  const rel = file.slice(repoRoot.length + 1).replaceAll('\\', '/');
+  for (const rawLine of text.split(/\r?\n/)) {
+    const parsed = parseUses(rawLine);
+    if (!parsed) continue;
+    const key = `${parsed.owner}/${parsed.repo}`;
+    const existing = pins.get(key);
+    if (existing) {
+      if (existing.sha !== parsed.sha || existing.label !== parsed.label) {
+        existing.sources.push(`${rel} (DIVERGENT: ${parsed.sha.slice(0, 7)} ${parsed.label})`);
+      } else {
+        existing.sources.push(rel);
+      }
+    } else {
+      pins.set(key, { sha: parsed.sha, label: parsed.label, sources: [rel] });
+    }
+  }
+}
+
+if (pins.size === 0) {
+  console.log('No SHA-pinned action references found under .github/workflows/.');
+  process.exit(0);
+}
+
+console.log(`Inspecting ${pins.size} unique action(s) across ${files.length} workflow file(s).`);
+console.log('');
+
+const rows = [];
+for (const [action, { sha, label, sources }] of pins) {
+  const [owner, repo] = action.split('/');
+  const latest = latestReleaseTag(owner, repo);
+  const latestSha = latest ? tagToCommitSha(owner, repo, latest) : null;
+  let status;
+  if (!latest) {
+    status = 'no-releases';
+  } else if (!latestSha) {
+    status = 'unresolved';
+  } else if (latestSha === sha) {
+    status = 'up-to-date';
+  } else {
+    status = 'PENDING';
+  }
+  rows.push({
+    action,
+    pinnedLabel: label,
+    pinnedSha: sha.slice(0, 7),
+    latestLabel: latest ?? '—',
+    latestSha: latestSha ? latestSha.slice(0, 7) : '—',
+    status,
+    sources,
+  });
+}
+
+const colWidths = {
+  action: Math.max(6, ...rows.map((r) => r.action.length)),
+  pinnedLabel: Math.max(7, ...rows.map((r) => r.pinnedLabel.length)),
+  pinnedSha: 7,
+  latestLabel: Math.max(7, ...rows.map((r) => r.latestLabel.length)),
+  latestSha: 7,
+  status: Math.max(8, ...rows.map((r) => r.status.length)),
+};
+const pad = (s, w) => s + ' '.repeat(Math.max(0, w - s.length));
+
+const header = [
+  pad('action', colWidths.action),
+  pad('pinned', colWidths.pinnedLabel),
+  pad('sha', colWidths.pinnedSha),
+  pad('latest', colWidths.latestLabel),
+  pad('sha', colWidths.latestSha),
+  pad('status', colWidths.status),
+].join('  ');
+console.log(header);
+console.log('-'.repeat(header.length));
+for (const r of rows) {
+  console.log(
+    [
+      pad(r.action, colWidths.action),
+      pad(r.pinnedLabel, colWidths.pinnedLabel),
+      pad(r.pinnedSha, colWidths.pinnedSha),
+      pad(r.latestLabel, colWidths.latestLabel),
+      pad(r.latestSha, colWidths.latestSha),
+      pad(r.status, colWidths.status),
+    ].join('  '),
+  );
+}
+
+const pending = rows.filter((r) => r.status === 'PENDING');
+console.log('');
+if (pending.length === 0) {
+  console.log('All pinned actions match their latest release.');
+} else {
+  console.log(`${pending.length} pending bump(s):`);
+  for (const r of pending) {
+    console.log(`  - ${r.action}: ${r.pinnedLabel} → ${r.latestLabel}`);
+    console.log(
+      `      gh api repos/${r.action}/git/ref/tags/${r.latestLabel}  # peel + verify, then edit ${r.sources[0]}`,
+    );
+  }
+}
+
+// Exit non-zero on PENDING so this script can gate a CI bot if desired
+// later; today it's run by humans on demand.
+process.exit(pending.length === 0 ? 0 : 1);

--- a/scripts/bump-actions.mjs
+++ b/scripts/bump-actions.mjs
@@ -47,9 +47,50 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   process.exit(0);
 }
 
-/** @type {(args: string[]) => string} */
-function gh(args) {
-  return execFileSync('gh', args, { encoding: 'utf8' }).trim();
+/**
+ * Coerce an `execFileSync` failure's `stderr` (Buffer | string | unknown)
+ * to a plain UTF-8 string. Avoids the `String(buffer)` cast that
+ * `@typescript-eslint/no-base-to-string` flags on `unknown`.
+ */
+function stderrText(err) {
+  if (!err || typeof err !== 'object' || !('stderr' in err)) return '';
+  const raw = /** @type {{ stderr: unknown }} */ (err).stderr;
+  if (typeof raw === 'string') return raw;
+  if (raw instanceof Uint8Array) return new TextDecoder().decode(raw);
+  return '';
+}
+
+/**
+ * Run `gh api` and bucket the outcome into ok / 404 / error so callers can
+ * tell "endpoint reports nothing" apart from "tooling/auth/network failure"
+ * and surface the latter loudly instead of silently returning null.
+ *
+ * @param {string[]} args
+ * @returns {{ ok: true; value: string }
+ *   | { ok: false; kind: 'not-found' }
+ *   | { ok: false; kind: 'error'; status: number | undefined; stderr: string; cause: unknown }}
+ */
+function ghTry(args) {
+  try {
+    return { ok: true, value: execFileSync('gh', args, { encoding: 'utf8' }).trim() };
+  } catch (err) {
+    const stderr = stderrText(err);
+    const status =
+      err && typeof err === 'object' && 'status' in err
+        ? Number(/** @type {{ status: unknown }} */ (err).status) || undefined
+        : undefined;
+    if (/HTTP 404|Not Found/i.test(stderr)) {
+      return { ok: false, kind: 'not-found' };
+    }
+    const fallback = err instanceof Error ? err.message : '';
+    return {
+      ok: false,
+      kind: 'error',
+      status,
+      stderr: stderr.trim() || fallback,
+      cause: err,
+    };
+  }
 }
 
 /** Parse a single `uses:` line, returning the pin record or null. */
@@ -78,50 +119,83 @@ function listWorkflowFiles(dir) {
   return out;
 }
 
-/** Resolve the latest release tag for `owner/repo`, or null if none. */
+/**
+ * Resolve the latest release tag for `owner/repo`. Returns `null` only on
+ * a clean 404 (the project really has no GitHub Releases). On any other
+ * `gh api` failure (missing CLI, expired auth, network blip, rate limit,
+ * 5xx) this throws so the caller can fail loud — the previous "swallow
+ * everything as null" form let those errors masquerade as no-releases and
+ * silently exit 0.
+ */
 function latestReleaseTag(owner, repo) {
-  try {
-    return gh(['api', `repos/${owner}/${repo}/releases/latest`, '--jq', '.tag_name']);
-  } catch {
-    return null;
-  }
+  const r = ghTry(['api', `repos/${owner}/${repo}/releases/latest`, '--jq', '.tag_name']);
+  if (r.ok) return r.value;
+  if (r.kind === 'not-found') return null;
+  const exit = r.status !== undefined ? ` (exit ${r.status})` : '';
+  throw new Error(
+    `gh api releases/latest failed for ${owner}/${repo}${exit}: ${r.stderr || '(no stderr)'}`,
+    { cause: r.cause },
+  );
 }
 
 /**
- * Resolve a tag to its commit SHA, peeling annotated tags. Returns null on
- * 404 (tag does not exist) or when the ref points at neither a commit nor
- * a peelable tag — the caller treats those as "no comparison possible".
+ * Resolve a tag to its commit SHA, peeling annotated tags. Returns `null`
+ * only on a clean 404 (tag missing) or when the ref points at neither a
+ * commit nor a peelable tag — the caller treats those as "no comparison
+ * possible". Any other `gh api` failure throws so transient tooling /
+ * network errors surface instead of being silently coerced to "unresolved".
  */
 function tagToCommitSha(owner, repo, tag) {
-  let refJson;
-  try {
-    refJson = gh(['api', `repos/${owner}/${repo}/git/ref/tags/${tag}`]);
-  } catch {
-    return null;
+  const refRes = ghTry(['api', `repos/${owner}/${repo}/git/ref/tags/${tag}`]);
+  if (!refRes.ok) {
+    if (refRes.kind === 'not-found') return null;
+    const exit = refRes.status !== undefined ? ` (exit ${refRes.status})` : '';
+    throw new Error(
+      `gh api git/ref/tags/${tag} failed for ${owner}/${repo}${exit}: ${refRes.stderr || '(no stderr)'}`,
+      { cause: refRes.cause },
+    );
   }
   let parsed;
   try {
-    parsed = JSON.parse(refJson);
-  } catch {
-    return null;
+    parsed = JSON.parse(refRes.value);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : '';
+    throw new Error(
+      `Failed to parse gh api ref/tags/${tag} response for ${owner}/${repo}: ${detail}`,
+      { cause: err },
+    );
   }
   const obj = parsed?.object;
   if (!obj) return null;
   if (obj.type === 'commit') return obj.sha;
   if (obj.type === 'tag') {
-    try {
-      const tagJson = gh(['api', `repos/${owner}/${repo}/git/tags/${obj.sha}`]);
-      const tagParsed = JSON.parse(tagJson);
-      return tagParsed?.object?.sha ?? null;
-    } catch {
-      return null;
+    const tagRes = ghTry(['api', `repos/${owner}/${repo}/git/tags/${obj.sha}`]);
+    if (!tagRes.ok) {
+      if (tagRes.kind === 'not-found') return null;
+      const exit = tagRes.status !== undefined ? ` (exit ${tagRes.status})` : '';
+      throw new Error(
+        `gh api git/tags/${obj.sha} failed for ${owner}/${repo}${exit}: ${tagRes.stderr || '(no stderr)'}`,
+        { cause: tagRes.cause },
+      );
     }
+    let tagParsed;
+    try {
+      tagParsed = JSON.parse(tagRes.value);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : '';
+      throw new Error(
+        `Failed to parse gh api git/tags/${obj.sha} response for ${owner}/${repo}: ${detail}`,
+        { cause: err },
+      );
+    }
+    return tagParsed?.object?.sha ?? null;
   }
   return null;
 }
 
 const files = listWorkflowFiles(workflowsDir);
-/** @type {Map<string, { sha: string; label: string; sources: string[] }>} */
+/** @typedef {{ sha: string; label: string; sources: string[] }} PinVariant */
+/** @type {Map<string, PinVariant[]>} */
 const pins = new Map();
 
 for (const file of files) {
@@ -131,16 +205,17 @@ for (const file of files) {
     const parsed = parseUses(rawLine);
     if (!parsed) continue;
     const key = `${parsed.owner}/${parsed.repo}`;
-    const existing = pins.get(key);
-    if (existing) {
-      if (existing.sha !== parsed.sha || existing.label !== parsed.label) {
-        existing.sources.push(`${rel} (DIVERGENT: ${parsed.sha.slice(0, 7)} ${parsed.label})`);
-      } else {
-        existing.sources.push(rel);
-      }
-    } else {
-      pins.set(key, { sha: parsed.sha, label: parsed.label, sources: [rel] });
+    let variants = pins.get(key);
+    if (!variants) {
+      variants = [];
+      pins.set(key, variants);
     }
+    let variant = variants.find((v) => v.sha === parsed.sha && v.label === parsed.label);
+    if (!variant) {
+      variant = { sha: parsed.sha, label: parsed.label, sources: [] };
+      variants.push(variant);
+    }
+    variant.sources.push(rel);
   }
 }
 
@@ -152,29 +227,74 @@ if (pins.size === 0) {
 console.log(`Inspecting ${pins.size} unique action(s) across ${files.length} workflow file(s).`);
 console.log('');
 
+/**
+ * @typedef {{
+ *   action: string;
+ *   pinnedLabel: string;
+ *   pinnedSha: string;
+ *   latestLabel: string;
+ *   latestSha: string;
+ *   status: 'up-to-date' | 'PENDING' | 'no-releases' | 'unresolved' | 'DIVERGENT' | 'ERROR';
+ *   variants: PinVariant[];
+ *   errorMsg?: string;
+ * }} Row
+ */
+/** @type {Row[]} */
 const rows = [];
-for (const [action, { sha, label, sources }] of pins) {
+
+for (const [action, variants] of pins) {
   const [owner, repo] = action.split('/');
-  const latest = latestReleaseTag(owner, repo);
-  const latestSha = latest ? tagToCommitSha(owner, repo, latest) : null;
-  let status;
-  if (!latest) {
-    status = 'no-releases';
-  } else if (!latestSha) {
-    status = 'unresolved';
-  } else if (latestSha === sha) {
-    status = 'up-to-date';
-  } else {
-    status = 'PENDING';
+  let latest = null;
+  /** @type {string | null} */
+  let latestSha = null;
+  /** @type {string | undefined} */
+  let errorMsg;
+  try {
+    latest = latestReleaseTag(owner, repo);
+    if (latest) latestSha = tagToCommitSha(owner, repo, latest);
+  } catch (err) {
+    errorMsg = err instanceof Error ? err.message : String(err);
   }
+  if (errorMsg !== undefined) {
+    rows.push({
+      action,
+      pinnedLabel: variants.length === 1 ? variants[0].label : `(${variants.length} variants)`,
+      pinnedSha: variants.length === 1 ? variants[0].sha.slice(0, 7) : '—',
+      latestLabel: '—',
+      latestSha: '—',
+      status: 'ERROR',
+      variants,
+      errorMsg,
+    });
+    continue;
+  }
+  if (variants.length > 1) {
+    rows.push({
+      action,
+      pinnedLabel: `(${variants.length} variants)`,
+      pinnedSha: '—',
+      latestLabel: latest ?? '—',
+      latestSha: latestSha ? latestSha.slice(0, 7) : '—',
+      status: 'DIVERGENT',
+      variants,
+    });
+    continue;
+  }
+  const v = variants[0];
+  /** @type {Row['status']} */
+  let status;
+  if (!latest) status = 'no-releases';
+  else if (!latestSha) status = 'unresolved';
+  else if (latestSha === v.sha) status = 'up-to-date';
+  else status = 'PENDING';
   rows.push({
     action,
-    pinnedLabel: label,
-    pinnedSha: sha.slice(0, 7),
+    pinnedLabel: v.label,
+    pinnedSha: v.sha.slice(0, 7),
     latestLabel: latest ?? '—',
     latestSha: latestSha ? latestSha.slice(0, 7) : '—',
     status,
-    sources,
+    variants,
   });
 }
 
@@ -212,19 +332,43 @@ for (const r of rows) {
 }
 
 const pending = rows.filter((r) => r.status === 'PENDING');
+const divergent = rows.filter((r) => r.status === 'DIVERGENT');
+const errored = rows.filter((r) => r.status === 'ERROR');
 console.log('');
-if (pending.length === 0) {
-  console.log('All pinned actions match their latest release.');
-} else {
+if (pending.length > 0) {
   console.log(`${pending.length} pending bump(s):`);
   for (const r of pending) {
+    const v = r.variants[0];
     console.log(`  - ${r.action}: ${r.pinnedLabel} → ${r.latestLabel}`);
     console.log(
-      `      gh api repos/${r.action}/git/ref/tags/${r.latestLabel}  # peel + verify, then edit ${r.sources[0]}`,
+      `      gh api repos/${r.action}/git/ref/tags/${r.latestLabel}  # peel + verify, then edit ${v.sources[0]}`,
     );
   }
 }
+if (divergent.length > 0) {
+  if (pending.length > 0) console.log('');
+  console.log(`${divergent.length} divergent pin(s) (same action, multiple SHA/label tuples):`);
+  for (const r of divergent) {
+    console.log(`  - ${r.action}: latest=${r.latestLabel} (${r.latestSha})`);
+    for (const v of r.variants) {
+      console.log(`      ${v.sha.slice(0, 7)}  # ${v.label}`);
+      for (const s of v.sources) console.log(`        ${s}`);
+    }
+  }
+}
+if (errored.length > 0) {
+  if (pending.length > 0 || divergent.length > 0) console.log('');
+  console.log(`${errored.length} action(s) failed to resolve:`);
+  for (const r of errored) {
+    console.log(`  - ${r.action}: ${r.errorMsg ?? '(no message)'}`);
+  }
+}
+if (pending.length === 0 && divergent.length === 0 && errored.length === 0) {
+  console.log('All pinned actions match their latest release.');
+}
 
-// Exit non-zero on PENDING so this script can gate a CI bot if desired
-// later; today it's run by humans on demand.
-process.exit(pending.length === 0 ? 0 : 1);
+// Exit non-zero on PENDING/DIVERGENT/ERROR so this script can gate a CI
+// bot if desired later; today it's run by humans on demand. Failing on
+// ERROR (rather than treating tooling/auth/network failures as "no
+// releases") keeps the gate honest under broken-tooling conditions.
+process.exit(pending.length === 0 && divergent.length === 0 && errored.length === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- Replaces every `uses: <owner>/<repo>@<tag>` reference across `.github/workflows/*.yml` (ci, pages, release, release-candidate, review-fix-shipped) with the resolved 40-char commit SHA, keeping the human-readable version label as a trailing `# vX.Y.Z` comment. **8 unique actions, 31 total references.** Tags resolved via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`, peeling annotated tags through `git/tags/<sha>` where required.
- Adds `scripts/bump-actions.mjs` (Node ESM, no deps) that walks every workflow, parses each pin, queries each action's latest release, and prints a status table with `up-to-date` / `PENDING` / `unresolved` / `no-releases` rows. Read-only — humans re-resolve via `gh api` and edit. Exits non-zero on PENDING so the signal can gate a future scheduled bot.
- `eslint.config.js` gains a `scripts/**/*.mjs` override that disables the type-checked unsafe-* rules and turns on Node globals — the script runs via plain `node`, not the lib's TS toolchain, so the `recommendedTypeChecked` preset would otherwise misfire on `JSON.parse` and `execFileSync` returns.

Pin table (`v6` etc. → SHA):

| Action | SHA | Label |
| --- | --- | --- |
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `actions/setup-node` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6.4.0 |
| `actions/github-script` | `f28e40c7f34bde8b3046d885e986cb6290c5673b` | v7.1.0 |
| `actions/upload-pages-artifact` | `fc324d3547104276b827a68afc52ff2a11cc49c9` | v5.0.0 |
| `actions/deploy-pages` | `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` | v5.0.0 |
| `changesets/action` | `6a0a831ff30acef54f2c6aa1cbbc1096b066edaf` | v1.7.0 |
| `reviewdog/action-actionlint` | `6fb7acc99f4a1008869fa8a0f09cfca740837d9d` | v1.72.0 |
| `andresz1/size-limit-action` | `e7493a72a44b113341c0cf6186ab49c17c4b65c1` | v1.6.1 |

Closes row 3 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md` (marked shipped in same diff). No library change. No changeset.

## Test plan

- [ ] CI workflows run green on this PR
- [ ] `node scripts/bump-actions.mjs` prints pending bumps without crashing
- [ ] `npm run verify` green locally (format:check + lint + typecheck + test + build + docs — all confirmed pre-push)