### PR TITLE
ci(coverage): post sticky PR comment with vitest coverage delta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,21 @@ jobs:
       - name: Run Vitest
         if: matrix.os != 'ubuntu-latest'
         run: npm test
+      # Ship coverage-summary.json across jobs so the PR-comment job
+      # can diff it against the latest develop run's summary. Tiny
+      # file (<10 KB), uploaded only on ubuntu since that is the only
+      # cell that runs `npm run test:coverage`. `always()` so a vitest
+      # threshold failure (which fails the test step) still uploads
+      # the numbers — that is exactly the case where the reviewer
+      # needs the PR-comment to surface which metric dropped.
+      - name: Upload coverage summary
+        if: always() && matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: coverage-summary
+          path: coverage/coverage-summary.json
+          if-no-files-found: error
+          retention-days: 14
 
   test-tfjs:
     name: Test tfjs (${{ matrix.backend }} on ${{ matrix.os }})
@@ -272,6 +287,83 @@ jobs:
         run: npm run build
       - name: Enforce bundle-size budget
         run: npx size-limit
+
+  coverage-pr-comment:
+    name: Coverage PR comment (vitest delta)
+    runs-on: ubuntu-latest
+    needs: [changes, test-core]
+    # Mirrors `size-limit-comment` semantics: posts the sticky comment
+    # whenever a code-change PR has finished `test-core` (only the
+    # ubuntu cell uploads `coverage-summary`, which is the artifact we
+    # diff). `always()` so a coverage-threshold failure (which trips
+    # vitest, failing `test-core`) still gets the PR comment with the
+    # numbers — that is exactly when the reviewer needs to see which
+    # metric dropped.
+    if: |
+      always()
+      && needs.changes.outputs.code == 'true'
+      && github.event_name == 'pull_request'
+      && needs.test-core.result != 'cancelled'
+      && needs.test-core.result != 'skipped'
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+      - name: Download PR coverage summary
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: coverage-summary
+          path: coverage
+      # Best-effort base-branch coverage. When develop has no successful
+      # CI run yet (first push, retention expiry), the script still
+      # renders absolute % without deltas.
+      - name: Download base-branch coverage summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p base-coverage
+          BASE_RUN_ID="$(gh run list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --branch "${{ github.event.pull_request.base.ref }}" \
+            --workflow ci.yml \
+            --status success \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId // empty')"
+          if [ -z "${BASE_RUN_ID}" ]; then
+            echo "No successful base-branch run found; deltas will be omitted."
+            exit 0
+          fi
+          if ! gh run download "${BASE_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name coverage-summary \
+            --dir base-coverage; then
+            echo "Base-branch artifact missing on run ${BASE_RUN_ID} (likely older than retention). Deltas will be omitted."
+          fi
+      - name: Post sticky coverage comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ -f base-coverage/coverage-summary.json ]; then
+            node scripts/coverage-pr-comment.mjs \
+              --post \
+              --pr-summary coverage/coverage-summary.json \
+              --base-summary base-coverage/coverage-summary.json
+          else
+            node scripts/coverage-pr-comment.mjs \
+              --post \
+              --pr-summary coverage/coverage-summary.json
+          fi
 
   size-limit-comment:
     name: Size-limit PR comment (gzip delta)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,16 +322,22 @@ jobs:
         with:
           name: coverage-summary
           path: coverage
-      # Best-effort base-branch coverage. Query the artifacts API by
-      # name + base branch directly (rather than `gh run list
-      # --status success`) — a successful docs-only run skips
-      # `test-core` (gated on `changes.outputs.code`) and therefore
-      # never produces `coverage-summary`, so picking "latest
-      # successful base run" can land on a run with no artifact and
-      # silently lose deltas after every docs merge until another
-      # code-changing run lands. Filtering by artifact name +
-      # non-expired + base branch picks the most recent run that
-      # ACTUALLY has coverage data.
+      # Best-effort base-branch coverage. Iterate the workflow's most
+      # recent base-branch runs and pick the first one that has a
+      # non-expired `coverage-summary` artifact. This handles two
+      # awkward cases at once:
+      #   - A docs-only run succeeds without producing the artifact
+      #     (its `test-core` job is gated on `changes.outputs.code`),
+      #     so picking "latest successful run" can land on an
+      #     artifact-less run.
+      #   - The org-wide `/actions/artifacts` endpoint isn't scoped
+      #     to a branch, so a base artifact older than the most
+      #     recent N global artifacts can fall off the page entirely
+      #     even if it still exists. Scoping by branch via
+      #     `/actions/runs?branch=…` and probing per-run artifacts
+      #     makes the search converge.
+      # Capped at 100 base-branch runs (5 pages of 20). At ~1 develop
+      # run per code merge, this covers months of activity.
       - name: Download base-branch coverage summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -339,15 +345,24 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p base-coverage
