### PR TITLE
test(agent): cover stage-blocked branch in learner failure scoring

### DIFF
--- a/docs/plans/2026-04-26-review-bot-minor-stage-blocked-failure-branch-has-42ede76-1.md
+++ b/docs/plans/2026-04-26-review-bot-minor-stage-blocked-failure-branch-has-42ede76-1.md
@@ -1,0 +1,50 @@
+---
+date: 2026-04-26
+slug: review-bot-minor-stage-blocked-failure-branch-has-42ede76-1
+finding-id: 42ede76.1
+tracker: '#87'
+severity: MINOR
+---
+
+# Fix review finding `42ede76.1` — `stage-blocked` failure branch has no test
+
+## Source
+
+From `#87` comment 4321324736, finding `42ede76.1`:
+
+> **[MINOR]** `src/agent/internal/CognitionPipeline.ts:143` — `stage-blocked` failure branch has no test
+>
+> **Problem:** `invokeSkillAction` gained four new `scoreFailure` call sites in this diff; the test file `Agent-learner-failure-score.test.ts` exercises three of them (`err(...)`, throws, `not-registered`) but never the `stage-blocked` branch (requires `ageModel` + `stageCapabilities` set + skill blocked by stage)
+>
+> **Why it matters:** A future refactor that accidentally drops or mis-shapes the `scoreFailure` call inside the stage-capability gate would go undetected; the branch is structurally distinct from the others because it fires before the registry lookup
+>
+> **Fix:**
+>
+> ```diff
+> // Add to Agent-learner-failure-score.test.ts
+> +it('scores an outcome when a skill is blocked by life stage', async () => {
+> +  const blocked: Skill = { id: 'blocked', label: 'Blocked', baseEffectiveness: 1,
+> +    execute: () => Promise.resolve(ok({ effectiveness: 1 })) };
+> +  const learner = recordingLearner();
+> +  const caps = new StageCapabilities({ kit: ['allowed'] }); // 'blocked' absent
+> +  const agent = agentWithSkill(blocked, learner, { ageModel: new AgeModel(...), stageCapabilities: caps });
+> +  agent.interact('blocked');
+> +  await agent.tick(0.016);
+> +  expect(learner.calls[0]).toMatchObject({ details: { failed: true, code: 'stage-blocked' } });
+> +});
+> ```
+
+## Acceptance
+
+- Apply the bot's proposed fix (see body above).
+- Add or update tests covering the new code paths.
+- `npm run verify` passes locally.
+- Codex review on the PR is acknowledged or rebutted on each thread.
+
+## Rollout
+
+- Branch: `fix/review-bot-minor-stage-blocked-failure-branch-has-42ede76-1` (already cut by review-fix skill).
+- PR base: `develop`.
+- PR body MUST contain on its own line: `Refs #87 finding:42ede76.1`.
+- PR body MUST NOT contain `Closes #87` / `Fixes #87`.
+- Changeset required if behavior changes (`npm run changeset`).

--- a/tests/unit/agent/Agent-learner-failure-score.test.ts
+++ b/tests/unit/agent/Agent-learner-failure-score.test.ts
@@ -6,6 +6,8 @@ import type { Learner, LearningOutcome } from '../../../src/cognition/learning/L
 import { InMemoryEventBus } from '../../../src/events/InMemoryEventBus.js';
 import { DirectBehaviorRunner } from '../../../src/cognition/behavior/DirectBehaviorRunner.js';
 import { INTERACTION_REQUESTED } from '../../../src/interaction/InteractionRequestedEvent.js';
+import { AgeModel } from '../../../src/lifecycle/AgeModel.js';
+import type { StageCapabilityMap } from '../../../src/lifecycle/StageCapabilities.js';
 import { Needs } from '../../../src/needs/Needs.js';
 import { ManualClock } from '../../../src/ports/ManualClock.js';
 import { SeededRng } from '../../../src/ports/SeededRng.js';
@@ -174,6 +176,42 @@ describe('Stage 8 (score) on SkillFailed branches', () => {
     // Pre-skill hunger ≈ 0.2 (initial level); post-skill would be 0.7.
     // Tolerate tiny float drift; the key claim is "pre, not post".
     expect(details.preNeeds!.hunger).toBeCloseTo(0.2, 5);
+  });
+
+  it('scores an outcome when a skill is blocked by life stage', async () => {
+    // The stage-capability gate fires BEFORE the registry lookup, so it
+    // is structurally distinct from the `not-registered` / `err(...)` /
+    // throws branches even though all four flow into `scoreFailure`.
+    // Without a direct test, a refactor could drop or mis-shape the
+    // `scoreFailure` call inside the gate without a single assertion
+    // catching it.
+    const blocked: Skill = {
+      id: 'blocked',
+      label: 'Blocked',
+      baseEffectiveness: 1,
+      execute() {
+        return Promise.resolve(ok({ effectiveness: 1 }));
+      },
+    };
+    const learner = recordingLearner();
+    // 'baby' stage explicitly only allows 'allowed' — 'blocked' falls
+    // through the allow-list check and gets denied.
+    const stageCapabilities: StageCapabilityMap = {
+      baby: { allow: ['allowed'] },
+    };
+    const ageModel = new AgeModel({
+      bornAt: 0,
+      schedule: [{ stage: 'baby', atSeconds: 0 }],
+    });
+    const agent = agentWithSkill(blocked, learner, { ageModel, stageCapabilities });
+    agent.interact('blocked');
+    await agent.tick(0.016);
+
+    expect(learner.calls).toHaveLength(1);
+    expect(learner.calls[0]).toMatchObject({
+      intention: { kind: 'satisfy', type: 'blocked' },
+      details: { failed: true, code: 'stage-blocked' },
+    });
   });
 
   it('omits preNeeds when the agent has no Needs subsystem', async () => {


### PR DESCRIPTION
## Summary

`CognitionPipeline.invokeSkillAction` flows into `scoreFailure` from
four branches: `err(...)`, throws, `not-registered`, and the
stage-capability gate. The `Agent-learner-failure-score.test.ts` suite
covered three but never the stage-blocked branch, even though the gate
fires BEFORE the registry lookup and is structurally distinct (it can
score a failure for a skill that IS registered).

This PR adds the missing test:
- registers `blocked` and routes interact `blocked` →
  `invokeSkill('blocked')` via the existing reactive-handler helper
- attaches an `AgeModel` at stage `baby` plus a `StageCapabilityMap`
  whose `baby` allow-list lists only `allowed` (so `blocked` is
  denied)
- ticks once and asserts the learner saw `details.failed: true,
  details.code: 'stage-blocked'`

A future refactor that drops or mis-shapes the `scoreFailure` call
inside the gate now fails this test instead of silently regressing.

Refs #87 finding:42ede76.1

## Test plan

- [x] `npm run verify` — 523 tests pass (was 522), lint + typecheck +
  build green
- [x] New test added; only test-file change. No source change, no
  behavior delta, no changeset needed