### PR TITLE
chore(build): silence rolldown vite:dts plugin-timings warning

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -121,6 +121,19 @@ export default defineConfig({
         entryFileNames: '[name].js',
         chunkFileNames: 'chunks/[name]-[hash].js',
       },
+      // `vite-plugin-dts` runs the TypeScript compiler to emit
+      // declarations and is intrinsically the slowest part of the
+      // build (~3s of a ~4s wall time). The levers we can pull are
+      // already tightened — `tsconfig.build.json` excludes tests,
+      // `skipLibCheck` is inherited from the base config,
+      // `rollupTypes: false` keeps us off the slow bundle-types
+      // path, and we are already pinned to the latest
+      // `vite-plugin-dts`. Rolldown's `pluginTimings` check is
+      // informational only; suppress it so the warning stops
+      // cluttering build output without misleading future
+      // contributors into chasing an actionable fix that does not
+      // exist.
+      checks: { pluginTimings: false },
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary

Every `npm run build` (locally during `npm run verify` and on every
CI run) prints:

```
[PLUGIN_TIMINGS] Warning: Your build spent significant time in
plugin `vite:dts`. See https://rolldown.rs/options/checks#plugintimings
```

This is rolldown's heuristic flagging plugins that dominate build
wall time. It is informational, not actionable — `vite-plugin-dts`
takes ~3.0s of a ~3.7s build (~80%) because it invokes the
TypeScript compiler to emit declarations, which is intrinsically the
slow part of the build.

## Investigation

Checked every lever before resorting to suppression:

- Pinned to `vite-plugin-dts@4.5.4` (latest as of 2026-04-26)
- `tsconfig.build.json` already excludes `tests/`, `examples/`,
  `*.test.ts`, `*.spec.ts`
- `skipLibCheck: true` is already inherited from the base
  `tsconfig.json`
- `rollupTypes: false` already keeps us off the slow bundle-types
  path
- `entryRoot: 'src'` already matches the actual source root
- `staticImport: true` already on

No remaining setting reduces `vite-plugin-dts` runtime. The warning
is rolldown describing reality.

## Fix

Suppress the rolldown check via
`build.rollupOptions.checks.pluginTimings: false`. Inline comment in
`vite.config.ts` records the investigation so the rationale is
visible in-place — no future contributor will spend time chasing a
fix that doesn't exist.

## Test plan

- [x] `npm run verify` — all green; build output now ends cleanly at
  `✓ built in 3.49s` with no `[PLUGIN_TIMINGS]` warning
- [x] Build wall-time unchanged (warning suppression has zero
  perf cost — it just gates a stdout write)
- [x] No library behavior change; tooling-only diff. No changeset

@codex review