-          BASE_RUN_ID="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=coverage-summary&per_page=50" \
-            --jq ".artifacts
-                  | map(select(.expired == false and .workflow_run.head_branch == \"${BASE_REF}\"))
-                  | sort_by(.created_at)
-                  | reverse
-                  | .[0].workflow_run.id // empty")"
+          BASE_RUN_ID=""
+          for PAGE in 1 2 3 4 5; do
+            RUNS="$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BASE_REF}&per_page=20&page=${PAGE}" \
+              --jq '.workflow_runs[].id')"
+            if [ -z "${RUNS}" ]; then break; fi
+            for RUN_ID in ${RUNS}; do
+              HAS_ART="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
+                --jq '[.artifacts[] | select(.name == "coverage-summary" and .expired == false)] | length')"
+              if [ "${HAS_ART}" -gt 0 ]; then
+                BASE_RUN_ID="${RUN_ID}"
+                break 2
+              fi
+            done
+          done
           if [ -z "${BASE_RUN_ID}" ]; then
-            echo "No coverage-summary artifact found on ${BASE_REF}. Deltas will be omitted."
+            echo "No coverage-summary artifact found on ${BASE_REF} (last 100 runs scanned). Deltas will be omitted."
             exit 0
           fi
           if ! gh run download "${BASE_RUN_ID}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,22 +322,25 @@ jobs:
         with:
           name: coverage-summary
           path: coverage
-      # Best-effort base-branch coverage. Iterate the workflow's most
-      # recent base-branch runs and pick the first one that has a
-      # non-expired `coverage-summary` artifact. This handles two
-      # awkward cases at once:
-      #   - A docs-only run succeeds without producing the artifact
-      #     (its `test-core` job is gated on `changes.outputs.code`),
-      #     so picking "latest successful run" can land on an
-      #     artifact-less run.
+      # Best-effort base-branch coverage. Iterate this workflow's most
+      # recent SUCCESSFUL base-branch runs and pick the first one that
+      # has a non-expired `coverage-summary` artifact. This converges
+      # on the right baseline even in awkward cases:
+      #   - The artifact upload runs `if: always()` so a failing
+      #     develop run still ships its summary; without a success
+      #     filter we could pick a flaky/failed run and produce a
+      #     misleading delta. Filter on `status=success` to be the
+      #     baseline a reviewer expects.
+      #   - A successful docs-only run skips `test-core` (gated on
+      #     `changes.outputs.code`) and therefore has no artifact;
+      #     iterating runs lets us walk past it without giving up.
       #   - The org-wide `/actions/artifacts` endpoint isn't scoped
-      #     to a branch, so a base artifact older than the most
-      #     recent N global artifacts can fall off the page entirely
-      #     even if it still exists. Scoping by branch via
-      #     `/actions/runs?branch=…` and probing per-run artifacts
-      #     makes the search converge.
-      # Capped at 100 base-branch runs (5 pages of 20). At ~1 develop
-      # run per code merge, this covers months of activity.
+      #     by branch, so an older base artifact can fall off the
+      #     page entirely even if it exists. Scoping by branch via
+      #     `/actions/workflows/ci.yml/runs?branch=…&status=success`
+      #     and probing per-run artifacts makes the search converge.
+      # Capped at 100 base-branch successful runs (5 pages × 20). At
+      # ~1 develop run per code merge, this covers months of activity.
       - name: Download base-branch coverage summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -348,7 +351,7 @@ jobs:
           BASE_RUN_ID=""
           for PAGE in 1 2 3 4 5; do
             RUNS="$(gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${BASE_REF}&per_page=20&page=${PAGE}" \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=${BASE_REF}&status=success&per_page=20&page=${PAGE}" \
               --jq '.workflow_runs[].id')"
             if [ -z "${RUNS}" ]; then break; fi
             for RUN_ID in ${RUNS}; do
@@ -362,7 +365,7 @@ jobs:
             done
           done
           if [ -z "${BASE_RUN_ID}" ]; then
-            echo "No coverage-summary artifact found on ${BASE_REF} (last 100 runs scanned). Deltas will be omitted."
+            echo "No coverage-summary artifact found on a successful ${BASE_REF} run (last 100 scanned). Deltas will be omitted."
             exit 0
           fi
           if ! gh run download "${BASE_RUN_ID}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,24 +323,30 @@ jobs:
           name: coverage-summary
           path: coverage
       # Best-effort base-branch coverage. Iterate this workflow's most
-      # recent SUCCESSFUL base-branch runs and pick the first one that
-      # has a non-expired `coverage-summary` artifact. This converges
-      # on the right baseline even in awkward cases:
+      # recent push-triggered, SUCCESSFUL base-branch runs and pick
+      # the first one that has a non-expired `coverage-summary`
+      # artifact. The combined filter set converges on the right
+      # baseline through several awkward cases:
       #   - The artifact upload runs `if: always()` so a failing
