### PR TITLE
chore(skill): polish review-fix tracker parse flow

### DIFF
--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -51,88 +51,93 @@ Confirm with the user:
 
 ### 1. Locate the finding(s)
 
-**Single-finding mode.** Substitute the user-provided finding ID
-(e.g. `682b557.3`) for `${ID}` below before running:
+Both modes share the same fetch + parse step. Node 22 is a hard
+project requirement (`.nvmrc`), so the parser is a checked-in script
+at `scripts/review-fix-parse.mjs`. **Do not** try to filter the
+comments JSON inline with `gh --jq`, `jq`, `node -e` heredocs, or
+`grep | sed`. The recipe below dodges five real footguns:
+
+1. `gh api --paginate --slurp --jq` is rejected by current `gh`
+   versions ("the `--slurp` option is not supported with `--jq` or
+   `--template`"). Slurp must run with no `--jq` filter.
+2. `--slurp` returns an array-of-pages (`[[...page1...], [...page2...]]`),
+   not a flat comment list. The script flattens; do not assume flat.
+3. `jq` is not installed by default on Windows or many CI images, so
+   the skill must not depend on it.
+4. Windows Git Bash maps `/tmp` for shell builtins but native Node
+   resolves the same path to `D:\tmp` (which usually does not exist).
+   Cache files therefore live under `.review-fix-cache/` in the repo
+   root (gitignored), not `/tmp` or `${HOME}`.
+5. Finding-marker text can appear inside another finding's
+   `<details>` body or quoted diff. The script only treats top-level
+   checklist lines (`^- \[[ x]\] `) as finding boundaries.
+
+```bash
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+mkdir -p .review-fix-cache
+gh api "repos/${REPO}/issues/87/comments" --paginate --slurp \
+  > .review-fix-cache/comments.json
+node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
+  > .review-fix-cache/parsed.json
+```
+
+`parsed.json` schema (one object — most recent comment with findings):
+
+```json
+{
+  "commentId": 4321324736,
+  "commentUrl": "https://github.com/<owner>/<repo>/issues/87#issuecomment-...",
+  "createdAt": "2026-04-26T05:21:55Z",
+  "findings": [
+    {
+      "id": "<sha7>.<idx>",
+      "shipped": false,
+      "shippedPr": null,
+      "severity": "BLOCKER" | "MAJOR" | "MINOR" | "NIT",
+      "path": "src/foo/Bar.ts:143",
+      "title": "<one-line title>",
+      "body": "<verbatim <details>...</details> chunk>"
+    }
+  ]
+}
+```
+
+The script exits 1 with `No comment on the tracker contains findings`
+if every comment is a no-op summary — surface that to the user and
+stop.
+
+**Single-finding mode.** Pick the entry whose `id` matches the
+user-provided ID:
 
 ```bash
 ID="<sha7>.<idx>"            # e.g. 682b557.3
-MARKER="<!-- f:${ID} -->"
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
-gh api "/repos/${REPO}/issues/87/comments" --paginate \
-  --jq ".[] | select(.body | contains(\"${MARKER}\")) | {id, body}"
+node -e "const d=JSON.parse(require('fs').readFileSync('.review-fix-cache/parsed.json','utf8')); const f=d.findings.find(x=>x.id===process.argv[1]); if(!f){console.error('Finding '+process.argv[1]+' not found in #'+d.commentId);process.exit(1)} if(f.shipped){console.error('Finding '+f.id+' already shipped in #'+f.shippedPr);process.exit(2)} process.stdout.write(JSON.stringify(f,null,2))" "${ID}" \
+  > .review-fix-cache/finding.json
 ```
 
-If no match: hard-fail with `Finding ${ID} not found in #87 comments`.
+If the user pasted a free-text description instead of `<sha7>.<idx>`:
+refuse and ask them to grab the ID from the tracker comment (or
+`gh issue view 87 --comments`).
 
-**Sweep mode (no argument).** Pull the most recent comment that
-actually contains finding markers (the review bot is allowed to post
-no-op comments like `YYYY-MM-DD — no-op …` with zero findings; those
-must be skipped, not picked), then extract every finding ID from it.
-Three pagination / shape subtleties matter:
+**Sweep mode (no argument).** Iterate `.findings[]` from
+`parsed.json`. For each entry:
 
-1. Without `--slurp`, `gh api --paginate --jq '... | last'` runs the
-   filter once per page and returns one row per page (last-of-each-
-   page, not the global latest comment).
-2. With `--slurp`, `gh api` returns an array of pages (one entry per
-   page) rather than a flat list of comments, so `sort_by(.created_at)`
-   would be operating on an array-of-arrays. Pipe through `add` first
-   to concatenate the pages into a single flat array.
-3. The newest comment may be a no-op summary with no findings. Filter
-   to comments whose body contains `<!-- f:` _before_ taking `last`,
-   so sweep mode picks the most recent comment that has work to do.
-4. When `last` is applied to an empty array it returns `null`, but a
-   bare `| {id, body}` projection turns that into the misleading
-   `{"id":null,"body":null}` — i.e. truthy JSON. Guard the projection
-   with `if . == null then empty else {id, body} end` so an
-   "everything is no-op" run yields a genuinely empty `LAST_COMMENT`.
-5. Finding-marker text can legitimately appear inside a finding's
-   `<details>` body or diff block (the bot quotes other comments).
-   Parse IDs only from checklist lines (`- [ ]` / `- [x]`) so quoted
-   marker templates inside bodies are not mistaken for real findings.
-
-```bash
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
-LAST_COMMENT="$(gh api "repos/${REPO}/issues/87/comments" \
-  --paginate --slurp \
-  --jq 'add
-        | map(select(.body | contains("<!-- f:")))
-        | sort_by(.created_at)
-        | last
-        | if . == null then empty else {id, body} end')"
-
-if [ -z "${LAST_COMMENT}" ] || [ "${LAST_COMMENT}" = "null" ]; then
-  echo "No comment on #87 contains findings — nothing to sweep" >&2
-  exit 1
-fi
-
-echo "${LAST_COMMENT}" | jq -r '.body' \
-  | grep -E '^- \[[ x]\] ' \
-  | grep -oE '<!-- f:[A-Za-z0-9]+\.[0-9]+ -->' \
-  | sed -E 's/<!-- f:(.+) -->/\1/'
-```
-
-For each ID returned:
-
-- Skip if its checklist line in the same comment body starts with
-  `- [x]` (already shipped — log `Skipping <id> (shipped in #N)` and
-  continue).
-- Skip if `.worktrees/fix-review-<slug>` already exists (log
-  `Skipping <id> (worktree exists at <path>)` and continue).
-- Otherwise, run steps 2 → 5 for that finding.
+- `shipped === true` → log `Skipping <id> (shipped in #<shippedPr>)`
+  and continue.
+- `.worktrees/fix-review-<slug>` already exists → log
+  `Skipping <id> (worktree exists at <path>)` and continue.
+- Otherwise run steps 2 → 5 for that finding.
 
 ### 2. Extract finding fields
 
-From the matched comment body, locate the line ending with
-`<!-- f:<sha7>.<idx> -->`. Pull:
+`scripts/review-fix-parse.mjs` already split the chosen finding into
+`{id, shipped, shippedPr, severity, path, title, body}`. Read those
+fields from `.review-fix-cache/finding.json` (single mode) or from
+`.review-fix-cache/parsed.json` `.findings[i]` (sweep mode). Do not
+re-parse the comment body by hand — the regex lives in the script.
 
-- **Severity** — the `**[…]**` token (`BLOCKER` / `MAJOR` / `MINOR` /
-  `NIT`).
-- **Path** — the backtick-quoted path immediately after.
-- **Title** — the text between `— ` and the HTML comment.
-- **Body** — the contents of the `<details>` block on the lines below.
-
-If the line shows `- [x]` instead of `- [ ]`: hard-fail
-`Finding <id> already shipped in #<PR>`.
+The parser already hard-fails single mode on `shipped === true`. In
+sweep mode, you must perform the equivalent skip yourself (step 1).
 
 ### 3. Compute slug + paths
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -22,14 +22,47 @@ description: Ingests one or all open findings from the rolling daily-code-review
 
 - **Single-finding mode** — user supplies a finding ID (`682b557.3`).
   Runs steps 1 → 6 once for that ID. Default and primary path.
+  Step 7 (post-merge cleanup) is user-driven and happens after the
+  PR ships.
 - **Sweep mode** — user invokes the skill with no argument. Pull the
   most recent comment on `#87` that contains finding markers (skip
   no-op comments), parse every `<!-- f:<id> -->` marker, skip ones
   already rendered `- [x]`, and run steps 2 → 5 once per remaining
   finding. Each finding still gets its own worktree + branch + plan
   (one finding = one branch = one PR — sweep just batches the _setup_,
-  not the findings themselves). At the end, print a single hand-off
-  summary listing every plan written.
+  not the findings themselves). Step 6 prints one combined hand-off
+  block; step 7 cleanup is per-finding and runs as each PR ships.
+
+## Workflow at a glance
+
+`review-fix` only owns the **plan-creation** stage. The full lifecycle
+of a tracker finding looks like this — the user drives steps 2-6 in
+their own shell after this skill hands off, and step 7 is the cleanup
+they run after the PR merges:
+
+```text
+1. /review-fix [<id>]               ← this skill
+     fetches tracker → picks finding → cuts worktree + branch → writes plan
+
+2. cd <worktree>
+   /superpowers:writing-plans <plan-path>
+     refine plan into chunked tasks
+
+3. /superpowers:executing-plans <plan-path>
+     TDD implementation, one task at a time
+
+4. npm run verify                   ← pre-PR gate
+
+5. gh pr create --base develop ...
+     PR body MUST include the magic line: Refs #87 finding:<id>
+
+6. Codex review → resolve threads → owner merges PR to develop
+
+7. Post-merge cleanup (this skill, §7 below)
+     prune worktree · delete branch · refresh develop
+     `review-fix-shipped` Action ticks the tracker line and appends
+     `(shipped in #<PR>)` automatically — do NOT edit the comment.
+```
 
 ## Before you start
 
@@ -233,33 +266,101 @@ From `#87` comment <comment-id>, finding `<id>`:
 
 ### 6. Hand off
 
-**Single-finding mode.** Print exactly:
+The hand-off message has three sections so the user always knows
+what's been done, what they do next, and what runs automatically.
+Use these exact headings — they're what the user scans for.
+
+**Single-finding mode.** Print:
 
 ```text
-Plan written to <plan-path> on branch <branch> in <worktree-dir>.
-Next: cd <worktree-dir> && /superpowers:writing-plans <plan-path>
+✅ Done by /review-fix:
+  - Cached tracker comments to .review-fix-cache/comments.json
+  - Picked finding <id> from comment <comment-id> (<commentUrl>)
+  - Cut branch <branch> off origin/develop
+  - Created worktree at <worktree-dir> (npm install complete)
+  - Wrote plan at <plan-path>
+
+▶ You do next:
+  1. cd <worktree-dir>
+  2. /superpowers:writing-plans <plan-path>
+  3. /superpowers:executing-plans <plan-path>          (TDD loop)
+  4. npm run verify                                    (pre-PR gate)
+  5. gh pr create --base develop  --title "..."  --body "..."
+       PR body MUST include this line on its own:
+         Refs #87 finding:<id>
+  6. After PR merges: run the cleanup commands in §7 of the skill
+     (or re-invoke /review-fix; the skill prints them again).
+
+ℹ️ What happens automatically:
+  - The `review-fix-shipped` Action ticks the tracker line `[x]` and
+    appends `(shipped in #<your-pr>)` once the PR merges. Do NOT
+    edit the tracker comment yourself.
 ```
 
-**Sweep mode.** Print one summary block listing every plan written
-plus every finding skipped (and why). Format:
+**Sweep mode.** One block listing every plan + every skip:
 
 ```text
 Sweep of #87 latest comment: <N> findings processed.
 
-Plans written:
+✅ Plans written:
   - <id-1>  →  <plan-path-1>  (branch <branch-1>, worktree <worktree-dir-1>)
   - <id-2>  →  <plan-path-2>  (branch <branch-2>, worktree <worktree-dir-2>)
 
-Skipped:
+⏭  Skipped:
   - <id-3>  (shipped in #N)
   - <id-4>  (worktree exists at <path>)
 
-Next: pick a worktree and run /superpowers:writing-plans <plan-path>
-inside it. One PR per finding.
+▶ You do next: pick one worktree at a time and run the same 6-step
+  loop documented in single-finding hand-off. One PR per finding.
+  Run /verify and open each PR in parallel; do NOT batch findings.
+
+ℹ️ Post-merge cleanup is per-finding too — see §7.
 ```
 
 **Do not** invoke `superpowers:writing-plans` automatically. The user
 runs it after reviewing each plan.
+
+### 7. Post-merge cleanup
+
+After a PR for a finding merges, the user runs these commands from
+the **main repo** (`D:\Projects\agent-library`), NOT from the
+worktree (you can't remove a worktree you're sitting inside). The
+skill should print this block verbatim with `<slug>` and `<branch>`
+substituted for the finding being cleaned up.
+
+```bash
+# 1. Hop back to the main repo and refresh develop
+cd <main-repo-root>
+git switch develop
+git pull --ff-only origin develop
+
+# 2. Drop the worktree (frees the path under .worktrees/)
+git worktree remove .worktrees/fix-review-<slug>
+
+# 3. Delete the local topic branch (already merged via squash)
+git branch -d fix/review-bot-<slug>
+
+# 4. Delete the remote topic branch — only if GitHub didn't already
+#    auto-delete it on merge. Safe to ignore the error if it's gone.
+git push origin --delete fix/review-bot-<slug> 2>/dev/null \
+  || echo "Remote branch already removed (auto-delete on merge)."
+
+# 5. Prune stale tracking refs so `git branch -a` stays clean
+git fetch --prune origin
+```
+
+**Sweep cleanup.** If multiple PRs merged in a batch, repeat the
+block above per `<slug>`. The user can list candidate worktrees
+with `git worktree list` and cross-check against `gh pr list
+--state merged --search "Refs #87 finding:" --limit 20`.
+
+**What the skill does NOT touch:**
+
+- The tracker comment on `#87`. The `review-fix-shipped` Action edits
+  it post-merge. Manual edits race the Action and corrupt the
+  `(shipped in #N)` rendering.
+- The `.review-fix-cache/` directory. It's gitignored and cheap to
+  rebuild on the next run; leaving it speeds up the next sweep.
 
 ## Do not
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -51,11 +51,11 @@ Confirm with the user:
 
 ### 1. Locate the finding(s)
 
-Both modes share the same fetch + parse step. Node 22 is a hard
-project requirement (`.nvmrc`), so the parser is a checked-in script
-at `scripts/review-fix-parse.mjs`. **Do not** try to filter the
-comments JSON inline with `gh --jq`, `jq`, `node -e` heredocs, or
-`grep | sed`. The recipe below dodges five real footguns:
+Both modes share the same fetch step. Node 22 is a hard project
+requirement (`.nvmrc`), so the parser is a checked-in script at
+`scripts/review-fix-parse.mjs`. **Do not** try to filter the comments
+JSON inline with `gh --jq`, `jq`, `node -e` heredocs, or `grep | sed`.
+The recipe below dodges five real footguns:
 
 1. `gh api --paginate --slurp --jq` is rejected by current `gh`
    versions ("the `--slurp` option is not supported with `--jq` or
@@ -72,55 +72,52 @@ comments JSON inline with `gh --jq`, `jq`, `node -e` heredocs, or
    `<details>` body or quoted diff. The script only treats top-level
    checklist lines (`^- \[[ x]\] `) as finding boundaries.
 
+Fetch every comment once into the project-local cache:
+
 ```bash
 REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 mkdir -p .review-fix-cache
 gh api "repos/${REPO}/issues/87/comments" --paginate --slurp \
   > .review-fix-cache/comments.json
+```
+
+**Single-finding mode.** Pass the ID via `--id`. The parser searches
+the **full comment history** (newest first) for that marker, so
+backlog findings on older tracker comments stay reachable — sweep
+mode only ever picks the newest comment, but single mode must not.
+
+```bash
+ID="<sha7>.<idx>"            # e.g. 682b557.3
+node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
+  --id "${ID}" \
+  > .review-fix-cache/finding.json
+```
+
+Parser exit codes (single mode):
+
+- `0` → match written to `finding.json` as
+  `{commentId, commentUrl, createdAt, finding: {…}}`.
+- `1` → ID not found in any comment. Refuse with
+  `Finding ${ID} not found in #87 comments`.
+- `2` → bad CLI args (e.g. user pasted a free-text description).
+  Refuse and ask them to grab the ID from
+  `gh issue view 87 --comments`.
+- `3` → ID found but already shipped. The script's stderr already
+  says `Finding <id> already shipped in #<PR>`; surface it and stop.
+
+**Sweep mode (no argument).** Run the parser without `--id` to get
+every finding from the most recent comment that contains markers:
+
+```bash
 node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
   > .review-fix-cache/parsed.json
 ```
 
-`parsed.json` schema (one object — most recent comment with findings):
+Sweep output: `{commentId, commentUrl, createdAt, findings: [Finding, …]}`.
+Exit 1 with `No comment on the tracker contains findings` if every
+comment is a no-op summary — surface that to the user and stop.
 
-```json
-{
-  "commentId": 4321324736,
-  "commentUrl": "https://github.com/<owner>/<repo>/issues/87#issuecomment-...",
-  "createdAt": "2026-04-26T05:21:55Z",
-  "findings": [
-    {
-      "id": "<sha7>.<idx>",
-      "shipped": false,
-      "shippedPr": null,
-      "severity": "BLOCKER" | "MAJOR" | "MINOR" | "NIT",
-      "path": "src/foo/Bar.ts:143",
-      "title": "<one-line title>",
-      "body": "<verbatim <details>...</details> chunk>"
-    }
-  ]
-}
-```
-
-The script exits 1 with `No comment on the tracker contains findings`
-if every comment is a no-op summary — surface that to the user and
-stop.
-
-**Single-finding mode.** Pick the entry whose `id` matches the
-user-provided ID:
-
-```bash
-ID="<sha7>.<idx>"            # e.g. 682b557.3
-node -e "const d=JSON.parse(require('fs').readFileSync('.review-fix-cache/parsed.json','utf8')); const f=d.findings.find(x=>x.id===process.argv[1]); if(!f){console.error('Finding '+process.argv[1]+' not found in #'+d.commentId);process.exit(1)} if(f.shipped){console.error('Finding '+f.id+' already shipped in #'+f.shippedPr);process.exit(2)} process.stdout.write(JSON.stringify(f,null,2))" "${ID}" \
-  > .review-fix-cache/finding.json
-```
-
-If the user pasted a free-text description instead of `<sha7>.<idx>`:
-refuse and ask them to grab the ID from the tracker comment (or
-`gh issue view 87 --comments`).
-
-**Sweep mode (no argument).** Iterate `.findings[]` from
-`parsed.json`. For each entry:
+For each entry in `parsed.json` `.findings[]`:
 
 - `shipped === true` → log `Skipping <id> (shipped in #<shippedPr>)`
   and continue.
@@ -128,16 +125,32 @@ refuse and ask them to grab the ID from the tracker comment (or
   `Skipping <id> (worktree exists at <path>)` and continue.
 - Otherwise run steps 2 → 5 for that finding.
 
+`Finding` shape (both modes):
+
+```json
+{
+  "id": "<sha7>.<idx>",
+  "shipped": false,
+  "shippedPr": null,
+  "severity": "BLOCKER" | "MAJOR" | "MINOR" | "NIT",
+  "path": "src/foo/Bar.ts:143",
+  "title": "<one-line title>",
+  "body": "<verbatim <details>...</details> chunk>"
+}
+```
+
 ### 2. Extract finding fields
 
 `scripts/review-fix-parse.mjs` already split the chosen finding into
 `{id, shipped, shippedPr, severity, path, title, body}`. Read those
-fields from `.review-fix-cache/finding.json` (single mode) or from
-`.review-fix-cache/parsed.json` `.findings[i]` (sweep mode). Do not
-re-parse the comment body by hand — the regex lives in the script.
+fields from `.review-fix-cache/finding.json` `.finding` (single mode)
+or from `.review-fix-cache/parsed.json` `.findings[i]` (sweep mode).
+Do not re-parse the comment body by hand — the regex lives in the
+script.
 
-The parser already hard-fails single mode on `shipped === true`. In
-sweep mode, you must perform the equivalent skip yourself (step 1).
+The parser already hard-fails single mode on `shipped === true`
+(exit 3). In sweep mode, you must perform the equivalent skip
+yourself (step 1).
 
 ### 3. Compute slug + paths
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs/api
 examples/**/dist
 examples/**/node_modules
 .worktrees
+.review-fix-cache
 .claude/settings.local.json
 .claude/.last-run
 

--- a/scripts/review-fix-parse.mjs
+++ b/scripts/review-fix-parse.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * review-fix tracker comment parser.
+ *
+ * Reads the raw `gh api ... --paginate --slurp` output for issue #87
+ * comments and emits a structured JSON description of the most recent
+ * comment that contains finding markers. Used by the `review-fix`
+ * skill to sidestep platform-specific shell pitfalls:
+ *   - Windows Git Bash maps `/tmp` to `D:\tmp` for native binaries,
+ *     breaking Node `fs.readFileSync('/tmp/...')`.
+ *   - `gh --paginate --slurp` rejects `--jq` / `--template` flags.
+ *   - `jq` is not installed by default on Windows or many CI images.
+ *
+ * Node is a hard project requirement (TypeScript library, ESM, Node 22
+ * per `.nvmrc`), so this script is the canonical parser the skill
+ * shells out to.
+ *
+ * Usage:
+ *   gh api "repos/<owner>/<repo>/issues/87/comments" --paginate --slurp \
+ *     > .review-fix-cache/comments.json
+ *   node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
+ *     > .review-fix-cache/parsed.json
+ *
+ * Output schema (single JSON object):
+ *   {
+ *     "commentId": <number>,
+ *     "commentUrl": <string>,
+ *     "createdAt": <iso8601>,
+ *     "findings": [
+ *       {
+ *         "id":        "<sha7>.<idx>",
+ *         "shipped":   <bool>,
+ *         "shippedPr": <number|null>,
+ *         "severity":  "BLOCKER" | "MAJOR" | "MINOR" | "NIT",
+ *         "path":      "<repo-relative path[:line]>",
+ *         "title":     "<one-line>",
+ *         "body":      "<raw verbatim body chunk, may include diff blocks>"
+ *       }
+ *     ]
+ *   }
+ *
+ * Exits 1 with a stderr message if no comment in the input contains
+ * finding markers (the bot may post no-op summary comments — those
+ * are skipped).
+ */
+
+import { readFileSync } from 'node:fs';
+import { argv, exit, stderr, stdout } from 'node:process';
+
+const inputPath = argv[2];
+if (!inputPath) {
+  stderr.write('usage: review-fix-parse.mjs <comments.json>\n');
+  exit(2);
+}
+
+const raw = JSON.parse(readFileSync(inputPath, 'utf8'));
+// `gh --paginate --slurp` returns an array of pages (one entry per
+// page), not a flat list of comments. Flatten one level so callers
+// can stay agnostic.
+const comments = (Array.isArray(raw) ? raw : [raw]).flat();
+
+const withFindings = comments
+  .filter((c) => typeof c.body === 'string' && c.body.includes('<!-- f:'))
+  .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+
+const last = withFindings[withFindings.length - 1];
+if (!last) {
+  stderr.write('No comment on the tracker contains findings — nothing to sweep\n');
+  exit(1);
+}
+
+const findings = parseFindings(last.body);
+const payload = JSON.stringify(
+  {
+    commentId: last.id,
+    commentUrl: last.html_url,
+    createdAt: last.created_at,
+    findings,
+  },
+  null,
+  2,
+);
+stdout.write(`${payload}\n`);
+
+/**
+ * Parses one comment body into individual finding entries.
+ *
+ * A finding header is a top-level checklist line (no leading
+ * whitespace) shaped like:
+ *
+ *   - [ ] **[SEVERITY]** `path` — title <!-- f:<sha7>.<idx> --> [(shipped in #N)]
+ *
+ * Quoted finding-marker text inside a `<details>` body is ignored —
+ * only top-level checklist lines mark finding boundaries. The body
+ * for each finding is every line between its header and the next
+ * header (or end-of-comment), with leading/trailing blank lines
+ * trimmed.
+ */
+function parseFindings(body) {
+  const lines = body.split(/\r?\n/);
+  const headerRe =
+    /^- \[(?<box>[ x])\] \*\*\[(?<sev>BLOCKER|MAJOR|MINOR|NIT)\]\*\* `(?<path>[^`]+)` — (?<title>.*?) <!-- f:(?<id>[A-Za-z0-9]+\.[0-9]+) -->(?<trail>.*)$/;
+
+  const headers = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const m = headerRe.exec(lines[i]);
+    if (m) headers.push({ index: i, ...m.groups });
+  }
+
+  return headers.map((h, idx) => {
+    const nextIndex = headers[idx + 1]?.index ?? lines.length;
+    const slice = lines.slice(h.index + 1, nextIndex);
+    // The last header's slice runs through the comment's trailing
+    // summary (counter-arguments, "Reviewed range", footer). Cut at
+    // the first standalone `---` so a finding body never absorbs
+    // metadata that belongs to the comment as a whole.
+    const ruleAt = slice.findIndex((line) => /^---\s*$/.test(line));
+    const bodyLines = ruleAt >= 0 ? slice.slice(0, ruleAt) : slice;
+    while (bodyLines.length > 0 && bodyLines[0].trim() === '') {
+      bodyLines.shift();
+    }
+    while (bodyLines.length > 0 && bodyLines[bodyLines.length - 1].trim() === '') {
+      bodyLines.pop();
+    }
+
+    const shippedMatch = /\(shipped in #(\d+)\)/.exec(h.trail ?? '');
+    return {
+      id: h.id,
+      shipped: h.box === 'x',
+      shippedPr: shippedMatch ? Number(shippedMatch[1]) : null,
+      severity: h.sev,
+      path: h.path,
+      title: h.title.trim(),
+      body: bodyLines.join('\n'),
+    };
+  });
+}

--- a/scripts/review-fix-parse.mjs
+++ b/scripts/review-fix-parse.mjs
@@ -96,9 +96,18 @@ const raw = JSON.parse(readFileSync(inputPath, 'utf8'));
 // can stay agnostic.
 const comments = (Array.isArray(raw) ? raw : [raw]).flat();
 
+// Filter by parsed checklist findings, NOT by raw `<!-- f:` substring.
+// A no-op summary comment may quote a previous finding's marker inside
+// its body or in a `<details>` block; if we keyed the sweep on
+// `body.includes('<!-- f:')` and the newest match happened to be such
+// a quote-only comment, sweep would emit an empty `findings: []` and
+// silently skip every older comment with real, actionable findings.
+// Pre-parsing here also lets us reuse the result downstream.
 const withFindings = comments
-  .filter((c) => typeof c.body === 'string' && c.body.includes('<!-- f:'))
-  .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+  .filter((c) => typeof c.body === 'string')
+  .map((c) => ({ comment: c, findings: parseFindings(c.body) }))
+  .filter((c) => c.findings.length > 0)
+  .sort((a, b) => new Date(a.comment.created_at) - new Date(b.comment.created_at));
 
 if (withFindings.length === 0) {
   stderr.write('No comment on the tracker contains findings — nothing to sweep\n');
@@ -109,24 +118,22 @@ if (targetId === null) {
   // Sweep: emit every finding from the newest comment that has any.
   const newest = withFindings[withFindings.length - 1];
   emit({
-    commentId: newest.id,
-    commentUrl: newest.html_url,
-    createdAt: newest.created_at,
-    findings: parseFindings(newest.body),
+    commentId: newest.comment.id,
+    commentUrl: newest.comment.html_url,
+    createdAt: newest.comment.created_at,
+    findings: newest.findings,
   });
   exit(0);
 }
 
-// Single: scan the full history (newest first) for the marker so a
+// Single: scan the full history (newest first) for the target ID so a
 // backlog finding on an older comment stays reachable. The first
 // match wins; duplicate IDs across comments would only happen if the
 // review bot re-emitted an old finding, in which case the freshest
 // occurrence is what the user wants.
-const marker = `<!-- f:${targetId} -->`;
 for (let i = withFindings.length - 1; i >= 0; i -= 1) {
-  const comment = withFindings[i];
-  if (!comment.body.includes(marker)) continue;
-  const match = parseFindings(comment.body).find((f) => f.id === targetId);
+  const { comment, findings } = withFindings[i];
+  const match = findings.find((f) => f.id === targetId);
   if (!match) continue;
   if (match.shipped) {
     stderr.write(`Finding ${targetId} already shipped in #${match.shippedPr ?? '?'}\n`);
@@ -154,7 +161,13 @@ function emit(obj) {
  * A finding header is a top-level checklist line (no leading
  * whitespace) shaped like:
  *
- *   - [ ] **[SEVERITY]** `path` — title <!-- f:<sha7>.<idx> --> [(shipped in #N)]
+ *   - [ ] **[SEVERITY]** `path` — title <!-- f:<sha7>.<idx> -->
+ *   - [x] **[SEVERITY]** `path` — title (shipped in #N) <!-- f:<sha7>.<idx> -->
+ *
+ * The `review-fix-shipped` Action inserts ` (shipped in #N)` between
+ * the title and the marker (NOT after the marker), so the shipped-PR
+ * extraction must run against the matched `title` group and the
+ * suffix must be stripped before storing.
  *
  * Quoted finding-marker text inside a `<details>` body is ignored —
  * only top-level checklist lines mark finding boundaries. The body
@@ -165,7 +178,8 @@ function emit(obj) {
 function parseFindings(body) {
   const lines = body.split(/\r?\n/);
   const headerRe =
-    /^- \[(?<box>[ x])\] \*\*\[(?<sev>BLOCKER|MAJOR|MINOR|NIT)\]\*\* `(?<path>[^`]+)` — (?<title>.*?) <!-- f:(?<id>[A-Za-z0-9]+\.[0-9]+) -->(?<trail>.*)$/;
+    /^- \[(?<box>[ x])\] \*\*\[(?<sev>BLOCKER|MAJOR|MINOR|NIT)\]\*\* `(?<path>[^`]+)` — (?<title>.*?) <!-- f:(?<id>[A-Za-z0-9]+\.[0-9]+) -->/;
+  const shippedSuffixRe = /\s*\(shipped in #(\d+)\)\s*$/;
 
   const headers = [];
   for (let i = 0; i < lines.length; i += 1) {
@@ -189,14 +203,15 @@ function parseFindings(body) {
       bodyLines.pop();
     }
 
-    const shippedMatch = /\(shipped in #(\d+)\)/.exec(h.trail ?? '');
+    const shippedMatch = shippedSuffixRe.exec(h.title);
+    const cleanTitle = h.title.replace(shippedSuffixRe, '').trim();
     return {
       id: h.id,
       shipped: h.box === 'x',
       shippedPr: shippedMatch ? Number(shippedMatch[1]) : null,
       severity: h.sev,
       path: h.path,
-      title: h.title.trim(),
+      title: cleanTitle,
       body: bodyLines.join('\n'),
     };
   });

--- a/scripts/review-fix-parse.mjs
+++ b/scripts/review-fix-parse.mjs
@@ -3,9 +3,15 @@
  * review-fix tracker comment parser.
  *
  * Reads the raw `gh api ... --paginate --slurp` output for issue #87
- * comments and emits a structured JSON description of the most recent
- * comment that contains finding markers. Used by the `review-fix`
- * skill to sidestep platform-specific shell pitfalls:
+ * comments and emits a structured JSON description of either:
+ *   - the most recent comment that contains finding markers (sweep
+ *     mode, default), or
+ *   - the comment that contains a specific finding ID (single mode,
+ *     `--id <sha7>.<idx>`), searching the full comment history so
+ *     backlog findings on older comments stay reachable.
+ *
+ * Used by the `review-fix` skill to sidestep platform-specific shell
+ * pitfalls:
  *   - Windows Git Bash maps `/tmp` to `D:\tmp` for native binaries,
  *     breaking Node `fs.readFileSync('/tmp/...')`.
  *   - `gh --paginate --slurp` rejects `--jq` / `--template` flags.
@@ -18,38 +24,69 @@
  * Usage:
  *   gh api "repos/<owner>/<repo>/issues/87/comments" --paginate --slurp \
  *     > .review-fix-cache/comments.json
+ *
+ *   # Sweep mode — newest comment with markers
  *   node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
  *     > .review-fix-cache/parsed.json
  *
- * Output schema (single JSON object):
+ *   # Single mode — specific finding ID, any comment in history
+ *   node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
+ *     --id 682b557.3 \
+ *     > .review-fix-cache/finding.json
+ *
+ * Sweep-mode output:
  *   {
- *     "commentId": <number>,
+ *     "commentId":  <number>,
  *     "commentUrl": <string>,
- *     "createdAt": <iso8601>,
- *     "findings": [
- *       {
- *         "id":        "<sha7>.<idx>",
- *         "shipped":   <bool>,
- *         "shippedPr": <number|null>,
- *         "severity":  "BLOCKER" | "MAJOR" | "MINOR" | "NIT",
- *         "path":      "<repo-relative path[:line]>",
- *         "title":     "<one-line>",
- *         "body":      "<raw verbatim body chunk, may include diff blocks>"
- *       }
- *     ]
+ *     "createdAt":  <iso8601>,
+ *     "findings":   [Finding, ...]
  *   }
  *
- * Exits 1 with a stderr message if no comment in the input contains
- * finding markers (the bot may post no-op summary comments — those
- * are skipped).
+ * Single-mode output:
+ *   {
+ *     "commentId":  <number>,
+ *     "commentUrl": <string>,
+ *     "createdAt":  <iso8601>,
+ *     "finding":    Finding
+ *   }
+ *
+ * Finding shape:
+ *   {
+ *     "id":        "<sha7>.<idx>",
+ *     "shipped":   <bool>,
+ *     "shippedPr": <number|null>,
+ *     "severity":  "BLOCKER" | "MAJOR" | "MINOR" | "NIT",
+ *     "path":      "<repo-relative path[:line]>",
+ *     "title":     "<one-line>",
+ *     "body":      "<raw verbatim body chunk, may include diff blocks>"
+ *   }
+ *
+ * Exit codes:
+ *   0  success
+ *   1  no comment / no finding matched
+ *   2  bad CLI arguments
+ *   3  finding matched but already shipped (single mode only)
  */
 
 import { readFileSync } from 'node:fs';
 import { argv, exit, stderr, stdout } from 'node:process';
 
-const inputPath = argv[2];
+const args = argv.slice(2);
+const inputPath = args[0];
+let targetId = null;
+for (let i = 1; i < args.length; i += 1) {
+  if (args[i] === '--id') {
+    targetId = args[i + 1];
+    i += 1;
+  }
+}
+
 if (!inputPath) {
-  stderr.write('usage: review-fix-parse.mjs <comments.json>\n');
+  stderr.write('usage: review-fix-parse.mjs <comments.json> [--id <sha7>.<idx>]\n');
+  exit(2);
+}
+if (targetId !== null && !/^[A-Za-z0-9]+\.[0-9]+$/.test(targetId)) {
+  stderr.write(`--id expects <sha7>.<idx> shape (e.g. 682b557.3), got "${targetId}"\n`);
   exit(2);
 }
 
@@ -63,24 +100,53 @@ const withFindings = comments
   .filter((c) => typeof c.body === 'string' && c.body.includes('<!-- f:'))
   .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
 
-const last = withFindings[withFindings.length - 1];
-if (!last) {
+if (withFindings.length === 0) {
   stderr.write('No comment on the tracker contains findings — nothing to sweep\n');
   exit(1);
 }
 
-const findings = parseFindings(last.body);
-const payload = JSON.stringify(
-  {
-    commentId: last.id,
-    commentUrl: last.html_url,
-    createdAt: last.created_at,
-    findings,
-  },
-  null,
-  2,
-);
-stdout.write(`${payload}\n`);
+if (targetId === null) {
+  // Sweep: emit every finding from the newest comment that has any.
+  const newest = withFindings[withFindings.length - 1];
+  emit({
+    commentId: newest.id,
+    commentUrl: newest.html_url,
+    createdAt: newest.created_at,
+    findings: parseFindings(newest.body),
+  });
+  exit(0);
+}
+
+// Single: scan the full history (newest first) for the marker so a
+// backlog finding on an older comment stays reachable. The first
+// match wins; duplicate IDs across comments would only happen if the
+// review bot re-emitted an old finding, in which case the freshest
+// occurrence is what the user wants.
+const marker = `<!-- f:${targetId} -->`;
+for (let i = withFindings.length - 1; i >= 0; i -= 1) {
+  const comment = withFindings[i];
+  if (!comment.body.includes(marker)) continue;
+  const match = parseFindings(comment.body).find((f) => f.id === targetId);
+  if (!match) continue;
+  if (match.shipped) {
+    stderr.write(`Finding ${targetId} already shipped in #${match.shippedPr ?? '?'}\n`);
+    exit(3);
+  }
+  emit({
+    commentId: comment.id,
+    commentUrl: comment.html_url,
+    createdAt: comment.created_at,
+    finding: match,
+  });
+  exit(0);
+}
+
+stderr.write(`Finding ${targetId} not found in any tracker comment\n`);
+exit(1);
+
+function emit(obj) {
+  stdout.write(`${JSON.stringify(obj, null, 2)}\n`);
+}
 
 /**
  * Parses one comment body into individual finding entries.


### PR DESCRIPTION
## Summary

- Replace the broken shell pipeline in `.claude/skills/review-fix/SKILL.md` with a checked-in Node parser at `scripts/review-fix-parse.mjs`.
- Skill no longer depends on `jq`, `gh --jq` + `--slurp` combo (rejected by current gh), `/tmp` (resolves to `D:\tmp` for native Node on Windows Git Bash), or ad-hoc `node -e` heredocs.
- Parser reads raw `--paginate --slurp` output, flattens the array-of-pages, picks the most recent tracker comment that contains finding markers, and emits structured JSON per finding.
- Cache lives in `.review-fix-cache/` in the repo root (gitignored) so the skill never depends on a writable platform temp dir.

## Why

`/review-fix` runs in this session ate four iterations of shell debugging before producing a finding list — `gh` rejected `--slurp + --jq`, `jq` was missing, `/tmp` mapped to `D:\tmp` for Node, then heredoc backslash escaping fought Windows paths. Encoding the parse step as a checked-in `.mjs` script (Node 22 is already a project requirement per `.nvmrc`) sidesteps all four traps.

## Test plan

- [x] `npm run verify` green locally (format:check, lint, typecheck, 522 tests, build, docs)
- [x] End-to-end smoke: `gh api … --paginate --slurp > .review-fix-cache/comments.json && node scripts/review-fix-parse.mjs .review-fix-cache/comments.json` → returns the latest #87 comment with all 4 findings parsed (correct `id`, `severity`, `path`, `title`, body bounded at first standalone `---`).
- [ ] Re-run `/review-fix` against #87 in a fresh session after merge to confirm zero shell debugging.

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)