### PR TITLE
chore(deps): pin peer dep minimums to tested versions; close row 12

### DIFF
--- a/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
+++ b/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
@@ -86,6 +86,8 @@ end-to-end, with each PR Codex-reviewed and resolved before the next.
 | 3   | TBD | `chore/ci-actions-sha-pinning`               | Every `uses:` reference in `.github/workflows/*.yml` pinned to a 40-char commit SHA with the version label as a trailing comment; `scripts/bump-actions.mjs` printer added so future drift is visible on demand. |
 | 10  | #108 | `refactor/mock-llm-completeSync-split`      | `MockLlmProvider.completeSync` 13 → 4 via `pickFromQueue` / `pickFromMatchOrError` / `runScript` / `abortStub` module-level helpers; no public API change; 19 tests untouched. |
 | 11  | #109 | `refactor/persona-bias-extract-helper`      | `defaultPersonaBias` arrow's per-rule weight calc lifted into `weightForRule(rule, intentionType, traits)`; main arrow becomes a flat `TRAIT_RULES.reduce(...)`. No public surface change, no changeset. |
+| 12  | —   | `refactor/non-null-assertion-cleanups`       | Closed as obsolete. All 4 target sites (`TfjsReasoner.ts:34`, `TfjsSnapshot.ts:45`, `MockLlmProvider.ts:166,173`) already non-null-assertion-free post-PR #108 (`MockLlmProvider` split) and earlier tfjs cleanups. `npm run lint` reports 0 non-null-assertion warnings repo-wide. No code change needed. |
+| 22  | TBD | `chore/peer-deps-pin-minimums`               | Replaced `"*"` peer ranges for `@anthropic-ai/sdk` / `openai` / `sim-ecs` / `excalibur` with real semver minimums. `excalibur` pinned to `^0.32.0` (matches devDeps). The other three are aspirational forward-compat hooks (no actual `import` from `src/` / `tests/` / `examples/`); pinned to latest stable major (`@anthropic-ai/sdk ^0.91.0`, `openai ^6.0.0`, `sim-ecs ^0.6.0`) so consumers don't accept arbitrary majors. No changeset (pre-1.0 metadata-only). |
 
 ---
 
@@ -365,16 +367,17 @@ surface (the `defaultPersonaBias` export, the `PersonaBiasFn` type, and
 the `TRAIT_RULES` table) is byte-identical. No test changes (coverage
 flows through the existing `UrgencyReasoner` suite). No changeset.
 
-### 12 — Non-null assertions cleanup
+### 12 — Non-null assertions cleanup — **shipped (obsolete)**
 
 **Branch:** `refactor/non-null-assertion-cleanups`
 
-Four sites: `TfjsReasoner.ts:34` (shuffle), `TfjsSnapshot.ts:45`
-(byte copy), `MockLlmProvider.ts:166,173` (post-length-check). All
-idiomatic under `noUncheckedIndexedAccess`. Either rewrite as
-`for…of` (eliminates the index-access narrowing) or wrap in an
-`assertDefined` helper for documentation value. Not urgent — kept on
-the menu so the lint warning count keeps shrinking.
+**As shipped:** all four target sites — `TfjsReasoner.ts:34`,
+`TfjsSnapshot.ts:45`, `MockLlmProvider.ts:166,173` — were already
+non-null-assertion-free as of develop @ f6e4464. PR #108
+(`MockLlmProvider.completeSync` split) removed the two `MockLlm`
+sites; the tfjs sites had been cleaned in earlier adapter work.
+`npm run lint` reports 0 `@typescript-eslint/no-non-null-assertion`
+warnings repo-wide. Closed as obsolete; no code change needed.
 
 ---
 
@@ -702,15 +705,27 @@ baseline, set at -2% floor.
 
 **Cost:** XS.
 
-### 22 — Peer deps pin minimums
+### 22 — Peer deps pin minimums — **shipped**
 
 **Branch:** `chore/peer-deps-pin-minimums`
 
-`package.json:117,123,124,120` — `@anthropic-ai/sdk`, `openai`,
-`sim-ecs`, `excalibur` all declare `"*"`. Allowing any major version
-is risky for consumers. Pin minimums (e.g. `^0.32.0` for excalibur,
-`^0.27.0` for Anthropic SDK, etc. — match the actually-tested
-versions).
+**As shipped:** `package.json#peerDependencies` no longer accepts
+arbitrary majors for the four wide-open peers.
+
+- `excalibur`: `*` → `^0.32.0` (matches `devDependencies` floor —
+  the version the integrations adapter is actually tested against).
+- `@anthropic-ai/sdk`: `*` → `^0.91.0` (latest stable; not in
+  `devDependencies` because no concrete `AnthropicLlmProvider`
+  ships in v1 — port + `MockLlmProvider` only).
+- `openai`: `*` → `^6.0.0` (same rationale; no concrete OpenAI
+  adapter ships in v1).
+- `sim-ecs`: `*` → `^0.6.0` (forward-compat hook; no `sim-ecs`
+  integration ships in v1, only mentioned as a future Phase B
+  surface).
+
+The latter three remain in `peerDependenciesMeta` as `optional` so
+consumers without an LLM / ECS path don't see install warnings.
+Metadata-only change; pre-1.0 has no consumers, so no changeset.
 
 **Cost:** S.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,17 +40,17 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@anthropic-ai/sdk": "*",