-      #     develop run still ships its summary; without a success
-      #     filter we could pick a flaky/failed run and produce a
-      #     misleading delta. Filter on `status=success` to be the
-      #     baseline a reviewer expects.
-      #   - A successful docs-only run skips `test-core` (gated on
-      #     `changes.outputs.code`) and therefore has no artifact;
-      #     iterating runs lets us walk past it without giving up.
-      #   - The org-wide `/actions/artifacts` endpoint isn't scoped
-      #     by branch, so an older base artifact can fall off the
-      #     page entirely even if it exists. Scoping by branch via
-      #     `/actions/workflows/ci.yml/runs?branch=…&status=success`
-      #     and probing per-run artifacts makes the search converge.
-      # Capped at 100 base-branch successful runs (5 pages × 20). At
-      # ~1 develop run per code merge, this covers months of activity.
+      #     develop run still ships its summary; `status=success`
+      #     keeps us off flaky/failed runs that would mis-represent
+      #     baseline coverage.
+      #   - The runs endpoint includes `pull_request`-event runs by
+      #     default. A PR base-merge run can have its head branch
+      #     equal to ${BASE_REF} but the artifact reflects the PR
+      #     code, not the base tip. `event=push` restricts to runs
+      #     triggered by direct branch pushes (i.e. merges to
+      #     develop), which is the actual baseline.
+      #   - A push-triggered docs-only run can succeed without
+      #     producing the artifact (its `test-core` job is gated on
+      #     `changes.outputs.code`); per-run artifact probing walks
+      #     past those without giving up.
+      # API calls are individually guarded with `|| ...` fallbacks so
+      # a transient `gh api` failure (rate limit, restricted token
+      # scope on some PR contexts) degrades to deltas-omitted rather
+      # than aborting the whole comment job under `pipefail`.
+      # Capped at 100 base-branch runs (5 pages × 20). At ~1 develop
+      # merge per code change this covers months of activity.
       - name: Download base-branch coverage summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -350,14 +356,16 @@ jobs:
           mkdir -p base-coverage
           BASE_RUN_ID=""
           for PAGE in 1 2 3 4 5; do
+            RUNS=""
             RUNS="$(gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=${BASE_REF}&status=success&per_page=20&page=${PAGE}" \
-              --jq '.workflow_runs[].id')"
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?branch=${BASE_REF}&status=success&event=push&per_page=20&page=${PAGE}" \
+              --jq '.workflow_runs[].id' 2>/dev/null)" || RUNS=""
             if [ -z "${RUNS}" ]; then break; fi
             for RUN_ID in ${RUNS}; do
+              HAS_ART="0"
               HAS_ART="$(gh api \
                 "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts" \
-                --jq '[.artifacts[] | select(.name == "coverage-summary" and .expired == false)] | length')"
+                --jq '[.artifacts[] | select(.name == "coverage-summary" and .expired == false)] | length' 2>/dev/null)" || HAS_ART="0"
               if [ "${HAS_ART}" -gt 0 ]; then
                 BASE_RUN_ID="${RUN_ID}"
                 break 2
@@ -365,7 +373,7 @@ jobs:
             done
           done
           if [ -z "${BASE_RUN_ID}" ]; then
-            echo "No coverage-summary artifact found on a successful ${BASE_REF} run (last 100 scanned). Deltas will be omitted."
+            echo "No coverage-summary artifact found on a push-triggered successful ${BASE_REF} run (last 100 scanned). Deltas will be omitted."
             exit 0
           fi
           if ! gh run download "${BASE_RUN_ID}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,32 +322,39 @@ jobs:
         with:
           name: coverage-summary
           path: coverage
-      # Best-effort base-branch coverage. When develop has no successful
-      # CI run yet (first push, retention expiry), the script still
-      # renders absolute % without deltas.
+      # Best-effort base-branch coverage. Query the artifacts API by
+      # name + base branch directly (rather than `gh run list
+      # --status success`) — a successful docs-only run skips
+      # `test-core` (gated on `changes.outputs.code`) and therefore
+      # never produces `coverage-summary`, so picking "latest
+      # successful base run" can land on a run with no artifact and
+      # silently lose deltas after every docs merge until another
+      # code-changing run lands. Filtering by artifact name +
+      # non-expired + base branch picks the most recent run that
+      # ACTUALLY has coverage data.
       - name: Download base-branch coverage summary
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
           mkdir -p base-coverage
