### PR TITLE
chore(ci): include scripts/ in code-change path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           changed=$(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$pr_number/files" --jq '.[].filename')
           echo "Changed files in PR #$pr_number:"
           printf '%s\n' "$changed"
-          if printf '%s\n' "$changed" | grep -E '^(src/|tests/|examples/|\.github/workflows/|package(-lock)?\.json|tsconfig[^/]*\.json|vite\.config\.|vitest\.config\.|eslint\.config\.|typedoc\.json)' >/dev/null; then
+          if printf '%s\n' "$changed" | grep -E '^(src/|tests/|examples/|scripts/|\.github/workflows/|package(-lock)?\.json|tsconfig[^/]*\.json|vite\.config\.|vitest\.config\.|eslint\.config\.|typedoc\.json)' >/dev/null; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- The `changes` job's path-filter regex omitted `scripts/`, so a PR that only modifies executable repo scripts (`scripts/bump-actions.mjs`, `scripts/seed-learning-network.ts`) was tagged `code=false` and skipped every gated job: `lint`, `typecheck`, `docs`, `test-core`, `test-tfjs`, `build`, `demo-build`. Script regressions could merge unvalidated.
- Add `scripts/` to the regex so script changes flip `code=true` and trigger the full gate.

## Why now

Codex flagged this as a P2 (id `3143181601`) on PR #114 (develop→demo promotion). Pre-existing develop CI bug — same pattern as the prior P2s already addressed by #116 / #117 / #118. PR #114 stays on hold until this lands; once it does, the demo promotion can re-sweep on a clean develop tip.

## Test plan

- [x] Inspected `scripts/` contents — two real code-touching files (`bump-actions.mjs`, `seed-learning-network.ts`); the gate had a real blind spot
- [x] Diff is a single regex addition; no functional code path changes
- [x] No changeset (CI-only chore — per `CLAUDE.md` "Docs / refactor / chore PRs can skip it")
- [ ] CI itself will exercise the new path on this PR (the workflow file change flips `code=true` via the `\.github/workflows/` clause that already existed; full gate runs)

## Related

- PR #114 still open, awaiting clean Codex re-sweep on the new develop tip after this lands.