### PR TITLE
fix(tfjs): load backend module before setBackend in fromJSON

### DIFF
--- a/.changeset/tfjs-fromjson-load-backend.md
+++ b/.changeset/tfjs-fromjson-load-backend.md
@@ -1,0 +1,13 @@
+---
+'agentonomous': patch
+---
+
+Fix `TfjsReasoner.fromJSON` to side-effect-import the matching
+`@tensorflow/tfjs-backend-*` package BEFORE calling `tf.setBackend`.
+Previously, `fromJSON({ backend: 'cpu' | 'wasm' | 'webgl' })` rejected
+with `TfjsBackendNotRegisteredError` whenever the consumer hadn't
+already imported the backend package themselves — even though the
+package was installed — because `tf.setBackend` queries the registry
+that the backend package's top-level `tf.registerBackend(...)` call
+populates. The new flow matches the existing
+`loadBackendModule → setBackend` order in `detectBestBackend`.

--- a/src/cognition/adapters/tfjs/TfjsReasoner.ts
+++ b/src/cognition/adapters/tfjs/TfjsReasoner.ts
@@ -557,6 +557,16 @@ export class TfjsReasoner<In = unknown, Out = unknown> implements Reasoner {
     const requestedBackend = opts.backend ?? 'cpu';
     if (tf.getBackend() !== requestedBackend) {
       try {
+        // Side-effect-import the backend package FIRST so its
+        // `tf.registerBackend(...)` runs and the factory is in
+        // `tf.engine().registryFactory` before `tf.setBackend` queries
+        // it. Consumers who pull in only `@tensorflow/tfjs-core` +
+        // `@tensorflow/tfjs-layers` (transitive deps of `agentonomous`)
+        // never trigger that registration on their own — without this
+        // load step, `setBackend` returns false and `fromJSON` rejects
+        // even when the package is installed. Mirrors the
+        // `loadBackendModule → setBackend` order in `detectBestBackend`.
+        await loadBackendModule(requestedBackend);
         const ok = await tf.setBackend(requestedBackend);
         if (!ok) throw new TfjsBackendNotRegisteredError(requestedBackend);
       } catch (err) {

--- a/tests/unit/cognition/adapters/TfjsReasoner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsReasoner.test.ts
@@ -527,6 +527,57 @@ describe('TfjsReasoner — bundled demo baseline', () => {
   });
 });
 
+describe('TfjsReasoner — fromJSON backend module loading', () => {
+  // Test infra side-effect-imports only the matrix-selected backend
+  // (`tests/setup/tfjsBackendSetup.ts`), so the OTHER backend's factory
+  // starts out absent from the tfjs registry. This mirrors a real
+  // consumer who pulls in `@tensorflow/tfjs-core` + `@tensorflow/tfjs-layers`
+  // (transitive deps of `agentonomous`) but never side-effect-imports
+  // the `tfjs-backend-*` package matching `opts.backend`. The bug under
+  // test: `fromJSON` previously called `tf.setBackend(opts.backend)`
+  // without first loading the backend module, so the factory wasn't in
+  // the registry → setBackend returned false → it threw
+  // `TfjsBackendNotRegisteredError` even when the package was installed.
+  //
+  // Placed BEFORE the `backend detection` describe so the tests in this
+  // block see the pristine "other backend factory absent" state. The
+  // backend-detection block intentionally probes wasm/webgl/cpu and
+  // would pollute the registry if it ran first.
+
+  afterEach(async () => {
+    if (tf.getBackend() !== TEST_BACKEND) {
+      await tf.setBackend(TEST_BACKEND);
+      await tf.ready();
+    }
+  });
+
+  it('fromJSON({backend: nonactive}) loads the backend package side-effect before tf.setBackend', async () => {
+    const otherBackend: 'cpu' | 'wasm' = TEST_BACKEND === 'cpu' ? 'wasm' : 'cpu';
+
+    const model = makeLinearModel();
+    const r = newReasoner({ model, featuresOf: () => [0, 0], interpret: () => null });
+    const snapshot = r.toJSON();
+    r.dispose();
+
+    // Whether `fromJSON` ultimately resolves or rejects depends on the
+    // backend's runtime activation (wasm in headless node may decline,
+    // cpu always succeeds). The contract under exercise is
+    // "loadBackendModule runs before setBackend", verifiable via
+    // `findBackendFactory(otherBackend) !== null` after the call —
+    // which holds regardless of activation outcome.
+    await TfjsReasoner.fromJSON(snapshot, {
+      featuresOf: () => [0, 0],
+      interpret: () => null,
+      backend: otherBackend,
+    }).catch(() => {
+      // Swallow — first-use activation may throw in node for wasm; the
+      // factory-registration assertion below is the real signal.
+    });
+
+    expect(tf.findBackendFactory(otherBackend)).not.toBeNull();
+  });
+});
+
 describe('TfjsReasoner — backend detection', () => {
   // `detectBestBackend` walks the chain via `tf.setBackend` and
   // commits the first that activates — this can flip the active tfjs


### PR DESCRIPTION
## Summary

- `TfjsReasoner.fromJSON({ backend })` called `tf.setBackend(backend)` without first side-effect-importing the matching `@tensorflow/tfjs-backend-*` package. In environments that import only `@tensorflow/tfjs-core` + `@tensorflow/tfjs-layers` (the transitive deps of `agentonomous`), the backend package's top-level `tf.registerBackend(...)` never runs, so the registry is empty → `setBackend` returns false → `fromJSON` rejects with `TfjsBackendNotRegisteredError` even when the package is installed.
- Add `await loadBackendModule(requestedBackend)` ahead of `setBackend`, mirroring the existing `loadBackendModule → setBackend` order in `detectBestBackend`.
- New test asserts `tf.findBackendFactory(otherBackend) !== null` after `fromJSON({ backend: otherBackend })` resolves OR rejects — the contract is "the factory must be registered", regardless of whether runtime activation ultimately succeeds (wasm in headless node may decline at first use).

## Why now

Codex flagged this as a P2 (id `3143030482`) on PR #114 (develop→demo promotion). Pre-existing develop bug, surfaced because PR #114 promotes everything new in develop. PR #114 is on hold until both this and the sibling `detectBestBackend` race fix land.

## Test plan

- [x] `npm run verify` — 521 tests pass, 0 lint errors, build + docs green
- [x] RED→GREEN verified: new test failed before the fix (`expected null not to be null`), passes after
- [x] Test placed before the `backend detection` describe so the matrix-selected setup leaves the OTHER backend's factory pristinely absent (the bug is otherwise untestable — once any test imports the other backend package, the registry is permanently warm)
- [x] Patch changeset queued (pre-1.0 release hold respected)

## Related

- Sibling fix for the second P2 (id `3143030481` — `detectBestBackend` concurrency race) coming in a separate PR.