-          BASE_RUN_ID="$(gh run list \
-            --repo "${GITHUB_REPOSITORY}" \
-            --branch "${{ github.event.pull_request.base.ref }}" \
-            --workflow ci.yml \
-            --status success \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId // empty')"
+          BASE_RUN_ID="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=coverage-summary&per_page=50" \
+            --jq ".artifacts
+                  | map(select(.expired == false and .workflow_run.head_branch == \"${BASE_REF}\"))
+                  | sort_by(.created_at)
+                  | reverse
+                  | .[0].workflow_run.id // empty")"
           if [ -z "${BASE_RUN_ID}" ]; then
-            echo "No successful base-branch run found; deltas will be omitted."
+            echo "No coverage-summary artifact found on ${BASE_REF}. Deltas will be omitted."
             exit 0
           fi
           if ! gh run download "${BASE_RUN_ID}" \
             --repo "${GITHUB_REPOSITORY}" \
             --name coverage-summary \
             --dir base-coverage; then
-            echo "Base-branch artifact missing on run ${BASE_RUN_ID} (likely older than retention). Deltas will be omitted."
+            echo "Download failed for run ${BASE_RUN_ID}. Deltas will be omitted."
           fi
       - name: Post sticky coverage comment
         env:

--- a/docs/plans/2026-04-26-review-bot-nit-coverage-thresholds-hardcoded-at-42ede76-3.md
+++ b/docs/plans/2026-04-26-review-bot-nit-coverage-thresholds-hardcoded-at-42ede76-3.md
@@ -1,0 +1,91 @@
+---
+date: 2026-04-26
+slug: review-bot-nit-coverage-thresholds-hardcoded-at-42ede76-3
+finding-id: 42ede76.3
+tracker: '#87'
+severity: NIT
+---
+
+# Fix review finding `42ede76.3` — Coverage thresholds hardcoded at one-time baseline
+
+## Source
+
+From `#87` comment 4321324736, finding `42ede76.3`:
+
+> **[NIT]** `vite.config.ts:176` — Coverage thresholds hardcoded at one-time baseline; no CI feedback when coverage improves
+>
+> **Problem:** Thresholds are static integers (`statements: 74, branches: 64, functions: 83, lines: 75`) derived from a single point-in-time measurement; if coverage climbs 10pp over the next quarter, the gate still passes at 74%
+>
+> **Why it matters:** The "don't let coverage regress" property weakens as the gap between actual and threshold widens; a 15pp regression would still pass
+>
+> **Fix:** Add a comment in the CI step that reminds to re-baseline after a coverage-improving PR lands, or automate a separate check that prints a warning when actual ≫ threshold (unverified — check vitest coverage diff reporters)
+
+## Approach
+
+Owner steered: rather than the bot's "advisory `::warning::` annotation"
+suggestion, mirror the existing `size-limit` sticky-PR-comment pattern.
+A reviewable Markdown table on the PR is much higher signal than a
+buried CI annotation, and it leverages infra that already exists
+(`andresz1/size-limit-action` posts the size-limit equivalent).
+
+Implementation:
+
+1. **Single source of truth for thresholds.** Extract the four
+   floors (`statements/branches/functions/lines`) plus the drift
+   envelope (`DRIFT_WARN_PP = 5`) into
+   `scripts/coverageThresholds.mjs`. `vite.config.ts` imports it for
+   the actual gate; the PR-comment script imports it for floor
+   labels and drift-warning thresholds. A `coverageThresholds.d.mts`
+   shim gives TS / ESLint type-checked references.
+2. **Vitest emits machine-readable summary.** Add `json-summary` to
+   `coverage.reporter` in `vite.config.ts` so
+   `coverage/coverage-summary.json` is produced alongside the
+   existing text/html/lcov reports.
+3. **Sticky PR comment.** New `scripts/coverage-pr-comment.mjs`:
+   - reads `coverage/coverage-summary.json` (PR head)
+   - optionally reads a base-branch summary (passed via `--base-summary`)
+   - renders a Markdown table — actual %, delta vs base, floor,
+     status (`✅` / `❌ below floor` / `⚠️ Npp above floor — consider
+     re-baselining`)
+   - upserts a sticky comment via the GitHub REST API, identified by
+     hidden marker `<!-- coverage-pr-comment -->`
+   - `--render-only` mode prints to stdout (used by
+     `npm run coverage:report` for local preview)
+4. **CI wiring.** Two changes in `.github/workflows/ci.yml`:
+   - `test-core` (ubuntu cell) uploads `coverage/coverage-summary.json`
+     as artifact `coverage-summary` (with `if: always()` so a vitest
+     threshold failure still ships the numbers — that's exactly when
+     reviewers need the table).
+   - New `coverage-pr-comment` job (parallel to `size-limit-comment`):
+     downloads the PR run's artifact, downloads the latest successful
+     `develop` run's same artifact via `gh run download`, runs the
+     comment script with `--post`. Permissions: `pull-requests: write`,
+     `actions: read`. Not added to `ci-gate` needs — it is purely
+     informational, never a blocker.
+
+Out of scope (separate PR): cyclomatic-complexity tracking. Tooling
+choice is non-trivial (`eslint complexity` is already a warning rule
+but file/function-level complexity, `code-complexity`, `madge`, etc.
+all emit different shapes) and complexity drift is slow-moving — bad
+fit for per-PR delta surface. Open as its own polish-and-harden roadmap
+row when desired.
+
+## Acceptance
+
+- `npm run verify` green locally.
+- `npm run coverage:report` renders the same Markdown table that CI
+  will post (without the GitHub API call).
+- New CI job `coverage-pr-comment` posts a sticky comment on this PR
+  showing 4 metrics + their delta vs the latest successful develop
+  run's coverage. (First push may show "base summary not available"
+  if the artifact retention has expired or develop hasn't yet
+  produced a run with the artifact — expected.)
+- Codex review acknowledged or rebutted on each thread.
+
+## Rollout
+
+- Branch: `fix/review-bot-nit-coverage-thresholds-hardcoded-at-42ede76-3` (already cut by review-fix skill).
+- PR base: `develop`.
+- PR body MUST contain on its own line: `Refs #87 finding:42ede76.3`.
+- PR body MUST NOT contain `Closes #87` / `Fixes #87`.
+- No changeset — tooling/CI-only change, no library behavior delta.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,6 +45,7 @@ export default tseslint.config(
             'vite.config.ts',
             '*.config.ts',
             'scripts/*.mjs',
+            'scripts/*.d.mts',
           ],
         },
         tsconfigRootDir: import.meta.dirname,
