### PR TITLE
fix(tfjs): serialise overlapping detectBestBackend calls

### DIFF
--- a/.changeset/tfjs-detect-backend-mutex.md
+++ b/.changeset/tfjs-detect-backend-mutex.md
@@ -1,0 +1,14 @@
+---
+'agentonomous': patch
+---
+
+Fix `TfjsReasoner.detectBestBackend` to serialise overlapping callers
+behind a single in-flight detection promise. Previously each
+invocation mutated global tfjs state via `tf.setBackend` independently,
+so two concurrent chains could race — one caller could resolve to
+`'wasm'` while the other raced through and left tfjs on `'cpu'`,
+breaking the first caller's "returned backend is the active backend"
+post-condition. Boot logic + UI initialization commonly trigger this
+overlap. Subsequent calls after the in-flight chain settles re-probe
+fresh, so consumers can re-detect after installing a new backend
+package mid-session.

--- a/src/cognition/adapters/tfjs/TfjsReasoner.ts
+++ b/src/cognition/adapters/tfjs/TfjsReasoner.ts
@@ -271,6 +271,17 @@ export type TrainResult = {
  * ```
  */
 export class TfjsReasoner<In = unknown, Out = unknown> implements Reasoner {
+  /**
+   * In-flight `detectBestBackend` promise, shared across overlapping
+   * callers so they don't each mutate global tfjs state via
+   * `tf.setBackend` independently. Cleared in a `finally` once the
+   * detection chain settles, so the next call after settle re-probes
+   * the environment (matters when callers want to re-detect after
+   * loading a new backend package). See
+   * `static detectBestBackend` for the full reasoning.
+   */
+  private static inflightDetection: Promise<'webgl' | 'wasm' | 'cpu'> | null = null;
+
   private readonly model: Sequential;
   private readonly featuresOf: TfjsReasonerOptions<In, Out>['featuresOf'];
   private readonly interpret: TfjsReasonerOptions<In, Out>['interpret'];
@@ -450,44 +461,64 @@ export class TfjsReasoner<In = unknown, Out = unknown> implements Reasoner {
    * indicates a broken environment.
    */
   static async detectBestBackend(): Promise<'webgl' | 'wasm' | 'cpu'> {
-    // Snapshot the prior backend (may be empty string when tf hasn't
-    // initialized any backend yet). If every probe fails, attempt to
-    // restore it before throwing — a failed `tf.setBackend` can leave
-    // `engine.backendInstance` cleared, so a later inference call from
-    // an unrelated code path would otherwise hit a broken global state
-    // (Codex P1 round 10).
-    const prior = tf.getBackend();
-    for (const name of BACKEND_PROBE_ORDER) {
-      try {
-        await loadBackendModule(name);
-        const ok = await tf.setBackend(name);
-        if (ok) {
-          await tf.ready();
-          return name;
+    // Serialise overlapping callers behind a single in-flight promise.
+    // Each invocation mutates global tfjs state via `tf.setBackend`, so
+    // two concurrent chains can race — one resolves to `'wasm'` while
+    // the other races through and leaves tfjs on `'cpu'`, breaking the
+    // first caller's "returned backend is the active backend"
+    // post-condition. Sharing the same promise means probes run once
+    // for the whole batch and every caller sees the same final state.
+    if (TfjsReasoner.inflightDetection !== null) {
+      return TfjsReasoner.inflightDetection;
+    }
+    TfjsReasoner.inflightDetection = (async (): Promise<'webgl' | 'wasm' | 'cpu'> => {
+      // Snapshot the prior backend (may be empty string when tf hasn't
+      // initialized any backend yet). If every probe fails, attempt to
+      // restore it before throwing — a failed `tf.setBackend` can leave
+      // `engine.backendInstance` cleared, so a later inference call from
+      // an unrelated code path would otherwise hit a broken global state
+      // (Codex P1 round 10).
+      const prior = tf.getBackend();
+      for (const name of BACKEND_PROBE_ORDER) {
+        try {
+          await loadBackendModule(name);
+          const ok = await tf.setBackend(name);
+          if (ok) {
+            await tf.ready();
+            return name;
+          }
+        } catch {
+          // Factory threw (e.g. WebGL in headless Node). Try next.
         }
-      } catch {
-        // Factory threw (e.g. WebGL in headless Node). Try next.
       }
-    }
-    // All-failed path: best-effort restore of the prior backend so the
-    // rejection doesn't silently corrupt global tf state. If `prior`
-    // was empty (no backend ever initialized) or the restore itself
-    // throws, leave tf in whatever state the loop ended on — the
-    // caller's `cpu`-bundled invariant has already been violated, so
-    // there is no clean fallback.
-    if (prior !== '') {
-      try {
-        await tf.setBackend(prior);
-        await tf.ready();
-      } catch {
-        // Best-effort — surfacing this as a separate error would mask
-        // the more useful rejection below.
+      // All-failed path: best-effort restore of the prior backend so the
+      // rejection doesn't silently corrupt global tf state. If `prior`
+      // was empty (no backend ever initialized) or the restore itself
+      // throws, leave tf in whatever state the loop ended on — the
+      // caller's `cpu`-bundled invariant has already been violated, so
+      // there is no clean fallback.
+      if (prior !== '') {
+        try {
+          await tf.setBackend(prior);
+          await tf.ready();
+        } catch {
+          // Best-effort — surfacing this as a separate error would mask
+          // the more useful rejection below.
+        }
       }
+      throw new Error(
+        'TfjsReasoner.detectBestBackend: every backend (webgl, wasm, cpu) failed to activate. ' +
+          'cpu is bundled and should always succeed — reaching this error indicates a broken environment.',
+      );
+    })();
+    try {
+      return await TfjsReasoner.inflightDetection;
+    } finally {
+      // Clear the slot once the detection settles so the next call
+      // after settle re-probes (lets a consumer re-detect after
+      // installing a new backend package mid-session).
+      TfjsReasoner.inflightDetection = null;
     }
-    throw new Error(
-      'TfjsReasoner.detectBestBackend: every backend (webgl, wasm, cpu) failed to activate. ' +
-        'cpu is bundled and should always succeed — reaching this error indicates a broken environment.',
-    );
   }
 
   /**

--- a/tests/unit/cognition/adapters/TfjsReasoner.test.ts
+++ b/tests/unit/cognition/adapters/TfjsReasoner.test.ts
@@ -5,7 +5,7 @@
 // safe (factory registration is idempotent) but is no longer required.
 import * as tf from '@tensorflow/tfjs-core';
 import { layers, sequential, type Sequential } from '@tensorflow/tfjs-layers';
-import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   TfjsReasoner,
   TfjsBackendNotRegisteredError,
@@ -600,5 +600,40 @@ describe('TfjsReasoner — backend detection', () => {
     const b = await TfjsReasoner.detectBestBackend();
     expect(a).toBe(b);
     expect(['cpu', 'wasm', 'webgl']).toContain(a);
+  });
+
+  it('detectBestBackend serialises overlapping calls (single in-flight detection shared across concurrent callers)', async () => {
+    // Three concurrent callers must share one detection chain. Without
+    // an in-flight lock each caller mutates global tfjs state via
+    // `tf.setBackend` independently — interleaved chains can return
+    // mismatched names (one caller resolves to `'wasm'` while another
+    // races through and leaves tfjs on `'cpu'`), violating the
+    // post-condition that `tf.getBackend()` agrees with the returned
+    // value for every caller.
+    //
+    // Spy on `tf.setBackend` to count invocations across the batch.
+    // With the lock, a single chain runs and probes at most
+    // `BACKEND_PROBE_ORDER.length === 3` backends → ≤ 3 setBackend
+    // calls. Without the lock, three independent chains could fire up
+    // to 3 × 3 = 9 invocations.
+    // Spy on the engine instance (`tf.setBackend` is a namespace export
+    // and ESM forbids redefining its property; the underlying
+    // `tf.engine().setBackend` is a regular instance method).
+    const engine = tf.engine();
+    const setBackendSpy = vi.spyOn(engine, 'setBackend');
+    setBackendSpy.mockClear();
+    try {
+      const [a, b, c] = await Promise.all([
+        TfjsReasoner.detectBestBackend(),
+        TfjsReasoner.detectBestBackend(),
+        TfjsReasoner.detectBestBackend(),
+      ]);
+      expect(a).toBe(b);
+      expect(b).toBe(c);
+      expect(tf.getBackend()).toBe(a);
+      expect(setBackendSpy.mock.calls.length).toBeLessThanOrEqual(3);
+    } finally {
+      setBackendSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- `TfjsReasoner.detectBestBackend()` mutated global tfjs state via `tf.setBackend` with no in-flight lock. Two concurrent chains could interleave probes and leave tfjs on a backend that didn't match the value returned to one of the callers — breaking the "returned backend is the active backend" post-condition. Hits boot logic + UI-init paths that detect concurrently.
- Add a private static `inflightDetection: Promise | null` slot. Overlapping callers share the same promise; the slot clears in a `finally` once the chain settles, so the next call after settle re-probes (lets consumers re-detect after installing a new backend package mid-session).

## Why now

Codex flagged this as a P2 (id `3143030481`) on PR #114 (develop→demo promotion). Pre-existing develop bug, surfaced because PR #114 promotes everything new in develop. PR #114 is on hold until both this and the sibling `fromJSON` backend-load fix (#117) land.

## Test plan

- [x] `npm run verify` — 521 tests pass, 0 lint errors, build + docs green
- [x] RED→GREEN verified: pre-fix run produced `a='wasm', b='wasm', c='cpu'` with the namespace-spy workaround using `tf.engine().setBackend` (the namespace export `tf.setBackend` is non-configurable under ESM); post-fix all three callers return identical backend names
- [x] Existing `idempotent across repeated calls` test still passes — the lock is only held while a chain is in-flight, so sequential post-settle calls re-probe as before
- [x] Patch changeset queued (pre-1.0 release hold respected)

## Related

- Sibling fix for the second P2 (id `3143030482` — `fromJSON` backend module load order): #117. Independent change, can land in either order.