+        "@anthropic-ai/sdk": "^0.91.0",
         "@tensorflow/tfjs-backend-cpu": "^4.22.0",
         "@tensorflow/tfjs-backend-wasm": "^4.22.0",
         "@tensorflow/tfjs-backend-webgl": "^4.22.0",
         "@tensorflow/tfjs-core": "^4.22.0",
         "@tensorflow/tfjs-layers": "^4.22.0",
-        "excalibur": "*",
+        "excalibur": "^0.32.0",
         "js-son-agent": "*",
         "mistreevous": "^4.0.0",
-        "openai": "*",
-        "sim-ecs": "*"
+        "openai": "^6.0.0",
+        "sim-ecs": "^0.6.0"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -117,17 +117,17 @@
     "vitest": "^4.1.4"
   },
   "peerDependencies": {
-    "@anthropic-ai/sdk": "*",
+    "@anthropic-ai/sdk": "^0.91.0",
     "@tensorflow/tfjs-backend-cpu": "^4.22.0",
     "@tensorflow/tfjs-backend-wasm": "^4.22.0",
     "@tensorflow/tfjs-backend-webgl": "^4.22.0",
     "@tensorflow/tfjs-core": "^4.22.0",
     "@tensorflow/tfjs-layers": "^4.22.0",
-    "excalibur": "*",
+    "excalibur": "^0.32.0",
     "js-son-agent": "*",
     "mistreevous": "^4.0.0",
-    "openai": "*",
-    "sim-ecs": "*"
+    "openai": "^6.0.0",
+    "sim-ecs": "^0.6.0"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {


### PR DESCRIPTION
## Summary

Closes roadmap rows **22** + **12** (`docs/plans/2026-04-25-comprehensive-polish-and-harden.md`).

### Row 22 — `chore/peer-deps-pin-minimums`

`package.json#peerDependencies` previously declared `"*"` for four peers, allowing any major version. Tightened to real semver ranges:

| Peer | Was | Now | Source of truth |
| --- | --- | --- | --- |
| `excalibur` | `*` | `^0.32.0` | `devDependencies."excalibur"` (the version the integration adapter is tested against) |
| `@anthropic-ai/sdk` | `*` | `^0.91.0` | latest stable on npm at pin time (not in `devDependencies` — see flag below) |
| `openai` | `*` | `^6.0.0` | latest stable major on npm at pin time (not in `devDependencies` — see flag below) |
| `sim-ecs` | `*` | `^0.6.0` | latest stable major on npm at pin time (not in `devDependencies` — see flag below) |

**Flag — three of four peers have no actual runtime usage.** Only `excalibur` is exercised by the codebase (via `src/integrations/excalibur/`). `@anthropic-ai/sdk`, `openai`, and `sim-ecs` are NOT imported anywhere in `src/`, `tests/`, or `examples/` (verified via `grep -rn "from '<pkg>'"`). They're forward-compat hooks for the deferred work captured in the plan's "Out of scope" section:

- LLM adapters (`AnthropicLlmProvider`, `OpenAiLlmProvider`) — Phase B; v1 ships only the `LlmProviderPort` + `MockLlmProvider`.
- `sim-ecs` integration — Phase B.

Per the row 22 task instruction ("either drop the peer dep entirely (if unused) or pin to the latest stable major"), I pinned to latest stable major rather than dropping. Dropping would change the documented public surface (the port docstrings reference these adapters by name) and force a follow-up PR when Phase B adapters land. All three remain `optional: true` in `peerDependenciesMeta`, so consumers without an LLM / ECS path see no install warnings.

### Row 12 — `refactor/non-null-assertion-cleanups` (closed obsolete, docs rider)

The four original target sites — `TfjsReasoner.ts:34`, `TfjsSnapshot.ts:45`, `MockLlmProvider.ts:166,173` — are already non-null-assertion-free as of `develop @ f6e4464`. PR #108's `MockLlmProvider.completeSync` split removed the two `MockLlm` sites; the tfjs sites had been cleaned in earlier adapter work. `npm run lint` confirms 0 `@typescript-eslint/no-non-null-assertion` warnings repo-wide. No code change needed; row marked shipped via natural attrition in the plan diff.

### Changeset

None. Metadata-only change; pre-1.0 has no shipped npm consumers (`MEMORY.md → project_v1_release_hold.md`).

## Test plan

- [x] `npm install` updates `package-lock.json` cleanly
- [x] `npm run format:check` clean
- [x] `npm run lint` 0 errors (2 unrelated pre-existing warnings on `CognitionPipeline.ts` complexity / max-params; 0 non-null-assertion warnings)
- [x] `npm run typecheck` clean (peer-dep tightening introduced no incompatibilities since none of the three pinned packages are imported)
- [x] `npm run test` 513/513 pass
- [x] `npm run build` clean; all entry points within `size-limit` budgets
- [x] `npm run docs` typedoc generates 0 errors

## Notes for review

- Heads-up: rows 4 + 21 are running in parallel agents. All three will mark themselves shipped in the same plan file — expect a 1-line plan-table conflict after the first one lands. Plan-rebase: order rows numerically, run verify, push.
- Did NOT touch `src/` per the row 22 scope.
- Did NOT touch `js-son-agent`'s peer range (still `"*"`); not in scope per the task brief, even though the same wildcard pattern applies. Can sweep in a follow-up if desired.