@@ -284,6 +285,7 @@ export default tseslint.config(
       globals: {
         console: 'readonly',
         process: 'readonly',
+        fetch: 'readonly',
       },
     },
     rules: {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     }
   ],
   "lint-staged": {
-    "*.{ts,tsx}": [
+    "*.{ts,tsx,mjs,d.mts}": [
       "eslint --fix",
       "prettier --write"
     ],

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "coverage:report": "node scripts/coverage-pr-comment.mjs --render-only",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/scripts/coverage-pr-comment.mjs
+++ b/scripts/coverage-pr-comment.mjs
@@ -129,8 +129,25 @@ async function ghJson(path, init = {}) {
   return res.json();
 }
 
+async function listAllComments(repo, pr) {
+  // Page through all issue comments. PRs accumulate review threads,
+  // bot comments, and back-and-forth quickly — single 100-comment
+  // pages can miss the bot's sticky after long discussions, leading
+  // to repeated `POST` instead of `PATCH` and a wall of duplicate
+  // coverage tables. Cap at 50 pages (5000 comments) — more than
+  // any sane PR — to bound the work.
+  const out = [];
+  for (let page = 1; page <= 50; page += 1) {
+    const batch = await ghJson(`/repos/${repo}/issues/${pr}/comments?per_page=100&page=${page}`);
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    out.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return out;
+}
+
 async function upsertStickyComment({ repo, pr, body }) {
-  const existing = await ghJson(`/repos/${repo}/issues/${pr}/comments?per_page=100`);
+  const existing = await listAllComments(repo, pr);
   // Match the marker AND require a bot-authored comment. A user could
   // legitimately quote the marker text in a review comment (e.g. while
   // discussing the script's behavior); without the bot filter we'd

--- a/scripts/coverage-pr-comment.mjs
+++ b/scripts/coverage-pr-comment.mjs
@@ -204,6 +204,20 @@ if (!env.GITHUB_TOKEN || !repo || !pr) {
   exit(0);
 }
 
-const result = await upsertStickyComment({ repo, pr, body });
-stdout.write(`coverage-pr-comment: ${result.action} comment ${result.id} on PR ${pr}.\n`);
+// Wrap the API write so transient failures (5xx, rate limits) and
+// permission slips (403 when fork PRs run without `pull-requests:
+// write`) degrade to a stdout fallback instead of failing the
+// CI job. The file-level contract says this helper is reviewer
+// signal, never a gate — that contract held when only network reads
+// could throw, and must keep holding now that we issue writes too.
+try {
+  const result = await upsertStickyComment({ repo, pr, body });
+  stdout.write(`coverage-pr-comment: ${result.action} comment ${result.id} on PR ${pr}.\n`);
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  stdout.write(
+    `coverage-pr-comment: failed to upsert sticky comment (${message}). Falling back to log-only:\n\n`,
+  );
+  stdout.write(`${body}\n`);
+}
 exit(0);

--- a/scripts/coverage-pr-comment.mjs
+++ b/scripts/coverage-pr-comment.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+/**
+ * Build (and optionally post) a sticky PR comment that compares the
+ * current branch's vitest coverage to the base branch's coverage and
+ * to the floors in `scripts/coverageThresholds.mjs`.
+ *
+ * Mirrors the size-limit-action sticky-comment UX: one Markdown comment
+ * per PR, edited in place across pushes. Marker
+ * `<!-- coverage-pr-comment -->` identifies the comment for upserts.
+ *
+ * Modes (selected by env / args):
+ *
+ * - `--render-only` (default when no `GITHUB_TOKEN`): print Markdown to
+ *   stdout. Useful locally and from `npm run coverage:report`.
+ * - `--post`: upsert the sticky comment on the PR. Requires
+ *   `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and `--pr <number>`.
+ *
+ * Inputs:
+ *
+ * - `--pr-summary <path>`: PR coverage-summary.json (default
+ *   `coverage/coverage-summary.json`).
+ * - `--base-summary <path>`: base coverage-summary.json. Optional —
+ *   when missing, the comment shows absolute % only (no delta) and a
+ *   notice that the base summary was not available.
+ *
+ * Always exits 0. The build-fails-on-regression contract belongs to
+ * vitest's threshold check (which trips before we even render); this
+ * script is reviewer-facing signal, not a gate.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { argv, env, exit, stdout } from 'node:process';
+
+import { COVERAGE_THRESHOLDS, DRIFT_WARN_PP } from './coverageThresholds.mjs';
+
+const METRICS = /** @type {const} */ (['statements', 'branches', 'functions', 'lines']);
+const COMMENT_MARKER = '<!-- coverage-pr-comment -->';
+
+function parseArgs(argList) {
+  const out = { mode: 'render-only' };
+  for (let i = 2; i < argList.length; i += 1) {
+    const arg = argList[i];
+    const next = argList[i + 1];
+    if (arg === '--render-only') out.mode = 'render-only';
+    else if (arg === '--post') out.mode = 'post';
+    else if (arg === '--pr-summary') {
+      out.prSummary = next;
+      i += 1;
+    } else if (arg === '--base-summary') {
+      out.baseSummary = next;
+      i += 1;
+    } else if (arg === '--pr') {
+      out.pr = next;
+      i += 1;
+    }
+  }
+  return out;
+}
+
+async function loadSummary(path) {
+  if (!path) return undefined;
+  try {
+    const raw = await readFile(path, 'utf8');
+    return JSON.parse(raw).total;
+  } catch (err) {
+    if (err?.code === 'ENOENT') return undefined;
+    throw err;
+  }
+}
+
+function metricRow(metric, prTotal, baseTotal) {
+  const floor = COVERAGE_THRESHOLDS[metric];
+  const actual = prTotal?.[metric]?.pct;
+  if (typeof actual !== 'number') return `| \`${metric}\` | _missing_ | — | ${floor}% | — |`;
+  const base = baseTotal?.[metric]?.pct;
+  let delta = '—';
+  if (typeof base === 'number') {
+    const diff = actual - base;
+    const arrow = diff > 0.005 ? '⬆️' : diff < -0.005 ? '⬇️' : '➖';
+    const sign = diff > 0 ? '+' : '';
+    delta = `${arrow} ${sign}${diff.toFixed(2)}pp`;
+  }
+  let status = '✅';
+  if (actual < floor) status = `❌ below floor`;
+  else if (actual - floor > DRIFT_WARN_PP) {
+    status = `⚠️ ${(actual - floor).toFixed(1)}pp above floor — consider re-baselining`;
+  }
+  return `| \`${metric}\` | ${actual.toFixed(2)}% | ${delta} | ${floor}% | ${status} |`;
+}
+
+function render({ prTotal, baseTotal, baseAvailable }) {
+  const lines = [
+    COMMENT_MARKER,
+    '## Coverage report',
+    '',
+    '| Metric | This PR | vs base | Floor | Status |',
+    '| --- | ---: | ---: | ---: | --- |',
+  ];
+  for (const m of METRICS) lines.push(metricRow(m, prTotal, baseTotal));
+  lines.push('');
+  if (!baseAvailable) {
+    lines.push(
+      '_Base-branch coverage summary was not available, so deltas are omitted. Once `develop` has a successful coverage run, the next PR push will show deltas._',
+    );
+    lines.push('');
+  }
+  lines.push(
+    `_Floors live in \`scripts/coverageThresholds.mjs\` (drift envelope ${DRIFT_WARN_PP}pp). Re-baseline by editing that file when ⚠️ appears above; cite the new measured value + commit SHA._`,
+  );
+  return lines.join('\n');
+}
+
+async function ghJson(path, init = {}) {
+  const url = `https://api.github.com${path}`;
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'x-github-api-version': '2022-11-28',
+    authorization: `Bearer ${env.GITHUB_TOKEN}`,
+    'user-agent': 'agentonomous-coverage-comment',
+    ...(init.headers ?? {}),
+  };
+  const res = await fetch(url, { ...init, headers });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub API ${init.method ?? 'GET'} ${path} → ${res.status}: ${body}`);
+  }
+  if (res.status === 204) return undefined;
+  return res.json();
+}
+
+async function upsertStickyComment({ repo, pr, body }) {
+  const existing = await ghJson(`/repos/${repo}/issues/${pr}/comments?per_page=100`);
+  const prior = existing.find((c) => typeof c.body === 'string' && c.body.includes(COMMENT_MARKER));
+  if (prior) {
+    await ghJson(`/repos/${repo}/issues/comments/${prior.id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ body }),
+    });
+    return { action: 'updated', id: prior.id };
+  }
+  const created = await ghJson(`/repos/${repo}/issues/${pr}/comments`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ body }),
+  });
+  return { action: 'created', id: created.id };
+}
+
+const args = parseArgs(argv);
+const prSummaryPath = resolve(process.cwd(), args.prSummary ?? 'coverage/coverage-summary.json');
+const baseSummaryPath = args.baseSummary ? resolve(process.cwd(), args.baseSummary) : undefined;
+
+const prTotal = await loadSummary(prSummaryPath);
+if (!prTotal) {
+  stdout.write(
+    `coverage-pr-comment: PR summary not found at ${prSummaryPath}. Run \`npm run test:coverage\` first.\n`,
+  );
+  exit(0);
+}
+const baseTotal = baseSummaryPath ? await loadSummary(baseSummaryPath) : undefined;
+const body = render({ prTotal, baseTotal, baseAvailable: Boolean(baseTotal) });
+
+if (args.mode === 'render-only') {
+  stdout.write(`${body}\n`);
+  exit(0);
+}
+
+const repo = env.GITHUB_REPOSITORY;
+const pr = args.pr ?? env.PR_NUMBER;
+if (!env.GITHUB_TOKEN || !repo || !pr) {
+  stdout.write(
+    'coverage-pr-comment: --post requires GITHUB_TOKEN + GITHUB_REPOSITORY + --pr (or PR_NUMBER). Falling back to render-only:\n\n',
+  );
+  stdout.write(`${body}\n`);
+  exit(0);
+}
+
+const result = await upsertStickyComment({ repo, pr, body });
+stdout.write(`coverage-pr-comment: ${result.action} comment ${result.id} on PR ${pr}.\n`);
+exit(0);

