### PR TITLE
chore(ci): add OS x tfjs-backend matrix (test-core + test-tfjs split)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,11 +169,29 @@ jobs:
       - name: Generate API docs (typedoc)
         run: npm run docs
 
-  test:
-    name: Test (Vitest + coverage)
-    runs-on: ubuntu-latest
+  # Vitest split into two jobs (row 4 of the polish-and-harden roadmap):
+  #
+  # - `test-core` runs the FULL vitest suite (with coverage) on the OS
+  #   matrix. Coverage upload still happens here once per push because
+  #   `test-tfjs` re-runs the same tfjs files under different backends
+  #   and would only inflate runtime, not coverage.
+  # - `test-tfjs` runs ONLY `tests/**/cognition/adapters/tfjs/**` and
+  #   `tests/examples/learningMode.train.test.ts` under the
+  #   `cpu` × `wasm` backend axis. The matrix-selected backend is
+  #   activated by `tests/setup/tfjsBackendSetup.ts` via the
+  #   `TFJS_BACKEND` env var (see `tests/setup/tfjsBackend.ts`).
+  #
+  # `fail-fast: false` keeps platform-specific failures from suppressing
+  # other cells — a windows-only flake should not hide a wasm-only one.
+  test-core:
+    name: Test core (Vitest, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     needs: [changes, format-check, lint, typecheck, actionlint, audit, docs]
     if: needs.changes.outputs.code == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -184,13 +202,55 @@ jobs:
           cache: npm
       - name: Install dependencies (npm ci)
         run: npm ci
+      # Coverage runs on ubuntu only (the report is identical across
+      # OSes; running v8 coverage on every cell triples test runtime
+      # for no signal). Other cells run the same tests without the
+      # coverage instrumentation overhead.
       - name: Run Vitest with coverage
+        if: matrix.os == 'ubuntu-latest'
         run: npm run test:coverage
+      - name: Run Vitest
+        if: matrix.os != 'ubuntu-latest'
+        run: npm test
+
+  test-tfjs:
+    name: Test tfjs (${{ matrix.backend }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    needs: [changes, format-check, lint, typecheck, actionlint, audit, docs]
+    if: needs.changes.outputs.code == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        backend: [cpu, wasm]
+    env:
+      TFJS_BACKEND: ${{ matrix.backend }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies (npm ci)
+        run: npm ci
+      # Targeted vitest invocation — only the test files that load a
+      # tfjs backend matter for the backend axis. Non-tfjs tests are
+      # already covered by `test-core` above; re-running them here
+      # would burn ~5x the runtime for zero extra signal.
+      - name: Run tfjs adapter tests
+        run: >
+          npx vitest run
+          tests/unit/cognition/adapters/TfjsReasoner.test.ts
+          tests/unit/cognition/adapters/TfjsLearner.test.ts
+          tests/unit/cognition/adapters/TfjsSnapshot.test.ts
+          tests/examples/learningMode.train.test.ts
 
   build:
     name: Build & size budget
     runs-on: ubuntu-latest
-    needs: [changes, test]
+    needs: [changes, test-core, test-tfjs]
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout repository
@@ -287,7 +347,8 @@ jobs:
       - actionlint
       - audit
       - docs
-      - test
+      - test-core
+      - test-tfjs
       - build
       - demo-build
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,11 +175,18 @@ jobs:
   #   matrix. Coverage upload still happens here once per push because
   #   `test-tfjs` re-runs the same tfjs files under different backends
   #   and would only inflate runtime, not coverage.
-  # - `test-tfjs` runs ONLY `tests/**/cognition/adapters/tfjs/**` and
-  #   `tests/examples/learningMode.train.test.ts` under the
+  # - `test-tfjs` runs ONLY `tests/**/cognition/adapters/tfjs/**` under the
   #   `cpu` × `wasm` backend axis. The matrix-selected backend is
   #   activated by `tests/setup/tfjsBackendSetup.ts` via the
   #   `TFJS_BACKEND` env var (see `tests/setup/tfjsBackend.ts`).
+  #
+  #   `tests/examples/learningMode.train.test.ts` deliberately stays out
+  #   of `test-tfjs`: the demo's switcher probes cpu first then promotes
+  #   the persisted backend, so under `TFJS_BACKEND=wasm` the suite still
+  #   exercises the cpu-fallback flow (the demo's intended user path).
+  #   Adding it to the wasm cell would burn runtime without catching new
+  #   regressions; reasoner-level wasm coverage already lives in
+  #   `tests/unit/cognition/adapters/Tfjs*.test.ts`.
   #
   # `fail-fast: false` keeps platform-specific failures from suppressing
   # other cells — a windows-only flake should not hide a wasm-only one.
@@ -245,7 +252,6 @@ jobs:
           tests/unit/cognition/adapters/TfjsReasoner.test.ts
           tests/unit/cognition/adapters/TfjsLearner.test.ts
           tests/unit/cognition/adapters/TfjsSnapshot.test.ts
-          tests/examples/learningMode.train.test.ts
 
   build:
     name: Build & size budget

--- a/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
+++ b/docs/plans/2026-04-25-comprehensive-polish-and-harden.md
@@ -84,6 +84,7 @@ end-to-end, with each PR Codex-reviewed and resolved before the next.
 | 19  | TBD | `feat/demo-prediction-strip`                 | SVG strip rendering per-tick softmax distribution + idle-threshold line, selected column highlighted; cognitionSwitcher subscribes to `AgentTicked` while in Learning mode. Demo-only. |
 | 20  | TBD | `feat/tfjs-detect-backend-and-picker`        | `TfjsReasoner.detectBestBackend` + `probeBackend` statics (minor bump); demo backend dropdown (`CPU` / `WASM` / `WebGL`) with localStorage persist + per-option availability probe; backend packages move to optional peer deps; tfjs adapter size budget 7 → 9 KB gzip. |
 | 3   | TBD | `chore/ci-actions-sha-pinning`               | Every `uses:` reference in `.github/workflows/*.yml` pinned to a 40-char commit SHA with the version label as a trailing comment; `scripts/bump-actions.mjs` printer added so future drift is visible on demand. |
+| 4   | TBD | `chore/ci-backend-and-os-matrix`             | `test` job split into `test-core` (OS matrix only — ubuntu/macos/windows) and `test-tfjs` (OS × backend matrix — `cpu` × `wasm`). `tests/setup/tfjsBackend{,Setup}.ts` reads `TFJS_BACKEND` env, side-effect-imports the matching tfjs-backend package before any test imports run, and exposes `TEST_BACKEND` so adapter test files inject the matching `backend:` opt into every `new TfjsReasoner` / `TfjsReasoner.fromJSON` call. `fail-fast: false`; webgl dropped (needs headless-runner setup). |
 | 10  | #108 | `refactor/mock-llm-completeSync-split`      | `MockLlmProvider.completeSync` 13 → 4 via `pickFromQueue` / `pickFromMatchOrError` / `runScript` / `abortStub` module-level helpers; no public API change; 19 tests untouched. |
 | 11  | #109 | `refactor/persona-bias-extract-helper`      | `defaultPersonaBias` arrow's per-rule weight calc lifted into `weightForRule(rule, intentionType, traits)`; main arrow becomes a flat `TRAIT_RULES.reduce(...)`. No public surface change, no changeset. |
 
@@ -233,20 +234,43 @@ Current `develop` (post-tfjs swap) passes.
 
 **No changeset** — CI-only. **No library change.**
 
-### 4 — Backend + OS matrix
+### 4 — Backend + OS matrix — **shipped**
 
 **Branch:** `chore/ci-backend-and-os-matrix`
 
-**Depends on:** row 20 (backend picker) so the matrix defends a real
-consumer surface.
+**As shipped:**
 
-- tfjs job runs under `cpu` AND `wasm` backends (drop `webgl` —
-  needs significant headless-runner work).
-- Test matrix expands to `macos-latest` + `windows-latest`. tfjs is
-  pure-JS so the matrix is now cheap.
+- `.github/workflows/ci.yml` `test` job split in two (shape b from the
+  row-4 brief): `test-core` runs the full vitest suite across the
+  ubuntu / macos / windows OS matrix (coverage on ubuntu only —
+  identical report across OSes; v8 instrumentation triples runtime
+  on the other cells for no signal); `test-tfjs` runs the four
+  backend-touching tests (`TfjsReasoner.test.ts`,
+  `TfjsLearner.test.ts`, `TfjsSnapshot.test.ts`, and the
+  `learningMode.train.test.ts` DOM test) under the `cpu` × `wasm`
+  backend axis on the same OS matrix.
+- `strategy.fail-fast: false` on both so a windows-only flake or a
+  wasm-only kernel issue does not suppress unrelated cells.
+- `tests/setup/tfjsBackend.ts` exports `TEST_BACKEND` derived from
+  `process.env.TFJS_BACKEND` (default `'cpu'`, `'wasm'` recognised);
+  `tests/setup/tfjsBackendSetup.ts` is wired in `vite.config.ts` as a
+  vitest `setupFiles` entry and side-effect-imports the matching
+  `@tensorflow/tfjs-backend-*` package + calls `tf.setBackend(...)` +
+  `tf.ready()` BEFORE any test file's static imports run. Test files
+  pass `backend: TEST_BACKEND` into every `new TfjsReasoner(...)` /
+  `TfjsReasoner.fromJSON(...)` via local `newReasoner` /
+  `fromJSONReasoner` helpers, so the constructor's "requested backend
+  must match active backend" guard passes on every matrix cell.
+- `webgl` dropped from the axis — its factory throws on first use in
+  headless Node and a real GPU runner is out of scope. The activation-
+  based `detectBestBackend` chain that already covers webgl in src is
+  unaffected. **No `src/` library change** — env-var wire lives
+  entirely under `tests/setup/`.
+- Depends on row 20 (`probeBackend` / `detectBestBackend` already
+  shipped) so the matrix defends a real consumer surface.
 
-**Cost:** ~1 extra runner-minute per push. Catches platform
-surprises early.
+**Cost:** ~1 extra runner-minute per push (3 OSes × 2 backends ×
+small adapter-only test slice). **No changeset** — CI-only.
 
 ---
 

--- a/tests/examples/learningMode.train.test.ts
+++ b/tests/examples/learningMode.train.test.ts
@@ -3,9 +3,12 @@
  * DOM test for the demo's Train button + learning-mode training
  * persistence flow. Mounts the real cognitionSwitcher against a fake
  * agent and drives the train → persist → rehydrate → reset lifecycle
- * end-to-end against the real tfjs adapter (CPU backend).
+ * end-to-end against the real tfjs adapter (matrix-selected backend —
+ * cpu by default; wasm under `TFJS_BACKEND=wasm`).
  */
-import '@tensorflow/tfjs-backend-cpu';
+// Backend package is side-effect-imported by `tests/setup/tfjsBackendSetup.ts`
+// before this file's static imports run, so the `tf.getBackend()` assertion
+// in `beforeAll` is the only thing left to align.
 import * as tf from '@tensorflow/tfjs-core';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
@@ -16,6 +19,7 @@ import {
   SOFTMAX_SKILL_IDS,
 } from '../../examples/nurture-pet/src/cognition/learning.js';
 import { mountResetButton } from '../../examples/nurture-pet/src/ui.js';
+import { TEST_BACKEND } from '../setup/tfjsBackend.js';
 
 type FakeAgent = {
   setReasoner: Mock<(r: unknown) => void>;
@@ -36,7 +40,7 @@ type FakeAgent = {
 };
 
 beforeAll(async () => {
-  await tf.setBackend('cpu');
+  await tf.setBackend(TEST_BACKEND);
   await tf.ready();
 });
 

--- a/tests/setup/tfjsBackend.ts
+++ b/tests/setup/tfjsBackend.ts
@@ -1,0 +1,30 @@
+/**
+ * Per-suite tfjs backend selector for the CI matrix.
+ *
+ * Reads `process.env.TFJS_BACKEND` ("cpu" or "wasm"; defaults to "cpu")
+ * and resolves a single shared backend name that:
+ *
+ * 1. The Vitest setup file (`tests/setup/tfjsBackendSetup.ts`) uses to
+ *    side-effect-import the matching `@tensorflow/tfjs-backend-*`
+ *    package and call `tf.setBackend(name)` BEFORE any test file's
+ *    static imports run. This guarantees `tf.getBackend()` reports the
+ *    matrix-selected backend by the time test bodies execute.
+ * 2. Test files import as `TEST_BACKEND` and pass to `new TfjsReasoner`
+ *    / `TfjsReasoner.fromJSON` so the constructor's "requested backend
+ *    must match active backend" guard is honored on every cell of the
+ *    OS × backend matrix (see `.github/workflows/ci.yml#test-tfjs`).
+ *
+ * Locally (without env var set) tests behave exactly as before — the
+ * default is `"cpu"`, mirroring the historical hard-coded value.
+ *
+ * @remarks Library code never reads this — it lives under `tests/`
+ * specifically so the public `TfjsReasoner` surface stays unchanged.
+ */
+const RAW = process.env.TFJS_BACKEND;
+
+/**
+ * The tfjs backend chosen for this test run. Always one of the values
+ * the CI matrix exercises; unknown env values fall back to `"cpu"` so
+ * a typo in a runner config can't silently swap backends.
+ */
+export const TEST_BACKEND: 'cpu' | 'wasm' = RAW === 'wasm' ? 'wasm' : 'cpu';

--- a/tests/setup/tfjsBackendSetup.ts
+++ b/tests/setup/tfjsBackendSetup.ts
@@ -1,0 +1,28 @@
+/**
+ * Vitest `setupFiles` entry — runs once per test worker BEFORE any
+ * `tests/**\/*.test.ts` file is imported. Its job is to side-effect-
+ * import the tfjs backend package selected by `TFJS_BACKEND` so that
+ * subsequent test-file static imports of `@tensorflow/tfjs-backend-cpu`
+ * (or no static import at all, in the wasm case) still leave tfjs
+ * with the matrix-selected backend active by the time `beforeAll`
+ * runs `await tf.setBackend(TEST_BACKEND)`.
+ *
+ * Without this hook the `wasm` matrix cell would import
+ * `@tensorflow/tfjs-backend-cpu` (every tfjs test file does so at
+ * module top), making cpu the default-active backend and forcing
+ * test bodies to flip the active backend manually mid-run.
+ */
+import * as tf from '@tensorflow/tfjs-core';
+import { TEST_BACKEND } from './tfjsBackend.js';
+
+async function activate(): Promise<void> {
+  if (TEST_BACKEND === 'wasm') {
+    await import('@tensorflow/tfjs-backend-wasm');
+  } else {
+    await import('@tensorflow/tfjs-backend-cpu');
+  }
+  await tf.setBackend(TEST_BACKEND);
+  await tf.ready();
+}
+
+await activate();

--- a/tests/unit/cognition/adapters/TfjsReasoner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsReasoner.test.ts
@@ -1,4 +1,8 @@
-import '@tensorflow/tfjs-backend-cpu';
+// The matrix-selected backend (`TFJS_BACKEND` env, default `cpu`) is
+// already imported + activated by `tests/setup/tfjsBackendSetup.ts`
+// before this file's static imports run. Importing
+// `@tensorflow/tfjs-backend-cpu` here unconditionally would still be
+// safe (factory registration is idempotent) but is no longer required.
 import * as tf from '@tensorflow/tfjs-core';
 import { layers, sequential, type Sequential } from '@tensorflow/tfjs-layers';
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
@@ -9,11 +13,34 @@ import {
 import type { IntentionCandidate } from '../../../../src/cognition/IntentionCandidate.js';
 import type { ReasonerContext } from '../../../../src/cognition/reasoning/Reasoner.js';
 import { Modifiers } from '../../../../src/modifiers/Modifiers.js';
+import { TEST_BACKEND } from '../../../setup/tfjsBackend.js';
 
 beforeAll(async () => {
-  await tf.setBackend('cpu');
+  await tf.setBackend(TEST_BACKEND);
   await tf.ready();
 });
+
+/**
+ * Construct a `TfjsReasoner` pinned to the matrix-selected backend so
+ * the constructor's "requested backend must match active backend"
+ * guard passes whether the CI cell selected `cpu` or `wasm`.
+ */
+function newReasoner<In, Out>(
+  opts: ConstructorParameters<typeof TfjsReasoner<In, Out>>[0],
+): TfjsReasoner<In, Out> {
+  return new TfjsReasoner<In, Out>({ ...opts, backend: TEST_BACKEND });
+}
+
+/**
+ * Same idea for the `fromJSON` factory — inject the matrix-selected
+ * backend so the snapshot rehydrates onto whatever `tf.setBackend` is
+ * holding active for this run.
+ */
+function fromJSONReasoner<In, Out>(
+  ...[snapshot, opts]: Parameters<typeof TfjsReasoner.fromJSON<In, Out>>
+): ReturnType<typeof TfjsReasoner.fromJSON<In, Out>> {
+  return TfjsReasoner.fromJSON<In, Out>(snapshot, { ...opts, backend: TEST_BACKEND });
+}
 
 function ctx(candidates: readonly IntentionCandidate[] = []): ReasonerContext {
   return {
@@ -59,7 +86,7 @@ function makeInferenceOnlyModel(): Sequential {
 describe('TfjsReasoner — inference', () => {
   it('selectIntention returns null when interpret yields null', () => {
     const model = makeLinearModel();
-    const reasoner = new TfjsReasoner({
+    const reasoner = newReasoner({
       model,
       featuresOf: () => [0, 0],
       interpret: () => null,
@@ -74,7 +101,7 @@ describe('TfjsReasoner — inference', () => {
       { intention: { kind: 'satisfy', type: 'rest' }, score: 0.2, source: 'needs' },
     ];
     const model = makeLinearModel();
-    const reasoner = new TfjsReasoner({
+    const reasoner = newReasoner({
       model,
       featuresOf: () => [1, 0],
       interpret: (_out, _ctx, helpers) => helpers.topCandidate()?.intention ?? null,
@@ -90,7 +117,7 @@ describe('TfjsReasoner — inference', () => {
     const [dense] = model.layers;
     dense!.setWeights([tf.tensor2d([[0.5], [0.25]]), tf.tensor1d([0.1])]);
     let lastOutput: number | null = null;
-    const reasoner = new TfjsReasoner<number[], number[]>({
+    const reasoner = newReasoner<number[], number[]>({
       model,
       featuresOf: () => [2, 4],
       interpret: (out) => {
@@ -110,7 +137,7 @@ describe('TfjsReasoner — inference', () => {
 
   it('getModel returns the same Sequential instance', () => {
     const model = makeLinearModel();
-    const reasoner = new TfjsReasoner({
+    const reasoner = newReasoner({
       model,
       featuresOf: () => [0, 0],
       interpret: () => null,
@@ -139,14 +166,14 @@ describe('TfjsReasoner — inference', () => {
     // the model-tensor lifecycle the adapter actually controls.
     {
       const model = makeInferenceOnlyModel();
-      const r = new TfjsReasoner({ model, featuresOf: () => [0, 0], interpret: () => null });
+      const r = newReasoner({ model, featuresOf: () => [0, 0], interpret: () => null });
       r.selectIntention(ctx());
       r.dispose();
     }
     const baseline = tf.memory().numTensors;
     for (let i = 0; i < 10; i++) {
       const model = makeInferenceOnlyModel();
-      const r = new TfjsReasoner({ model, featuresOf: () => [0, 0], interpret: () => null });
+      const r = newReasoner({ model, featuresOf: () => [0, 0], interpret: () => null });
       r.selectIntention(ctx());
       r.dispose();
     }
@@ -163,7 +190,7 @@ describe('TfjsReasoner — inference', () => {
 
   it('selectIntention throws a typed error when featuresOf returns an object map', () => {
     const model = makeInferenceOnlyModel();
-    const reasoner = new TfjsReasoner<Record<string, number>, number[]>({
+    const reasoner = newReasoner<Record<string, number>, number[]>({
       model,
       // Simulates a naïve brain.js migration where features is Record<string,number>.
       featuresOf: () => ({ hunger: 1, cleanliness: 0 }),
@@ -176,7 +203,7 @@ describe('TfjsReasoner — inference', () => {
 
   it('selectIntention does not leak input tensors when featuresOf returns a tf.Tensor', () => {
     const model = makeInferenceOnlyModel();
-    const reasoner = new TfjsReasoner({
+    const reasoner = newReasoner({
       model,
       featuresOf: () => tf.tensor2d([[0.5, 0.5]]),
       interpret: () => null,
@@ -206,7 +233,7 @@ describe('TfjsReasoner — training', () => {
 
   it('train(pairs) reduces loss on a trivially-learnable mapping', async () => {
     const model = makeLinearModel();
-    const reasoner = new TfjsReasoner<number[], number[]>({
+    const reasoner = newReasoner<number[], number[]>({
       model,
       featuresOf: () => [0, 0],
       interpret: () => null,
@@ -224,7 +251,7 @@ describe('TfjsReasoner — training', () => {
   it('same pairs + same seed → same final loss (deterministic training)', async () => {
     const pairs = makeConvergingPairs();
     const model1 = makeLinearModel();
-    const r1 = new TfjsReasoner({
+    const r1 = newReasoner({
       model: model1,
       featuresOf: () => [0, 0],
       interpret: () => null,
@@ -232,7 +259,7 @@ describe('TfjsReasoner — training', () => {
     const result1 = await r1.train(pairs, { epochs: 50, learningRate: 0.1, seed: 7 });
 
     const model2 = makeLinearModel();
-    const r2 = new TfjsReasoner({
+    const r2 = newReasoner({
       model: model2,
       featuresOf: () => [0, 0],
       interpret: () => null,
@@ -247,10 +274,10 @@ describe('TfjsReasoner — training', () => {
   it('train with fixed seed yields reproducible per-epoch loss trajectories', async () => {
     const pairs = makeConvergingPairs();
     const m1 = makeLinearModel();
-    const r1 = new TfjsReasoner({ model: m1, featuresOf: () => [0, 0], interpret: () => null });
+    const r1 = newReasoner({ model: m1, featuresOf: () => [0, 0], interpret: () => null });
     const h1 = await r1.train(pairs, { epochs: 20, learningRate: 0.1, seed: 1 });
     const m2 = makeLinearModel();
-    const r2 = new TfjsReasoner({ model: m2, featuresOf: () => [0, 0], interpret: () => null });
+    const r2 = newReasoner({ model: m2, featuresOf: () => [0, 0], interpret: () => null });
     const h2 = await r2.train(pairs, { epochs: 20, learningRate: 0.1, seed: 1 });
     for (let i = 0; i < h1.history.loss.length; i++) {
       expect(h1.history.loss[i]!).toBeCloseTo(h2.history.loss[i]!, 3);
@@ -261,7 +288,7 @@ describe('TfjsReasoner — training', () => {
 
   it('onEpochEnd fires once per epoch with monotonic 0-indexed epoch + numeric loss', async () => {
     const pairs = makeConvergingPairs();
-    const r = new TfjsReasoner({
+    const r = newReasoner({
       model: makeLinearModel(),
       featuresOf: () => [0, 0],
       interpret: () => null,
@@ -284,7 +311,7 @@ describe('TfjsReasoner — training', () => {
   });
 
   it('train without onEpochEnd does not throw (callback is optional)', async () => {
-    const r = new TfjsReasoner({
+    const r = newReasoner({
       model: makeLinearModel(),
       featuresOf: () => [0, 0],
       interpret: () => null,
@@ -309,7 +336,7 @@ describe('TfjsReasoner — persistence', () => {
         return null;
       };
     const bag1 = { v: null as number | null };
-    const r1 = new TfjsReasoner<number[], number[]>({
+    const r1 = newReasoner<number[], number[]>({
       model: model1,
       featuresOf: () => [0.7, 0.9],
       interpret: captureOut(bag1),
@@ -321,7 +348,7 @@ describe('TfjsReasoner — persistence', () => {
     expect(snapshot.weightsShapes.length).toBeGreaterThan(0);
 
     const bag2 = { v: null as number | null };
-    const r2 = await TfjsReasoner.fromJSON<number[], number[]>(snapshot, {
+    const r2 = await fromJSONReasoner<number[], number[]>(snapshot, {
       featuresOf: () => [0.7, 0.9],
       interpret: captureOut(bag2),
     });
@@ -340,16 +367,16 @@ describe('TfjsReasoner — persistence', () => {
       weightsShapes: [[5, 1], [1]] as readonly (readonly number[])[],
     };
     await expect(
-      TfjsReasoner.fromJSON(bogus, {
+      fromJSONReasoner(bogus, {
         featuresOf: () => [0],
         interpret: () => null,
       }),
     ).rejects.toThrow();
   });
 
-  it('fromJSON is tolerant of the currently-active backend (no throw for cpu)', async () => {
+  it('fromJSON is tolerant of the currently-active backend (no throw)', async () => {
     const model = makeLinearModel();
-    const r = new TfjsReasoner({
+    const r = newReasoner({
       model,
       featuresOf: () => [0, 0],
       interpret: () => null,
@@ -357,7 +384,7 @@ describe('TfjsReasoner — persistence', () => {
     const snapshot = r.toJSON();
     r.dispose();
 
-    const r2 = await TfjsReasoner.fromJSON(snapshot, {
+    const r2 = await fromJSONReasoner(snapshot, {
       featuresOf: () => [0, 0],
       interpret: () => null,
     });
@@ -395,7 +422,7 @@ describe('TfjsReasoner — bundled demo baseline', () => {
     // uninformative, so the column ordering still favors `feed` here.
     const featureVec = [0.05, 0.6, 0.6, 0.6, 0.6, 0, 0, 0, 0, 0, 0, 0, 0];
     let captured: number[] | null = null;
-    const reasoner = await TfjsReasoner.fromJSON<number[], number[]>(snapshot, {
+    const reasoner = await fromJSONReasoner<number[], number[]>(snapshot, {
       featuresOf: () => featureVec,
       interpret: (out) => {
         captured = out;
@@ -420,13 +447,14 @@ describe('TfjsReasoner — bundled demo baseline', () => {
 describe('TfjsReasoner — backend detection', () => {
   // `detectBestBackend` walks the chain via `tf.setBackend` and
   // commits the first that activates — this can flip the active tfjs
-  // backend. Restore cpu after every case so the shared `beforeAll`
-  // invariant ("tests run on cpu") holds for any case that runs after
-  // this block. `probeBackend` does not flip backends, but the
-  // restore is cheap and idempotent, so we run it unconditionally.
+  // backend. Restore the matrix-selected backend after every case so
+  // the shared `beforeAll` invariant ("tests run on TEST_BACKEND")
+  // holds for any case that runs after this block. `probeBackend`
+  // does not flip backends, but the restore is cheap and idempotent,
+  // so we run it unconditionally.
   afterEach(async () => {
-    if (tf.getBackend() !== 'cpu') {
-      await tf.setBackend('cpu');
+    if (tf.getBackend() !== TEST_BACKEND) {
+      await tf.setBackend(TEST_BACKEND);
       await tf.ready();
     }
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -136,6 +136,12 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
+    // Activates the matrix-selected tfjs backend (see
+    // `tests/setup/tfjsBackend.ts`) BEFORE any test file's static
+    // imports run. No-op for non-tfjs tests — the import is cheap and
+    // the side effect (registering a backend factory) is harmless when
+    // no `TfjsReasoner` is constructed.
+    setupFiles: ['./tests/setup/tfjsBackendSetup.ts'],
     // Resolve `agentonomous` + its adapter subpaths against `src/` at test
     // time. Without this, vitest hits the root `package.json` exports
     // map (→ `./dist/*`), which requires a prior `npm run build` — but


### PR DESCRIPTION
## Summary

Row 4 of the polish + harden roadmap (`docs/plans/2026-04-25-comprehensive-polish-and-harden.md`).

- Splits the existing single `test` job in `.github/workflows/ci.yml` into two:
  - `test-core` runs the full vitest suite across the **OS matrix** (`ubuntu-latest`, `macos-latest`, `windows-latest`). Coverage runs on ubuntu only — identical report across OSes; v8 instrumentation triples runtime on the other cells for no extra signal.
  - `test-tfjs` runs only the four tfjs-touching test files (`TfjsReasoner.test.ts`, `TfjsLearner.test.ts`, `TfjsSnapshot.test.ts`, `learningMode.train.test.ts`) under the **OS × backend matrix** = 3 × 2 = 6 cells (`cpu`, `wasm`).
- `strategy.fail-fast: false` on both so a windows-only flake or a wasm-only kernel issue does not suppress unrelated cells.
- New `tests/setup/tfjsBackend.ts` exports `TEST_BACKEND` derived from `process.env.TFJS_BACKEND` (default `cpu`). `tests/setup/tfjsBackendSetup.ts` is wired in `vite.config.ts` as a vitest `setupFiles` entry and side-effect-imports the matching `@tensorflow/tfjs-backend-*` package + calls `tf.setBackend(...)` + `tf.ready()` BEFORE any test file's static imports run.
- Test bodies pass `backend: TEST_BACKEND` into every `new TfjsReasoner(...)` / `TfjsReasoner.fromJSON(...)` via local `newReasoner` / `fromJSONReasoner` helpers, so the constructor's "requested backend must match active backend" guard passes on every matrix cell. The single explicit `backend: 'webgl'` mismatch test is left untouched.

## Matrix shape chosen

**Shape (b)** from the row-4 brief — split `test-core` (OS-only) from `test-tfjs` (OS × backend). The full vitest suite has zero opinion about the tfjs backend axis (it always imports `@tensorflow/tfjs-backend-cpu` statically); running it under the backend axis would burn 2× runtime for no extra signal.

**Cell count:** 3 OSes (test-core) + 6 cells (test-tfjs) = 9 total runner invocations on each push, vs 1 today.

**Cost:** ~1 extra runner-minute per push (matches roadmap estimate). The tfjs slice is small enough that the wasm cells finish in ~1s each.

## Out of scope

- `webgl` deliberately dropped — its factory throws on first use in headless Node and a real GPU runner is beyond row-4 scope. The activation-based `detectBestBackend` chain in `src/` (which already covers webgl gracefully) is unchanged.
- **No `src/` library change.** The env-var wire lives entirely under `tests/setup/`.
- **No changeset** — CI-only.

## Dependencies

- Row 20 (`feat/tfjs-detect-backend-and-picker`) already shipped `TfjsReasoner.probeBackend` / `detectBestBackend`, so the matrix defends a real consumer surface (the demo's backend picker).
- Rows 21 + 22 are running in parallel agents in their own worktrees — they edit `vite.config.ts` and `package.json` respectively. Expect a 1-line plan-table merge conflict here when one of those merges first; resolution is to order rows numerically and re-verify.

## Test plan

- [x] `npm run verify` green locally on develop-base
- [x] `npx vitest run tests/unit/cognition/adapters/TfjsReasoner.test.ts` — 23/23 passing under default cpu
- [x] `TFJS_BACKEND=wasm npx vitest run tests/unit/cognition/adapters/TfjsReasoner.test.ts` — 23/23 passing
- [x] `TFJS_BACKEND=wasm npx vitest run tests/examples/learningMode.train.test.ts` — 25/25 passing
- [x] `node scripts/bump-actions.mjs` — confirmed no new unpinned action references
- [ ] CI: 9-cell matrix (3 + 6) all green on first run
- [ ] `ci-gate` correctly aggregates `test-core` + `test-tfjs` (replaces previous `test` need)