### PR TITLE
fix(tfjs): preserve batch shape in TfjsReasoner.toInputTensor

### DIFF
--- a/.changeset/tfjs-reasoner-batch-rank.md
+++ b/.changeset/tfjs-reasoner-batch-rank.md
@@ -1,0 +1,13 @@
+---
+'agentonomous': patch
+---
+
+Fix `TfjsReasoner.toInputTensor` so a `number[][]` (or `TypedArray[]`)
+returned by `featuresOf` keeps its intended rank-2 shape `[B, N]`
+instead of being wrapped to a rank-3 `[1, B, N]`. Previously every
+array-like input picked up an extra leading axis, so consumers wiring
+batch features hit `Error when checking : expected dense_X_input to
+have 2 dimension(s), but got array with shape [1,B,N]` from
+`model.predict`. The 1-D `number[]` and single `TypedArray` paths still
+wrap to `[1, N]` (unchanged contract — matches the JSDoc that already
+documented batch input as supported).

--- a/src/cognition/adapters/tfjs/TfjsReasoner.ts
+++ b/src/cognition/adapters/tfjs/TfjsReasoner.ts
@@ -108,7 +108,19 @@ function seededShuffle<T>(arr: T[], rng: () => number): void {
  */
 function toInputTensor(features: unknown): tf.Tensor {
   if (features instanceof tf.Tensor) return features as tf.Tensor;
-  if (Array.isArray(features) || ArrayBuffer.isView(features)) {
+  if (Array.isArray(features)) {
+    const first: unknown = features[0];
+    if (first !== undefined && (Array.isArray(first) || ArrayBuffer.isView(first))) {
+      // Pre-batched: `number[][]` or `TypedArray[]`. Already rank-2 in
+      // intent — pass through to `tf.tensor` as-is so the resulting
+      // tensor is `[B, N]`, not `[1, B, N]`.
+      return tf.tensor(features as never);
+    }
+    // Single sample: `number[]` or empty array. Wrap to `[1, N]`.
+    return tf.tensor([features as never]);
+  }
+  if (ArrayBuffer.isView(features)) {
+    // Single TypedArray. Wrap to `[1, N]`.
     return tf.tensor([features as never]);
   }
   const got = features === null ? 'null' : typeof features;

--- a/tests/unit/cognition/adapters/TfjsReasoner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsReasoner.test.ts
@@ -201,6 +201,89 @@ describe('TfjsReasoner — inference', () => {
     reasoner.dispose();
   });
 
+  it('selectIntention with number[] (single sample) wraps to shape [1, N] — output length matches model.units', () => {
+    // 1-D path: a `number[]` of length 2 must wrap to a rank-2 tensor
+    // `[1, 2]`, so a `units: 1` head emits a single scalar (length 1
+    // after `dataSync` flatten). Pins the contract for the
+    // `toInputTensor` 1-D branch.
+    const model = makeInferenceOnlyModel();
+    let captured: number[] | null = null;
+    const reasoner = newReasoner<number[], number[]>({
+      model,
+      featuresOf: () => [0.5, 0.5],
+      interpret: (out) => {
+        captured = out;
+        return null;
+      },
+    });
+    reasoner.selectIntention(ctx());
+    expect(captured).not.toBeNull();
+    expect(captured!).toHaveLength(1);
+    reasoner.dispose();
+  });
+
+  it('selectIntention with Float32Array (single sample) wraps to shape [1, N]', () => {
+    // TypedArray-of-numbers path: same wrap as `number[]` — a single
+    // `Float32Array` of length 2 must produce a rank-2 input
+    // `[1, 2]`, yielding output length 1.
+    const model = makeInferenceOnlyModel();
+    let captured: number[] | null = null;
+    const reasoner = newReasoner<Float32Array, number[]>({
+      model,
+      featuresOf: () => new Float32Array([0.5, 0.5]),
+      interpret: (out) => {
+        captured = out;
+        return null;
+      },
+    });
+    reasoner.selectIntention(ctx());
+    expect(captured).not.toBeNull();
+    expect(captured!).toHaveLength(1);
+    reasoner.dispose();
+  });
+
+  it('selectIntention with number[][] (pre-batched B samples) preserves rank-2 shape [B, N] — output flattens to B*units', () => {
+    // Pre-batched path: a `number[][]` of two samples must NOT pick up
+    // an extra leading axis. The input tensor must be rank 2
+    // (`[2, 2]`), so a `units: 1` head emits two scalars
+    // (length 2 after flatten). Without this guard the implementation
+    // wraps to rank 3 `[1, 2, 2]` and dense-layer predict either
+    // throws (ndim mismatch) or produces wrong-rank output.
+    const model = makeInferenceOnlyModel();
+    let captured: number[] | null = null;
+    const reasoner = newReasoner<number[][], number[]>({
+      model,
+      featuresOf: () => [
+        [0, 0],
+        [1, 1],
+      ],
+      interpret: (out) => {
+        captured = out;
+        return null;
+      },
+    });
+    reasoner.selectIntention(ctx());
+    expect(captured).not.toBeNull();
+    expect(captured!).toHaveLength(2);
+    reasoner.dispose();
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['string', 'hello'],
+    ['number', 42],
+  ] as const)('selectIntention throws TypeError when featuresOf returns %s', (_label, value) => {
+    const model = makeInferenceOnlyModel();
+    const reasoner = newReasoner<unknown, number[]>({
+      model,
+      featuresOf: () => value,
+      interpret: () => null,
+    });
+    expect(() => reasoner.selectIntention(ctx())).toThrow(TypeError);
+    reasoner.dispose();
+  });
+
   it('selectIntention does not leak input tensors when featuresOf returns a tf.Tensor', () => {
     const model = makeInferenceOnlyModel();
     const reasoner = newReasoner({


### PR DESCRIPTION
## Summary

- `toInputTensor` always wrapped array-likes with an extra leading axis, so `featuresOf` returning a `number[][]` produced a rank-3 `[1, B, N]` tensor instead of the documented rank-2 `[B, N]`. Dense `model.predict` then threw `expected ndim=2, got ndim=3`, breaking every batch-inference path.
- Distinguish single-sample from pre-batched at runtime: peek at `features[0]` and skip the wrap when it is itself array-like (`Array.isArray` or `ArrayBuffer.isView`). Single `number[]` / `Float32Array` still wrap to `[1, N]` — unchanged contract; this fix makes the implementation match the JSDoc that already documented batch input as supported.
- Adds tests for rank-2 batch input, single `Float32Array`, single `number[]` output length, and the `null` / `undefined` / `string` / `number` error paths.

## Why now

Codex flagged this as a P2 (id `3142675540`) on PR #114 (develop→demo promotion). The finding is actually a pre-existing develop bug, not promotion-introduced. PR #114 is on hold until this lands; once it does, #114's head auto-tracks the new develop tip and can re-promote.

The demo's `featuresOf` returns a single `number[]` per tick, so the demo never exercises the batch path and has never tripped this. Library consumers wiring batch features ARE affected.

## Test plan

- [x] `npm run verify` — green (format, lint, typecheck, 520 tests, build, docs)
- [x] New `TfjsReasoner` tests cover: `number[]` (single) → output length 1; `Float32Array` (single) → output length 1; `number[][]` (batch of 2) → output length 2; `null`/`undefined`/string/number → `TypeError`
- [x] RED→GREEN verified: batch-rank test failed on develop with the exact `[1,2,2]` ndim-mismatch error before the fix, passes after
- [x] Pre-1.0 release hold respected — patch changeset queued, no version bump consumed