--- a/scripts/coverage-pr-comment.mjs
+++ b/scripts/coverage-pr-comment.mjs
@@ -131,7 +131,17 @@ async function ghJson(path, init = {}) {
 
 async function upsertStickyComment({ repo, pr, body }) {
   const existing = await ghJson(`/repos/${repo}/issues/${pr}/comments?per_page=100`);
-  const prior = existing.find((c) => typeof c.body === 'string' && c.body.includes(COMMENT_MARKER));
+  // Match the marker AND require a bot-authored comment. A user could
+  // legitimately quote the marker text in a review comment (e.g. while
+  // discussing the script's behavior); without the bot filter we'd
+  // happily overwrite their reply with the next coverage update,
+  // breaking conversation continuity.
+  const prior = existing.find(
+    (c) =>
+      typeof c.body === 'string' &&
+      c.body.includes(COMMENT_MARKER) &&
+      c.user?.type === 'Bot',
+  );
   if (prior) {
     await ghJson(`/repos/${repo}/issues/comments/${prior.id}`, {
       method: 'PATCH',

--- a/scripts/coverage-pr-comment.mjs
+++ b/scripts/coverage-pr-comment.mjs
@@ -154,10 +154,7 @@ async function upsertStickyComment({ repo, pr, body }) {
   // happily overwrite their reply with the next coverage update,
   // breaking conversation continuity.
   const prior = existing.find(
-    (c) =>
-      typeof c.body === 'string' &&
-      c.body.includes(COMMENT_MARKER) &&
-      c.user?.type === 'Bot',
+    (c) => typeof c.body === 'string' && c.body.includes(COMMENT_MARKER) && c.user?.type === 'Bot',
   );
   if (prior) {
     await ghJson(`/repos/${repo}/issues/comments/${prior.id}`, {

--- a/scripts/coverageThresholds.d.mts
+++ b/scripts/coverageThresholds.d.mts
@@ -1,0 +1,14 @@
+/**
+ * Type declarations for `coverageThresholds.mjs`. Imported by
+ * `vite.config.ts` (and by anything else that wants type-checked
+ * references to the floors), so TS sees concrete types instead of
+ * `any` for the ESM constants.
+ */
+export const COVERAGE_THRESHOLDS: Readonly<{
+  statements: number;
+  branches: number;
+  functions: number;
+  lines: number;
+}>;
+
+export const DRIFT_WARN_PP: number;

--- a/scripts/coverageThresholds.mjs
+++ b/scripts/coverageThresholds.mjs
@@ -1,0 +1,47 @@
+/**
+ * Single source of truth for the Vitest coverage gate.
+ *
+ * Both `vite.config.ts` (which configures vitest's `coverage.thresholds`)
+ * and `scripts/coverage-pr-comment.mjs` (the sticky PR-comment renderer)
+ * import from here. Keeping them in one place avoids the bug where
+ * bumping the gate without bumping the drift comparator (or vice versa)
+ * silently desyncs the two.
+ *
+ * **Re-baselining a floor.** When the PR-comment shows ⚠️ (actual ≥
+ * `floor + DRIFT_WARN_PP` on some metric), re-run
+ * `npm run test:coverage`, read the new percentages from
+ * `coverage/coverage-summary.json`, and set each floor to
+ * `floor(measured − 2)` (so routine PRs don't trip the gate but a
+ * coverage regression beyond ~2pp fails the build). Update the
+ * **Baseline** comment below with the new measurements + the commit
+ * SHA they were taken at, in the same PR.
+ */
+
+/**
+ * Floor percentages for each v8 coverage metric. Vitest fails the build
+ * if any actual percentage drops below the corresponding floor.
+ *
+ * **Baseline 2026-04-25 (commit f6e4464):** statements 76.22 / branches
+ * 66.61 / functions 85.42 / lines 77.78. Floors set at
+ * `floor(measured − 2)`.
+ */
+export const COVERAGE_THRESHOLDS = Object.freeze({
+  statements: 74,
+  branches: 64,
+  functions: 83,
+  lines: 75,
+});
+
+/**
+ * Drift envelope (in percentage points) used by
+ * `scripts/coverage-pr-comment.mjs`. When `actual − floor` exceeds this
+ * value on any metric, the sticky PR comment marks that metric ⚠️ with
+ * "consider re-baselining". Advisory only — the actual regression gate
+ * is the floors above (vitest fails the build when actual < floor).
+ *
+ * 5pp is the empirical headroom we tolerate before a floor drifts far
+ * enough from reality that a sizeable regression could slip through. A
+ * stricter value (e.g. 3pp) produces too many warnings; looser (e.g.
+ * 10pp) defeats the purpose of the check.
+ */
+export const DRIFT_WARN_PP = 5;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,8 @@ import type { Plugin } from 'vite';
 import { defineConfig } from 'vitest/config';
 import dts from 'vite-plugin-dts';
 
+import { COVERAGE_THRESHOLDS } from './scripts/coverageThresholds.mjs';
+
 // Library mode build. Entries:
 // - main:        src/index.ts                        → dist/index.js
 // - excalibur:   src/integrations/excalibur/index.ts → dist/integrations/excalibur/index.js
@@ -170,20 +172,20 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html', 'lcov'],
+      // `json-summary` is consumed by `scripts/coverage-pr-comment.mjs`
+      // (the sticky PR comment showing actual % + delta vs base + drift
+      // status). Other reporters are for humans reading the report
+      // locally / from the lcov artifact.
+      reporter: ['text', 'html', 'lcov', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/index.ts', 'src/**/*.d.ts'],
-      // Baseline 2026-04-25 (commit f6e4464): statements 76.22 / branches
-      // 66.61 / functions 85.42 / lines 77.78. Thresholds set at
-      // floor(measured - 2) so routine PRs don't trip the gate but a
-      // coverage regression beyond ~2pp fails the build. Bump these in
-      // step with measured improvements (cite the new baseline + commit).
-      thresholds: {
-        statements: 74,
-        branches: 64,
-        functions: 83,
-        lines: 75,
-      },
+      // Floors live in `scripts/coverageThresholds.mjs` (single source
+      // of truth for both this gate and the PR-comment renderer). The
+      // PR-comment job warns when actual climbs `DRIFT_WARN_PP`pp above
+      // a floor; that is the cue to re-baseline (set the floor to
+      // `floor(measured - 2)` and cite the new measurement + commit
+      // SHA in the threshold module's docstring).
+      thresholds: COVERAGE_THRESHOLDS,
     },
   },
 });


### PR DESCRIPTION
## Summary

Coverage floors (`statements: 74, branches: 64, functions: 83,
lines: 75`) in `vite.config.ts` were a one-time baseline. Daily
review (#87 finding `42ede76.3`) flagged the gap-grows-silently risk:
when actual coverage drifts above a floor, no CI signal tells anyone
to re-baseline — so a 15pp regression could land without the floor
ever having moved meaningfully from reality.

Rather than the bot's suggested "advisory `::warning::` annotation"
(buried in CI logs), this PR mirrors the existing `size-limit-action`
sticky-PR-comment pattern. One Markdown table per PR, edited in place
across pushes — high-signal, reviewable inline, reuses infra
reviewers already read.

## What changed

**Single source of truth.** New `scripts/coverageThresholds.mjs` (+
`.d.mts` shim) exports `COVERAGE_THRESHOLDS` and `DRIFT_WARN_PP`.
`vite.config.ts` imports it for the gate; the comment script imports
it for floor labels and drift warnings. Re-baselining now happens in
one place, with the baseline measurement + commit SHA cited in the
docstring.

**Sticky PR comment.** New `scripts/coverage-pr-comment.mjs`:

- reads `coverage/coverage-summary.json` for PR head, optionally for
  base
- renders a Markdown table — actual %, delta vs base, floor, status
  (`✅` / `❌ below floor` / `⚠️ Npp above floor — consider
  re-baselining`)
- `--render-only` mode prints to stdout (`npm run coverage:report` for
  local preview)
- `--post` upserts a sticky comment via the GitHub REST API,
  identified by hidden marker `<!-- coverage-pr-comment -->`

**CI wiring** (`.github/workflows/ci.yml`):

- `test-core` (ubuntu cell) uploads `coverage-summary.json` as
  artifact `coverage-summary` with `if: always()` — vitest still
  writes the summary on threshold failure, and that is exactly when
  reviewers need the comment to surface which metric dropped.
- New `coverage-pr-comment` job: downloads PR run's artifact, then
  the latest successful develop-run's same artifact via
  `gh run download`. Permissions `pull-requests: write` (post) +
  `actions: read` (cross-run download). NOT added to `ci-gate` needs
  — purely informational.
- Adds `json-summary` to vitest's `coverage.reporter` list so the
  summary file gets emitted.

**eslint.config.js**: `fetch` global for `scripts/**/*.mjs`;
`scripts/*.d.mts` allowed in
`parserOptions.projectService.allowDefaultProject`.

## Followup (out of scope)

Owner asked about complexity-metric tracking too — separate roadmap
row, separate PR. Tooling choice (file-level `code-complexity`,
function-level `eslint-plugin-sonarjs`, dep-graph `madge`) and signal
characteristics (slow-moving, noisy per-PR) are different enough that
mixing them muddies both surfaces.

Refs #87 finding:42ede76.3

## Test plan

- [x] `npm run verify` — 523 tests pass, lint + typecheck + build green
- [x] `npm run coverage:report` renders the same Markdown table this
  PR's CI run will post (without the GitHub API call)
- [x] First push will likely show "base summary not available" since
  develop has not yet produced the artifact; expected and documented
  in the comment body. Subsequent develop merges + re-pushes will
  populate the deltas
- [x] No library behavior change — no changeset

@codex review