### PR TITLE
feat(demo): add agentonomous favicon for browser examples

### DIFF
--- a/branding/README.md
+++ b/branding/README.md
@@ -1,0 +1,11 @@
+# branding/
+
+Canonical visual assets for the `agentonomous` library.
+
+- `favicon.svg` — 32×32 SVG favicon (indigo rounded square + white
+  lowercase `a`). Browser examples wire it up via a small Vite plugin in
+  their `vite.config.ts`; see
+  `examples/nurture-pet/vite.config.ts` for the reference implementation.
+  Do not copy this file into example source trees — the plugin serves it
+  in dev (middleware at `/favicon.svg`) and writes it to `dist/` on
+  build, so a checked-in copy would only drift.

--- a/branding/favicon.svg
+++ b/branding/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="agentonomous">
+  <rect width="32" height="32" rx="6" fill="#4f46e5"/>
+  <path fill="#fff" fill-rule="evenodd" d="M8 18a6 6 0 1 0 12 0 6 6 0 1 0-12 0Zm3 0a3 3 0 1 1 6 0 3 3 0 1 1-6 0ZM19 11h4v13h-4z"/>
+</svg>

--- a/docs/plans/2026-04-26-example-favicon.md
+++ b/docs/plans/2026-04-26-example-favicon.md
@@ -1,0 +1,312 @@
+# Example Favicon Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a library-branded SVG favicon (`agentonomous`) wired into every browser example via a small Vite plugin, with `branding/favicon.svg` as the single source of truth.
+
+**Architecture:** Canonical SVG at `branding/favicon.svg`. Each browser example's `vite.config.ts` registers a small `brandFaviconPlugin()` that (a) serves the asset at `/favicon.svg` in dev via a middleware and (b) copies it into the example's `dist/` on `closeBundle` for production builds. The example's HTML references it with a relative `href` so Vite's `base` rewrite works for the GitHub Pages deploy (`PAGES_BASE=/agentonomous/`). Today only `examples/nurture-pet/` is wired; `examples/llm-mock/` is a Node CLI with no HTML and is out of scope.
+
+**Tech Stack:** SVG, Vite 8 plugin API, Node 22 ESM, `node:fs`/`node:path`.
+
+**Spec:** `docs/specs/2026-04-26-example-favicon.md`. Read before starting.
+
+## File structure
+
+- **Create:** `branding/favicon.svg` — the canonical asset, ≤700 bytes.
+- **Create:** `branding/README.md` — short note describing source-of-truth + Vite-plugin wiring.
+- **Modify:** `examples/nurture-pet/vite.config.ts` — add `brandFaviconPlugin()` + register it in `defineConfig({ plugins: [...] })`.
+- **Modify:** `examples/nurture-pet/index.html` — add `<link rel="icon" …>` inside `<head>`.
+
+No `.gitignore` change. No file committed to `examples/nurture-pet/public/`.
+
+---
+
+## Chunk 1: Asset + branding doc
+
+### Task 1: Create canonical SVG favicon
+
+**Files:**
+- Create: `branding/favicon.svg`
+
+- [ ] **Step 1: Write the SVG file**
+
+Contents (exact bytes):
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="agentonomous">
+  <rect width="32" height="32" rx="6" fill="#4f46e5"/>
+  <path fill="#fff" fill-rule="evenodd" d="M8 18a6 6 0 1 0 12 0 6 6 0 1 0-12 0Zm3 0a3 3 0 1 1 6 0 3 3 0 1 1-6 0ZM19 11h4v13h-4z"/>
+</svg>
+```
+
+The `<path>` is hand-built: an annular bowl (outer circle r=6 minus inner circle r=3, joined with `fill-rule="evenodd"`) for the rounded counter, plus a 4×13 right-stem rectangle. Reads as a geometric lowercase `a` at favicon sizes without depending on a system font.
+
+- [ ] **Step 2: Verify the file size**
+
+Run: `node -e "console.log(require('node:fs').statSync('branding/favicon.svg').size)"`
+Expected: a number ≤ 700.
+
+- [ ] **Step 3: Visually verify the glyph**
+
+Open `branding/favicon.svg` directly in a browser (e.g. `start branding/favicon.svg` on Windows, `open …` on macOS).
+Expected: an indigo rounded square with a white lowercase `a` (annular bowl + right stem), centered.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add branding/favicon.svg
+git commit -m "feat(branding): add canonical agentonomous favicon
+
+Single SVG (indigo #4f46e5 rounded square + white lowercase 'a' as
+hand-built path: annular bowl + right stem). Source of truth for
+every browser example; wiring follows in subsequent commits."
+```
+
+---
+
+### Task 2: Document the branding directory
+
+**Files:**
+- Create: `branding/README.md`
+
+- [ ] **Step 1: Write the README**
+
+Contents:
+
+```markdown
+# branding/
+
+Canonical visual assets for the `agentonomous` library.
+
+- `favicon.svg` — 32×32 SVG favicon (indigo rounded square + white
+  lowercase `a`). Browser examples wire it up via a small Vite plugin in
+  their `vite.config.ts`; see
+  `examples/nurture-pet/vite.config.ts` for the reference implementation.
+  Do not copy this file into example source trees — the plugin serves it
+  in dev (middleware at `/favicon.svg`) and writes it to `dist/` on
+  build, so a checked-in copy would only drift.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add branding/README.md
+git commit -m "docs(branding): describe favicon source-of-truth wiring"
+```
+
+---
+
+## Chunk 2: Vite plugin + HTML link
+
+### Task 3: Register `brandFaviconPlugin` in nurture-pet's Vite config
+
+**Files:**
+- Modify: `examples/nurture-pet/vite.config.ts`
+
+- [ ] **Step 1: Add imports**
+
+Insert at the top of the file (after the existing imports):
+
+```ts
+import { copyFileSync, readFileSync } from 'node:fs';
+import type { Plugin } from 'vite';
+```
+
+- [ ] **Step 2: Add the `FAVICON_SRC` constant + plugin function**
+
+Insert below the existing `libDist` helper (before `agentonomousAliases`):
+
+```ts
+const FAVICON_SRC = resolve(here, '..', '..', 'branding', 'favicon.svg');
+
+/**
+ * Serves the canonical agentonomous favicon (branding/favicon.svg) without
+ * committing a copy into the example's source tree.
+ *
+ * - Dev: middleware streams the file at /favicon.svg.
+ * - Build: closeBundle copies it into dist/favicon.svg so the deployed
+ *   bundle includes it.
+ */
+function brandFaviconPlugin(): Plugin {
+  return {
+    name: 'agentonomous:brand-favicon',
+    configureServer(server) {
+      server.middlewares.use('/favicon.svg', (_req, res) => {
+        res.setHeader('Content-Type', 'image/svg+xml');
+        res.end(readFileSync(FAVICON_SRC));
+      });
+    },
+    closeBundle() {
+      copyFileSync(FAVICON_SRC, resolve(here, 'dist', 'favicon.svg'));
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Register the plugin in `defineConfig`**
+
+Modify the existing `defineConfig({ … })` to add a `plugins` field. Final shape:
+
+```ts
+export default defineConfig({
+  base,
+  server: { port: 5173 },
+  plugins: [brandFaviconPlugin()],
+  resolve: {
+    alias: agentonomousAliases,
+  },
+  build: {
+    target: 'es2022',
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+});
+```
+
+- [ ] **Step 4: Typecheck the example config**
+
+Run from the repo root: `npm run typecheck`
+Expected: PASS. The Vite config is included in the project's `tsc --noEmit` graph and must compile without errors.
+
+- [ ] **Step 5: Build the demo and verify `dist/favicon.svg` exists**
+
+The library must be built first (the example aliases `agentonomous` to `../../dist/`).
+
+Run from the repo root:
+
+```bash
+npm run build
+cd examples/nurture-pet
+npm run build
+ls dist/favicon.svg
+```
+
+Expected: `dist/favicon.svg` exists. Also verify it is byte-identical to the canonical asset:
+
+```bash
+diff -q ../../branding/favicon.svg dist/favicon.svg
+```
+
+Expected: no output (files match).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/nurture-pet/vite.config.ts
+git commit -m "feat(demo): wire agentonomous favicon via Vite plugin
+
+Adds brandFaviconPlugin to examples/nurture-pet/vite.config.ts. Dev
+middleware serves branding/favicon.svg at /favicon.svg; closeBundle
+copies it into dist/ on build. Single source of truth; nothing is
+written into examples/nurture-pet/public/."
+```
+
+---
+
+### Task 4: Reference the favicon from `index.html`
+
+**Files:**
+- Modify: `examples/nurture-pet/index.html`
+
+- [ ] **Step 1: Add the `<link>` tag inside `<head>`**
+
+Insert after the existing `<meta name="viewport" …>` line and before the `<title>`:
+
+```html
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
+```
+
+The `href` is intentionally relative (no leading `/`). Vite rewrites it against `base` during the HTML transform so a `PAGES_BASE=/agentonomous/` build resolves to `/agentonomous/favicon.svg`, not `/favicon.svg` (which would 404 on GitHub Pages).
+
+- [ ] **Step 2: Verify the build rewrites the href under `PAGES_BASE`**
+
+Run from `examples/nurture-pet/`:
+
+```bash
+PAGES_BASE=/agentonomous/ npm run build
+grep favicon dist/index.html
+```
+
+Expected output line:
+
+```
+<link rel="icon" type="image/svg+xml" href="/agentonomous/favicon.svg" />
+```
+
+If the output keeps a leading `/agentonomous/agentonomous/` (double-prefix) or omits the prefix entirely, the `<link>` `href` is wrong — recheck Step 1.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/nurture-pet/index.html
+git commit -m "feat(demo): reference agentonomous favicon from index.html"
+```
+
+---
+
+## Chunk 3: Verify + open PR
+
+### Task 5: Run pre-PR gate, manual smoke, open PR
+
+- [ ] **Step 1: Run the full gate from the repo root**
+
+Run: `npm run verify`
+Expected: format:check, lint, typecheck, test, build all PASS.
+
+If any stage fails, fix the cause in a new commit on `feat/favicon` — do NOT use `--no-verify`. Re-run `npm run verify` until green.
+
+- [ ] **Step 2: Manual smoke test**
+
+Run from repo root: `npm run demo:dev`
+Open http://localhost:5173/.
+Expected: the browser tab shows an indigo square with a white `a`. Hard-refresh (Ctrl+Shift+R / Cmd+Shift+R) to bypass any cached default favicon.
+Switch to OS dark mode and reload. Expected: same favicon, still legible (indigo on the dark tab strip).
+
+If the favicon does not render, check the dev server console for `/favicon.svg` requests — the middleware should log a 200. If you see a 404, the plugin is not registered; recheck Task 3 Step 3.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/favicon
+```
+
+- [ ] **Step 4: Open the PR against `develop`**
+
+```bash
+gh pr create --base develop --title "feat(demo): add agentonomous favicon for browser examples" --body "$(cat <<'EOF'
+## Summary
+- Adds canonical `branding/favicon.svg` (indigo rounded square + white lowercase `a`, hand-built path).
+- Wires it through `examples/nurture-pet` via a small Vite plugin: dev middleware + build-time copy into `dist/`.
+- References it from `examples/nurture-pet/index.html` with a relative `href` so `PAGES_BASE` resolves correctly on GitHub Pages.
+- No `public/favicon.svg` committed in the example — `branding/` is the single source of truth.
+
+Spec: `docs/specs/2026-04-26-example-favicon.md`.
+Plan: `docs/plans/2026-04-26-example-favicon.md`.
+
+No changeset: pure example wiring + new branding asset; no library behavior change.
+
+## Test plan
+- [ ] `npm run verify` is green.
+- [ ] `npm run demo:dev` shows the favicon in the browser tab in light + dark mode.
+- [ ] `cd examples/nurture-pet && PAGES_BASE=/agentonomous/ npm run build && grep favicon dist/index.html` prints `/agentonomous/favicon.svg`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Arm Codex polling**
+
+After the `@codex review` workflow fires (auto-triggered by PR open), arm a 5-minute cron poll loop per the project's standing rule (`feedback_pr_codex_polling`). Stop on findings or approval comment.
+
+---
+
+## Notes for executor
+
+- **Worktree:** This plan is meant to run inside `.worktrees/feat-favicon/` on branch `feat/favicon`. Do not edit `develop` directly.
+- **Determinism:** Nothing here interacts with the deterministic tick pipeline. Library `src/` is untouched. No new use of `Date.now()`, `Math.random()`, or `setTimeout`.
+- **Out of scope (explicitly):**
+  - PNG/ICO fallbacks.
+  - Touch-icon / Apple-touch-icon assets.
+  - Wiring favicons into `examples/llm-mock/` (Node CLI, no HTML).
+  - Factoring `brandFaviconPlugin` into `examples/_shared/` (deferred until a second HTML example exists — see spec "Future work").

--- a/docs/plans/2026-04-26-example-favicon.md
+++ b/docs/plans/2026-04-26-example-favicon.md
@@ -4,7 +4,7 @@
 
 **Goal:** Ship a library-branded SVG favicon (`agentonomous`) wired into every browser example via a small Vite plugin, with `branding/favicon.svg` as the single source of truth.
 
-**Architecture:** Canonical SVG at `branding/favicon.svg`. Each browser example's `vite.config.ts` registers a small `brandFaviconPlugin()` that (a) serves the asset at `/favicon.svg` in dev via a middleware and (b) copies it into the example's `dist/` on `closeBundle` for production builds. The example's HTML references it with a relative `href` so Vite's `base` rewrite works for the GitHub Pages deploy (`PAGES_BASE=/agentonomous/`). Today only `examples/nurture-pet/` is wired; `examples/llm-mock/` is a Node CLI with no HTML and is out of scope.
+**Architecture:** Canonical SVG at `branding/favicon.svg`. Each browser example's `vite.config.ts` registers a small `brandFaviconPlugin()` that (a) serves the asset at `/favicon.svg` in dev via a middleware and (b) copies it into the example's `dist/` on `closeBundle` for production builds. The example's HTML references it with a bare-relative `href` (`favicon.svg`); browsers resolve it against the document URL at runtime, so both `localhost:5173/` and the GitHub Pages deploy at `https://user.github.io/agentonomous/` fetch the asset correctly without any Vite-side rewrite (Vite only rewrites root-relative URLs resolving to files in `publicDir`, which this plugin doesn't use). Today only `examples/nurture-pet/` is wired; `examples/llm-mock/` is a Node CLI with no HTML and is out of scope.
 
 **Tech Stack:** SVG, Vite 8 plugin API, Node 22 ESM, `node:fs`/`node:path`.
 
@@ -216,24 +216,34 @@ Insert after the existing `<meta name="viewport" …>` line and before the `<tit
 <link rel="icon" type="image/svg+xml" href="favicon.svg" />
 ```
 
-The `href` is intentionally relative (no leading `/`). Vite rewrites it against `base` during the HTML transform so a `PAGES_BASE=/agentonomous/` build resolves to `/agentonomous/favicon.svg`, not `/favicon.svg` (which would 404 on GitHub Pages).
+Note: bare-relative `href` (no leading `/`). Vite leaves bare-relative
+URLs untouched in the HTML transform (it only rewrites root-relative
+URLs that resolve to files in `publicDir`, which this plugin doesn't
+use). Runtime behavior is correct anyway: a page served at
+`https://user.github.io/agentonomous/index.html` resolves the relative
+href to `https://user.github.io/agentonomous/favicon.svg`, which is
+where `closeBundle` wrote the asset. No Vite rewrite involved.
 
-- [ ] **Step 2: Verify the build rewrites the href under `PAGES_BASE`**
+- [ ] **Step 2: Verify the build leaves the href bare-relative**
 
 Run from `examples/nurture-pet/`:
 
 ```bash
-PAGES_BASE=/agentonomous/ npm run build
+npm run build
 grep favicon dist/index.html
 ```
 
 Expected output line:
 
 ```
-<link rel="icon" type="image/svg+xml" href="/agentonomous/favicon.svg" />
+<link rel="icon" type="image/svg+xml" href="favicon.svg" />
 ```
 
-If the output keeps a leading `/agentonomous/agentonomous/` (double-prefix) or omits the prefix entirely, the `<link>` `href` is wrong — recheck Step 1.
+The href is unchanged from `index.html` source — Vite does not rewrite
+bare-relative URLs. Browsers resolve it against the document URL at
+runtime, which is what makes both `localhost:5173/` and
+`user.github.io/agentonomous/` work without per-deployment build
+arguments.
 
 - [ ] **Step 3: Commit**
 
@@ -277,7 +287,7 @@ gh pr create --base develop --title "feat(demo): add agentonomous favicon for br
 ## Summary
 - Adds canonical `branding/favicon.svg` (indigo rounded square + white lowercase `a`, hand-built path).
 - Wires it through `examples/nurture-pet` via a small Vite plugin: dev middleware + build-time copy into `dist/`.
-- References it from `examples/nurture-pet/index.html` with a relative `href` so `PAGES_BASE` resolves correctly on GitHub Pages.
+- References it from `examples/nurture-pet/index.html` with a bare-relative `href`; browsers resolve it against the document URL at runtime so both `localhost:5173/` and the GitHub Pages deploy fetch it correctly without a build-time rewrite.
 - No `public/favicon.svg` committed in the example — `branding/` is the single source of truth.
 
 Spec: `docs/specs/2026-04-26-example-favicon.md`.
@@ -288,7 +298,7 @@ No changeset: pure example wiring + new branding asset; no library behavior chan
 ## Test plan
 - [ ] `npm run verify` is green.
 - [ ] `npm run demo:dev` shows the favicon in the browser tab in light + dark mode.
-- [ ] `cd examples/nurture-pet && PAGES_BASE=/agentonomous/ npm run build && grep favicon dist/index.html` prints `/agentonomous/favicon.svg`.
+- [ ] `cd examples/nurture-pet && npm run build && grep favicon dist/index.html` prints `favicon.svg` (bare-relative is intentional — see plan Task 4).
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF

--- a/docs/specs/2026-04-26-example-favicon.md
+++ b/docs/specs/2026-04-26-example-favicon.md
@@ -1,0 +1,113 @@
+# 2026-04-26 — Example favicon
+
+## Goal
+
+Ship a single, library-branded favicon (`agentonomous`) that every browser
+example wires up automatically. Today there is exactly one HTML example
+(`examples/nurture-pet`); the design must scale to additional examples
+without per-example asset duplication.
+
+## Non-goals
+
+- Logo for README, npm, or social preview cards. Out of scope; this is a
+  16×16/32×32 tab favicon only.
+- PNG / ICO fallback for legacy browsers. SVG-only by user decision —
+  evergreen browsers cover the demo audience.
+- Touch-icon / Apple-touch-icon assets. Can be layered on later if a PWA
+  posture is ever pursued.
+- Wiring favicons into non-browser examples (`examples/llm-mock` is a
+  Node CLI; it has no HTML surface).
+
+## Asset
+
+- **File:** `branding/favicon.svg`, single source of truth, ~600 bytes.
+- **Format:** SVG, 32×32 viewBox.
+- **Shape:** rounded square, corner radius 6 (≈19%).
+- **Background fill:** `#4f46e5` (indigo — matches the demo's primary
+  button color).
+- **Glyph:** white lowercase `a`, geometric sans, optical weight ≈700,
+  centered, x-height ≈ 60% of the square. Hand-built `<path>` so render is
+  font-independent.
+- **Theming:** identical in light + dark — indigo on white tab strips and
+  on dark Chrome strips both render legibly without a color-scheme switch.
+
+## Wiring
+
+A small Vite plugin (`brandFaviconPlugin`) inlined in each example's
+`vite.config.ts` handles both dev and build:
+
+```ts
+import { copyFileSync, readFileSync } from 'node:fs';
+
+const FAVICON_SRC = resolve(here, '..', '..', 'branding', 'favicon.svg');
+
+function brandFaviconPlugin() {
+  return {
+    name: 'agentonomous:brand-favicon',
+    configureServer(server) {
+      server.middlewares.use('/favicon.svg', (_req, res) => {
+        res.setHeader('Content-Type', 'image/svg+xml');
+        res.end(readFileSync(FAVICON_SRC));
+      });
+    },
+    closeBundle() {
+      copyFileSync(FAVICON_SRC, resolve(here, 'dist', 'favicon.svg'));
+    },
+  };
+}
+```
+
+- **Dev (`npm run dev`):** middleware serves the canonical asset at
+  `/favicon.svg` on every request. No file is written into the example's
+  source tree.
+- **Build (`vite build`):** `closeBundle` copies the asset into the
+  example's `dist/` so deployed bundles include it.
+- **HTML wiring:** `<link rel="icon" type="image/svg+xml" href="favicon.svg" />`
+  inside `<head>`. The relative `href` (no leading `/`) lets Vite's
+  `base` prefix work for GitHub Pages deploys (`PAGES_BASE=/agentonomous/`).
+
+### Why a Vite plugin and not `predev` / `prebuild` scripts
+
+A pre-step would have to write a copy into `examples/<name>/public/favicon.svg`,
+which then gets either committed (stale duplicate) or `.gitignore`-d
+(invisible drift). The plugin keeps `branding/favicon.svg` as the single
+on-disk artifact and keeps each example's source tree free of generated
+files.
+
+## Files changed
+
+1. `branding/favicon.svg` — new, the canonical asset.
+2. `branding/README.md` — new, ~3 lines: "Canonical agentonomous favicon.
+   Examples wire it via a small Vite plugin in their `vite.config.ts`. See
+   `examples/nurture-pet/vite.config.ts` for the reference implementation."
+3. `examples/nurture-pet/vite.config.ts` — add `brandFaviconPlugin()` and
+   register it in `defineConfig({ plugins: [...] })`.
+4. `examples/nurture-pet/index.html` — add the `<link rel="icon" …>` line
+   inside `<head>`.
+
+No `.gitignore` change. No file inside any `examples/*/public/` directory.
+
+## Verification
+
+- `npm run verify` (root) green: format:check, lint, typecheck, test, build.
+- Manual: `npm run demo:dev`, hard-refresh the tab, confirm the favicon
+  renders in the browser tab strip in both light and dark themes.
+- Manual: `cd examples/nurture-pet && npm run build`, confirm
+  `examples/nurture-pet/dist/favicon.svg` exists post-build.
+- GitHub Pages: deploys via the existing workflow without changes; only
+  the `<link>` href + `closeBundle` copy are new, both already respect
+  `PAGES_BASE`.
+
+## Branch / PR / changeset
+
+- **Branch:** `feat/favicon` (worktree `.worktrees/feat-favicon`).
+- **PR target:** `develop`.
+- **Changeset:** none. Pure example wiring + new branding asset; no library
+  behavior change, so no semver bump owed.
+
+## Future work (not in this PR)
+
+- Factor `brandFaviconPlugin` into `examples/_shared/vite-plugins/` once a
+  second HTML example exists. YAGNI for one consumer.
+- Add `branding/logo.svg` (full wordmark, larger than the favicon) when a
+  social-preview / npm card is needed. Out of scope here.

--- a/docs/specs/2026-04-26-example-favicon.md
+++ b/docs/specs/2026-04-26-example-favicon.md
@@ -63,8 +63,14 @@ function brandFaviconPlugin() {
 - **Build (`vite build`):** `closeBundle` copies the asset into the
   example's `dist/` so deployed bundles include it.
 - **HTML wiring:** `<link rel="icon" type="image/svg+xml" href="favicon.svg" />`
-  inside `<head>`. The relative `href` (no leading `/`) lets Vite's
-  `base` prefix work for GitHub Pages deploys (`PAGES_BASE=/agentonomous/`).
+  inside `<head>`. The bare-relative `href` (no leading `/`) is left
+  untouched by Vite's HTML transform (Vite only rewrites root-relative
+  URLs that resolve to files in `publicDir`, which this plugin
+  intentionally does not use). Runtime behavior is correct anyway:
+  browsers resolve a relative `href` against the document URL, so a
+  page served from `https://user.github.io/agentonomous/` fetches
+  `https://user.github.io/agentonomous/favicon.svg` — exactly where
+  `closeBundle` wrote the asset.
 
 ### Why a Vite plugin and not `predev` / `prebuild` scripts
 
@@ -73,6 +79,16 @@ which then gets either committed (stale duplicate) or `.gitignore`-d
 (invisible drift). The plugin keeps `branding/favicon.svg` as the single
 on-disk artifact and keeps each example's source tree free of generated
 files.
+
+### GH Pages
+
+`closeBundle` writes the asset to `dist/favicon.svg`, which the GH
+Pages workflow deploys at `/agentonomous/favicon.svg`. The HTML
+`<link href="favicon.svg">` is bare-relative and is left as-is in
+`dist/index.html` (Vite does not rewrite it — see "HTML wiring"
+above). Browsers resolve the relative href against the page URL, so
+the deployed favicon loads correctly. No `PAGES_BASE`-specific build
+logic is required.
 
 ## Files changed
 
@@ -94,9 +110,9 @@ No `.gitignore` change. No file inside any `examples/*/public/` directory.
   renders in the browser tab strip in both light and dark themes.
 - Manual: `cd examples/nurture-pet && npm run build`, confirm
   `examples/nurture-pet/dist/favicon.svg` exists post-build.
-- GitHub Pages: deploys via the existing workflow without changes; only
-  the `<link>` href + `closeBundle` copy are new, both already respect
-  `PAGES_BASE`.
+- GitHub Pages: deploys via the existing workflow without changes. See
+  the "GH Pages" subsection above for why the bare-relative `href`
+  resolves correctly without any `PAGES_BASE` rewrite.
 
 ## Branch / PR / changeset
 

--- a/examples/nurture-pet/index.html
+++ b/examples/nurture-pet/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <title>Nurture pet demo</title>
     <style>
       :root {

--- a/examples/nurture-pet/vite.config.ts
+++ b/examples/nurture-pet/vite.config.ts
@@ -1,6 +1,8 @@
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
+import { copyFileSync, readFileSync } from 'node:fs';
+import type { Plugin } from 'vite';
 
 /**
  * Asset base path. Respects `PAGES_BASE` so the CI Pages workflow can serve
@@ -11,6 +13,31 @@ const base = process.env.PAGES_BASE ?? '/';
 
 const here = fileURLToPath(new URL('.', import.meta.url));
 const libDist = (subpath: string) => resolve(here, '..', '..', 'dist', subpath);
+
+const FAVICON_SRC = resolve(here, '..', '..', 'branding', 'favicon.svg');
+
+/**
+ * Serves the canonical agentonomous favicon (branding/favicon.svg) without
+ * committing a copy into the example's source tree.
+ *
+ * - Dev: middleware streams the file at /favicon.svg.
+ * - Build: closeBundle copies it into dist/favicon.svg so the deployed
+ *   bundle includes it.
+ */
+function brandFaviconPlugin(): Plugin {
+  return {
+    name: 'agentonomous:brand-favicon',
+    configureServer(server) {
+      server.middlewares.use('/favicon.svg', (_req, res) => {
+        res.setHeader('Content-Type', 'image/svg+xml');
+        res.end(readFileSync(FAVICON_SRC));
+      });
+    },
+    closeBundle() {
+      copyFileSync(FAVICON_SRC, resolve(here, 'dist', 'favicon.svg'));
+    },
+  };
+}
 
 /**
  * Resolve `agentonomous` and its adapter subpaths against the library's built
@@ -45,6 +72,7 @@ const agentonomousAliases = [
 export default defineConfig({
   base,
   server: { port: 5173 },
+  plugins: [brandFaviconPlugin()],
   resolve: {
     alias: agentonomousAliases,
   },


### PR DESCRIPTION
## Summary
- Adds canonical `branding/favicon.svg` (indigo rounded square + white lowercase `a`, hand-built path).
- Wires it through `examples/nurture-pet` via a small Vite plugin: dev middleware + build-time copy into `dist/`.
- References it from `examples/nurture-pet/index.html` with a bare-relative `href` so the browser resolves it against the document URL — works for both `localhost:5173/` (dev middleware) and `https://luis85.github.io/agentonomous/` (deployed asset).
- No `public/favicon.svg` committed in the example — `branding/` is the single source of truth.

Spec: `docs/specs/2026-04-26-example-favicon.md`.
Plan: `docs/plans/2026-04-26-example-favicon.md`.

No changeset: pure example wiring + new branding asset; no library behavior change.

## Test plan
- [ ] `npm run verify` is green.
- [ ] `npm run demo:dev` shows the favicon in the browser tab in light + dark mode.
- [ ] `cd examples/nurture-pet && npm run build && grep favicon dist/index.html` prints `favicon.svg` (bare-relative is intentional — see plan Task 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)