### PR TITLE
chore(test): enforce vitest coverage thresholds at -2% floor

### DIFF
--- a/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
+++ b/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
@@ -154,7 +154,7 @@ land in parallel batches. Tooling closes out.
 | 18  | demo     | `feat/demo-richer-feature-vector`                   | Add mood + modifier-count + recent-events to the feature vector                  | S     | —     |
 | 19  | demo     | `feat/demo-prediction-strip`                        | HUD strip showing last scalar output + `URGENCY_THRESHOLD` line                  | S     | —     |
 | 20  | lib      | `feat/tfjs-detect-backend-and-picker`               | `TfjsReasoner.detectBestBackend()` + demo backend dropdown                       | S+S   | minor |
-| 21  | tooling  | `chore/vitest-coverage-thresholds`                  | Set coverage floors (lines/functions/branches/statements) at current −2%        | XS    | —     |
+| 21  | tooling  | `chore/vitest-coverage-thresholds`                  | Set coverage floors (lines/functions/branches/statements) at current −2% — **shipped** | XS    | —     |
 | 22  | tooling  | `chore/peer-deps-pin-minimums`                      | `excalibur`, `openai`, `anthropic-sdk`, `sim-ecs` `*` → real semver ranges       | S     | —     |
 | 23  | docs     | `docs/result-jsdoc`                                 | JSDoc on `isOk` / `isErr` / `map` / `mapErr` / `andThen` / `unwrap`              | XS    | —     |
 | 24  | docs     | `docs/intention-candidate-discriminant`             | Semantic JSDoc on `IntentionCandidate.discriminant` (range, tie-break)           | XS    | —     |
@@ -691,14 +691,25 @@ getter needed.
 
 ## Track 5 — Tooling (rows 21–22)
 
-### 21 — Vitest coverage thresholds
+### 21 — Vitest coverage thresholds — **shipped**
 
 **Branch:** `chore/vitest-coverage-thresholds`
 
-`vite.config.ts:156-161` sets up the reporter but doesn't enforce
-`thresholds: { lines, functions, branches, statements }`. CI runs
-coverage (`test:coverage`) but a drop wouldn't fail. Measure current
-baseline, set at -2% floor.
+**As shipped:**
+
+- Baseline measured on develop @ `f6e4464`: statements 76.22% /
+  branches 66.61% / functions 85.42% / lines 77.78%.
+- `vite.config.ts` `coverage` block now carries a `thresholds`
+  entry set at floor(measured − 2): `statements: 74`, `branches:
+  64`, `functions: 83`, `lines: 75`. Vitest exits non-zero when
+  coverage dips below any of them, so CI's `test:coverage` job
+  starts catching regressions instead of silently shrugging.
+- A trailing comment cites the baseline date + commit so future
+  bumps know what to compare against.
+- Verified the gate fires: temporarily bumping `statements` to 79
+  produced `ERROR: Coverage for statements (76.22%) does not meet
+  global threshold (79%)` and exit code 1 (reverted before
+  commit).
 
 **Cost:** XS.
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -167,6 +167,17 @@ export default defineConfig({
       reporter: ['text', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/index.ts', 'src/**/*.d.ts'],
+      // Baseline 2026-04-25 (commit f6e4464): statements 76.22 / branches
+      // 66.61 / functions 85.42 / lines 77.78. Thresholds set at
+      // floor(measured - 2) so routine PRs don't trip the gate but a
+      // coverage regression beyond ~2pp fails the build. Bump these in
+      // step with measured improvements (cite the new baseline + commit).
+      thresholds: {
+        statements: 74,
+        branches: 64,
+        functions: 83,
+        lines: 75,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

`vite.config.ts` configures the v8 coverage reporter but never set a `thresholds` block, so `npm run test:coverage` reported coverage numbers in CI without ever failing on a regression. This PR pins per-metric floors at `floor(measured - 2)` so routine PRs keep passing but a >~2pp drop in any of the four metrics fails the gate.

## Baseline (develop @ `f6e4464`)

| Metric     | Measured | Threshold (floor − 2) |
| ---------- | -------- | --------------------- |
| Statements | 76.22%   | 74                    |
| Branches   | 66.61%   | 64                    |
| Functions  | 85.42%   | 83                    |
| Lines      | 77.78%   | 75                    |

A trailing comment above the `thresholds` block cites the baseline date + commit so future bumps know what to compare against.

## Gate-fires verification

Temporarily bumped `statements` from 74 → 79 and re-ran `npm run test:coverage`:

```
ERROR: Coverage for statements (76.22%) does not meet global threshold (79%)
vitest exit=1
```

Reverted to `74` before committing — the committed config exits 0 on `develop`'s current coverage.

## Roadmap

Marks row 21 of `docs/plans/2026-04-25-comprehensive-polish-and-harden.md` as shipped (mirrors the section-B / row-3 pattern: table marker + section header + "As shipped" bullet list).

## Test plan

- [x] `npm run test:coverage` exits 0 with thresholds in place
- [x] `npm run verify` green (format:check, lint, typecheck, test, build)
- [x] Manually bumped a threshold above measured to confirm vitest exits non-zero
- [ ] CI's `test:coverage` job stays green on this PR