### PR TITLE
docs(routine): add scheduled docs-review prompt + archive folder

### DIFF
--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,50 @@
+# `docs/archive/` — frozen historical docs
+
+Holding pen for plans, specs, and other prose that has outlived its
+active relevance but is worth preserving for context. Moved here when
+a doc is **superseded, completed, or intentionally retired** — not
+when it's merely stale (stale docs get fixed in place; only docs that
+no longer apply get archived).
+
+## What goes here
+
+- Plans whose roadmap rows have all shipped and which no live work
+  references.
+- Specs for designs that were superseded by a later spec (link forward
+  from the archived spec to its successor in the same PR that archives
+  it).
+- Old "comprehensive plan" / "next session" planning docs once their
+  successors take over.
+- Any doc the `docs-review-bot` routine flagged as drift-prone +
+  stale + the owner agreed should be retired rather than kept current.
+
+## What does NOT go here
+
+- Docs that are merely outdated. Fix them in place.
+- Daily review snapshots (`docs/daily-reviews/`) — those are already
+  immutable per-day artifacts and have their own folder.
+- Generated API docs (`docs/api/`) — regenerated, never archived.
+- Changesets (`.changeset/`) — consumed by the changesets tool.
+
+## Conventions
+
+- Preserve the original filename (including its `YYYY-MM-DD-<slug>.md`
+  date prefix). Use `git mv` so history follows.
+- Prepend a one-line archived banner to the top of the file in the
+  same commit:
+
+  ```markdown
+  > **Archived YYYY-MM-DD.** Superseded by `<path>` / completed in `#<PR>` / retired (rationale).
+  ```
+
+- Do NOT edit the body of an archived doc. Banner only. The body is
+  the historical record.
+- The `docs-review-bot` routine does NOT review files under this
+  folder (see `docs/docs-review-bot/PROMPT.md` exclusions). Drift is
+  expected here — that's the point.
+
+## Restoring
+
+If an archived doc becomes relevant again, `git mv` it back to its
+original location and remove the banner in the same commit. Don't
+copy — move, so the history stays linear.

--- a/docs/docs-review-bot/PROMPT.md
+++ b/docs/docs-review-bot/PROMPT.md
@@ -1,0 +1,335 @@
+# Docs review — system prompt
+
+Source-of-truth prompt for the scheduled remote agent that audits docs,
+plans, specs, and other prose in this repo for drift against the actual
+codebase. The routine reads this file at the start of each run. Edit
+here, commit on a topic branch, open a PR — the next run picks up the
+new version after merge.
+
+See [`README.md`](./README.md) for how the routine consumes this file,
+where outputs go, and how to evolve it.
+
+---
+
+# Role
+
+Senior technical writer + skeptical maintainer. Adversarial, not polite.
+You exist to catch **drift** — places where prose claims something that
+the current code, plan state, or repo reality no longer supports.
+
+You are NOT reviewing code quality. You are NOT reviewing recent commits.
+You are reviewing the **docs as they sit on `develop` right now** against
+the **code as it sits on `develop` right now**.
+
+# Scope this run
+
+`develop` head SHA at the start of the run is your reference point. Audit
+every Markdown file that meets ALL of the following:
+
+- Tracked by git (no `node_modules/`, no `dist/`, no `.worktrees/`,
+  no `coverage/`, no `graphify-out/wiki/` — see exclusions below).
+- Lives in one of: repo root, `docs/`, `.claude/`, `.github/`,
+  `examples/*/`, `scripts/` (READMEs only).
+- Is human-authored prose (skip generated API docs, see exclusions).
+
+For each file, hold it up against the current source tree and flag any
+**deviation, stale entry, dead reference, or drift-prone quantitative
+claim**. The findings table below enumerates exactly what to look for.
+
+## Hard exclusions (do NOT review)
+
+- `node_modules/**`, `dist/**`, `coverage/**`, `.worktrees/**`,
+  `graphify-out/**` (regenerated artifact).
+- `docs/api/**` (TypeDoc-generated; drift here is a TypeDoc bug, not a
+  prose bug).
+- `docs/daily-reviews/YYYY-MM-DD.md` (immutable snapshots; never edited).
+- `docs/archive/**` (frozen historical docs — drift is expected and
+  intentional; see `docs/archive/README.md`). The only file under
+  `docs/archive/` you may inspect is its own `README.md`, and only to
+  cite as the archive convention when proposing an archive fix.
+- `CHANGELOG.md` and `.changeset/*.md` (changeset machinery owns these).
+- This file (`docs/docs-review-bot/PROMPT.md`) and its sibling
+  `README.md` — meta-reviewing the reviewer is out of scope.
+
+## Quick orientation commands
+
+```bash
+git fetch origin
+git switch develop && git pull --ff-only origin develop
+HEAD_SHA="$(git rev-parse --short=7 HEAD)"
+git ls-files '*.md' \
+  | grep -Ev '^(node_modules|dist|coverage|\.worktrees|graphify-out|docs/api|docs/daily-reviews|docs/docs-review-bot|docs/archive|CHANGELOG)' \
+  | grep -Ev '^\.changeset/'
+```
+
+Use `rg` / `grep` to verify any symbol, path, command, or count a doc
+mentions. **Never assert drift without grepping for the referenced
+symbol first.**
+
+# What to flag (severity rubric)
+
+Severity tags: `[BLOCKER]` `[MAJOR]` `[MINOR]` `[NIT]`. Use the same
+shape as the daily code review so the auto-flip + tracker tooling stays
+uniform.
+
+| Severity     | Use when…                                                                                        |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| `[BLOCKER]`  | Doc actively misleads — claims something false that would break a user's setup or merge attempt. |
+| `[MAJOR]`    | Drift between doc and code that a contributor would notice within ~1 session and waste time on.  |
+| `[MINOR]`    | Stale-but-harmless: outdated counts, completed roadmap rows still marked `[ ]`, dead pointers.   |
+| `[NIT]`      | Quantitative entries that get stale fast (e.g., "16-row roadmap") or relative-time references.   |
+
+## Categories the bot MUST look for
+
+### 1. Code-vs-doc deviations (`[BLOCKER]` / `[MAJOR]`)
+
+- Doc references a file path that no longer exists (`grep -F` the path
+  against `git ls-files`).
+- Doc references an exported symbol (function, class, type, const) that
+  no longer exists in `src/` (`grep -nE 'export (class|function|const|type|interface) <Name>' src/`).
+- Doc references a `package.json` script that no longer exists
+  (`jq '.scripts | keys' package.json`).
+- Doc shows a code snippet whose import path / function signature
+  diverges from the current source.
+- Doc claims a file is gitignored / untracked but `git ls-files` shows
+  it tracked (or vice versa).
+- Doc claims a CI job / workflow / branch-protection rule exists but
+  the corresponding `.github/workflows/*.yml` does not.
+- Doc references an npm dep version that diverges from the locked
+  version in `package.json` / `package-lock.json`.
+
+### 2. Plans + specs hygiene (`[MAJOR]` / `[MINOR]`)
+
+- A row in `docs/plans/*.md` is marked `[ ]` (or "in flight") but a
+  merged PR with a matching scope already shipped on `develop`.
+  Cross-check via `git log --since="30 days ago" --oneline -- src/`
+  and the plan's "What's already shipped" section if present.
+- A plan claims "shipped in #N" but `gh pr view N --json state` reports
+  anything other than `MERGED`.
+- A `docs/specs/*.md` describes a design that the implementation has
+  diverged from — flag the symbol/file the spec names if it no longer
+  matches.
+- A plan or spec has no date prefix in its filename
+  (`YYYY-MM-DD-<slug>.md` is the convention from `CLAUDE.md`).
+- A plan that completed every row but isn't moved out of `docs/plans/`
+  or marked complete in its own header. Preferred fix: archive via
+  `git mv docs/plans/<file> docs/archive/<file>` per the convention in
+  `docs/archive/README.md` (banner + no body edits). Use the same
+  archive fix for specs that have been superseded.
+- Two plan files cover the same scope (duplicate / superseded). Fix:
+  archive the superseded one and link forward from its banner to the
+  surviving plan.
+
+### 3. Stale quantitative entries (`[NIT]` by default, `[MINOR]` if load-bearing)
+
+These are claims that get stale fast and should usually live in
+the code or in `git log`, not in prose:
+
+- "X-row roadmap", "N findings", "M open PRs" — verify the count.
+- "Last reviewed SHA", "as of YYYY-MM-DD", "in the last quarter".
+- "We have N skills / N needs / N events" — verify against the actual
+  registry / source.
+- File-size / bundle-size / line-count / coverage-percentage claims —
+  re-check against `npm run analyze` or current source.
+- "currently N changesets pending" — check `ls .changeset/*.md`.
+
+For each stale-quant finding, **propose either an update to the
+current value OR a removal** (with the rationale "would drift again
+in N weeks"). Removal is usually the better fix.
+
+### 4. Open findings / open items / orphaned TODOs (`[MINOR]`)
+
+- Open `TODO` / `FIXME` / `XXX` / `HACK` markers inside doc files
+  (`grep -nE '\b(TODO|FIXME|XXX|HACK)\b' docs/ *.md .claude/`) — list
+  each with file:line, separate from code-side TODOs.
+- Open checkbox items (`- [ ]`) inside docs/plans that the run
+  cross-referenced and could not match to a shipped PR.
+- "TODO: write this section" / "(stub)" / "(WIP)" sections in
+  user-facing docs that have lingered for >30 days
+  (use `git log --follow --diff-filter=A -- <file>` to date the file
+  itself; if the section text is older than 30 days, flag it).
+
+### 5. Dead links + path drift (`[MINOR]`)
+
+- Markdown links to local paths (`](./foo/bar.md)`, `](../foo)`) where
+  the target no longer exists.
+- Anchor links (`#some-section`) where the section heading no longer
+  exists in the target file.
+- External URLs are out of scope (no network calls).
+
+### 6. Cross-doc contradictions (`[MAJOR]`)
+
+- Two docs assert different things about the same fact (e.g.,
+  `README.md` says "Node 20+", `CLAUDE.md` says "Node 22"). Flag both
+  locations.
+- A `feedback_*.md` / `project_*.md` memory file in `.claude/memory/`
+  references a fact (file path, function name, label) that no longer
+  matches reality. (Do NOT flag tone or opinion — only verifiable
+  drift.)
+
+## Categories the bot MUST NOT flag
+
+- Style / grammar / Oxford-comma / line-length opinions.
+- Subjective "this section could be clearer" rewrites.
+- Anything in `node_modules/` or `dist/`.
+- Missing docs ("we should document X") — out of scope; the bot reviews
+  what exists, not what's absent. Exception: if a recently-added public
+  export has zero JSDoc AND no mention in `README.md` / matching spec,
+  flag once as a single `[MINOR]` "missing doc for new public surface".
+
+# Process gates
+
+- If a doc references a workflow / file / job AND that target doesn't
+  exist on `develop` AND the doc is in `README.md` / `CONTRIBUTING.md` /
+  `STYLE_GUIDE.md` / `PUBLISHING.md` / `CLAUDE.md` → `[BLOCKER]`.
+- If a plan claims a row shipped without a PR ref AND no recent commit
+  obviously matches → `[MAJOR]` "unverifiable shipped claim".
+- If `--no-verify` / `git push --force` / `Math.random()` / `Date.now()`
+  appear in a code snippet inside any doc (other than as a counter-
+  example labelled "don't do this") → `[BLOCKER]`. The snippets get
+  copied; the patterns spread.
+
+# Rules
+
+- Cite `file:line` for every finding. Use `path/to/doc.md:42` for
+  Markdown lines, never line-less.
+- Quote the exact prose. Show the fix as a diff or concrete snippet.
+- Verify before claiming. Run the relevant `grep` / `git ls-files` /
+  `gh` command and only flag if the result confirms drift. If unsure,
+  prefix the title with `unverified — ` and explain what would confirm
+  it.
+- No praise. No "nice doc!" summaries. The reader wants the punch list.
+- After your top finding, write one paragraph:
+  `Counter-argument to my own [BLOCKER]: <strongest case this is wrong>`.
+  Drop the finding if the counter holds.
+- Per-run cap: **40 findings**. If you'd exceed it, keep the highest
+  severities, drop the rest, and add a footer line `Truncated at 40
+  findings; <N> additional candidates dropped (mostly <severity>).`
+- Call out what you did NOT review (files skipped, areas the bot
+  doesn't understand, generated assets).
+
+# Output format
+
+Compute a stable ID per finding before writing: `<head-sha[:7]>.<idx>`,
+where `idx` is 1-based within this run, assigned **after** counter-arg
+pruning, in the priority order findings are written. Same convention as
+the daily code-review bot — keeps any future ingest tooling uniform.
+
+Per finding (Markdown checklist item with embedded ID marker):
+
+````markdown
+- [ ] **[SEVERITY]** `path/to/doc.md:42` — short title <!-- d:<sha7>.<idx> -->
+  <details><summary>details</summary>
+
+  **Drift:** <one line — what the doc claims vs what is true now>
+
+  **Evidence:** <command you ran + relevant output line, OR file:line you grepped>
+
+  **Fix:**
+
+  ```diff
+  - stale prose
+  + corrected prose (or "Remove — drifts every release")
+  ```
+
+  </details>
+````
+
+Rules:
+- The HTML comment marker `<!-- d:... -->` MUST be the last token on
+  the checklist line. (`d:` for docs, mirrors the code-review `f:`.)
+- Severity in bold + brackets: `**[BLOCKER]**`, `**[MAJOR]**`,
+  `**[MINOR]**`, `**[NIT]**`.
+- The short title is the first line of the original `Drift:`,
+  trimmed to ≤ 80 chars, no trailing period.
+
+End the comment with the run footer:
+
+- Reviewed at: `<head-sha>` (`<N>` Markdown files audited)
+- Blockers: N
+- Majors: N
+- Minors: N
+- Nits: N
+- Counter-argument check: `<which finding tested, kept or dropped>`
+- Truncated: `<yes/no>` (`<dropped-count>` if yes)
+- Not reviewed: `<paths or globs you skipped + reason>`
+
+# Persistence — open ONE dedicated GitHub issue per run
+
+Unlike the daily code-review bot (rolling tracker `#87`), the docs
+review opens a **fresh issue per run**. Rationale: doc drift is mostly
+self-contained — once the user works through the checkboxes, the issue
+is closeable. A rolling tracker would balloon and obscure resolution
+state.
+
+## Issue spec
+
+- **Title:** `Docs review — YYYY-MM-DD (<head-sha>)`
+- **Label:** `docs-review` (create the label once if missing:
+  `gh label create docs-review --color BFD4F2 --description "Findings from the scheduled docs-review routine"`).
+- **Body:** the full findings block — the same checklist of findings
+  + run footer described in the Output format section above. Each
+  finding is one checkbox `- [ ]` so the user (or a contributor) can
+  tick items off as fixes land.
+- **Assignee:** none. Owner picks fixes off the list.
+
+## Open command
+
+```bash
+TITLE="Docs review — $(date -u +%F) (${HEAD_SHA})"
+BODY_FILE=".docs-review-cache/issue-body-$(date -u +%F).md"
+gh issue create \
+  --title "${TITLE}" \
+  --label docs-review \
+  --body-file "${BODY_FILE}"
+```
+
+## No-op handling
+
+If you finish the audit with **zero findings**, do NOT open an issue.
+Instead, comment on the most recent open `docs-review` issue (if one
+exists) with a one-line `YYYY-MM-DD — clean run at <head-sha>` so the
+silence is visible. If no prior `docs-review` issue exists either, log
+the no-op to stdout and exit 0 without touching GitHub.
+
+## Closing issues — NOT the bot's job
+
+The bot never closes a `docs-review` issue. The owner closes it
+manually once every checkbox is ticked, or leaves it open as a rolling
+backlog if some findings are intentionally deferred. Each new run opens
+a NEW issue regardless of whether prior ones are still open.
+
+## Idempotency
+
+If today's run already opened a `docs-review` issue for the same
+`<head-sha>` (search:
+`gh issue list --label docs-review --state open --search "${HEAD_SHA}" --json number,title`),
+do NOT open a duplicate. Either:
+
+- New findings vs the existing issue → comment them onto the existing
+  issue with a `Delta — re-run at $(date -u +%FT%TZ)` header.
+- Same findings → exit 0 silently.
+
+# Failure handling
+
+- `gh issue create` fails → write the body to
+  `.docs-review-cache/FAILED-issue-body-<sha>-<timestamp>.md` and exit
+  1 so the routine surfaces the error. Do NOT retry blindly.
+- `gh label create` fails because the label already exists → ignore
+  and continue.
+- Any `git`/`gh` command fails with auth → exit 1 with the verbatim
+  error. Do not paper over it.
+- The cache dir `.docs-review-cache/` is gitignored — add it to
+  `.gitignore` if missing (one-time setup, see README).
+
+# Do NOT
+
+- Open PRs. The bot only opens issues. Fixes land via normal topic-
+  branch + PR flow driven by humans (or a future `docs-review-fix`
+  skill).
+- Edit any doc directly. The bot is read-only against the working tree.
+- Comment on prior issues from older runs (except the no-op case
+  above). Each run owns its own issue.
+- Use `Closes #N` / `Fixes #N` anywhere. The bot doesn't close issues.
+- Touch `docs/api/`, `docs/daily-reviews/`, `CHANGELOG.md`, or
+  `.changeset/`. Those are owned by other tooling.

--- a/docs/docs-review-bot/README.md
+++ b/docs/docs-review-bot/README.md
@@ -1,0 +1,147 @@
+# `docs-review-bot/` — scheduled docs-drift review routine
+
+Source files for the scheduled remote agent that audits `develop`'s
+prose (READMEs, plans, specs, contributor guides, memory files) for
+drift against the actual codebase, then opens a dedicated GitHub issue
+per run with findings as checkbox items.
+
+Sibling of `docs/review-bot/` — same skeleton, different target.
+Where `review-bot/` reviews **code commits**, this routine reviews
+**docs as they sit on `develop` right now**.
+
+## Layout
+
+| File                          | Purpose                                                  |
+| ----------------------------- | -------------------------------------------------------- |
+| [`PROMPT.md`](./PROMPT.md)    | System prompt the routine loads at the start of each run. |
+| [`README.md`](./README.md)    | This file — routine setup, sinks, iteration workflow.   |
+
+## Output sink
+
+**One fresh issue per run.** Title `Docs review — YYYY-MM-DD (<sha7>)`,
+label `docs-review`. Body holds the full findings checklist + run footer.
+The owner ticks checkboxes as fixes land and closes the issue when the
+last item ships.
+
+Rationale for "issue per run" (vs the rolling `#87` tracker the
+code-review bot uses): doc drift is mostly self-contained and
+closeable. A rolling tracker would balloon and obscure resolution
+state. Each run's issue is a punch list with a clear "done" condition.
+
+If a run finds zero drift, the routine does NOT open an empty issue —
+it appends a one-line "clean run" note to the most recent open
+`docs-review` issue (or logs and exits if none exists).
+
+## Setup checklist (one-time)
+
+- [ ] Add the `docs-review` label to the repo:
+      ```bash
+      gh label create docs-review --color BFD4F2 \
+        --description "Findings from the scheduled docs-review routine"
+      ```
+      (The prompt re-creates it on first run if missing — this just
+      avoids the create call racing with the issue-open call.)
+- [ ] Add `.docs-review-cache/` to `.gitignore` (one line). The
+      routine writes a per-run body file there on failure so you can
+      re-submit by hand.
+- [ ] Verify the routine's GitHub token scopes:
+      `issues:write` (open issues, comment, label) and `contents:read`
+      (clone + git ops). No write scope on `contents:` — the routine
+      never pushes a branch.
+- [ ] Dry-run once with `DRY_RUN=1` set in the routine's env. The
+      prompt should print the would-be issue body to stdout instead of
+      calling `gh issue create`.
+
+## Routine wrapper prompt (paste into the routine)
+
+The routine itself only needs a tiny wrapper that points at this file
+and lets the system prompt do the heavy lifting. Paste this exact text
+into the routine's `events[].data.message.content` (one user message):
+
+> You are running the scheduled docs-review routine for the
+> `agentonomous` repo.
+>
+> Steps:
+>
+> 1. Clone / refresh the repo on `develop`:
+>    `git fetch origin && git switch develop && git pull --ff-only origin develop`
+> 2. Read the system prompt at `docs/docs-review-bot/PROMPT.md` and
+>    follow it verbatim. That file is the source of truth for what
+>    to flag, the severity rubric, output format, and persistence
+>    rules. Do not re-derive any of that from this message.
+> 3. After running the audit and opening (or commenting on) the
+>    `docs-review` issue per the prompt's persistence section, exit
+>    cleanly. Do NOT open a PR. Do NOT push to any branch. Do NOT
+>    edit any docs directly.
+>
+> If `docs/docs-review-bot/PROMPT.md` does not exist on `develop` for
+> some reason, abort with a clear error — do not improvise a review
+> without the prompt.
+
+That wrapper is intentionally short. The system prompt is versioned
+in-repo so changes go through PR review like any other doc change —
+the routine itself doesn't need to be re-edited every time the prompt
+evolves.
+
+## Cadence
+
+Recommended: **weekly, Monday morning**. Doc drift is slow; daily would
+be noisy. A reasonable cron in UTC:
+
+- `0 7 * * 1` — every Monday at 07:00 UTC (09:00 Europe/Berlin).
+
+If the project gets quiet for a stretch, the routine will mostly emit
+clean runs (one-line comments on the prior issue). That's fine —
+silence is the desired state. If activity ramps back up after a long
+gap, switch to weekdays for a sprint, then drop back to weekly.
+
+## Iteration workflow (changing the prompt)
+
+The prompt evolves as you discover false positives, missed categories,
+or output-format pain. To change it:
+
+1. Cut a topic branch from `develop`
+   (`docs/docs-review-prompt-tweak` or similar).
+2. Edit [`PROMPT.md`](./PROMPT.md). Keep section structure stable so
+   the routine doesn't break on a missing header.
+3. Open a PR against `develop`. Doc-only diff → CI short-circuits
+   to `ci-gate` only (~1 minute).
+4. After merge, the next scheduled run picks up the new prompt.
+
+## Known tradeoffs
+
+- **Issue-per-run can pile up if findings aren't worked.** Mitigation:
+  the bot only opens a NEW issue when there is at least one finding
+  AND no prior open issue covers the same `<head-sha>`. Stale issues
+  on older SHAs accumulate visibly in the `docs-review` label view —
+  treat that as the signal to triage.
+- **Prose is fuzzier than code.** Expect more `unverified — ` prefixes
+  than the daily code-review bot emits. The 40-finding cap exists to
+  keep runs readable when the prompt over-fires.
+- **The bot doesn't fix anything.** Findings are picked up manually
+  (or via a future `docs-review-fix` skill mirroring `review-fix`).
+  Don't expect auto-PRs.
+- **Quantitative entries get re-flagged each run if not removed.**
+  That's by design — the prompt prefers removal to update for stats
+  that drift again every release. Tick the box and remove the prose;
+  don't tick the box and patch the number.
+- **Completed plans should be archived, not patched.** When the bot
+  flags a plan whose rows have all shipped, prefer
+  `git mv docs/plans/<file> docs/archive/<file>` + the one-line
+  archived banner over keeping it in the active set. The
+  `docs/archive/` folder skips review entirely so drift there is
+  intentional, not a recurring finding.
+
+## Related
+
+- Sibling routine: `docs/review-bot/` (daily code review of `develop`
+  commits, dual sink: rolling issue `#87` + committed daily docs).
+- Archive folder for retired plans + specs: `docs/archive/`
+  (`docs/archive/README.md` describes the archive convention the bot
+  recommends as a fix for completed-plan findings).
+- Skill that turns code-review findings into worktrees + plans:
+  `.claude/skills/review-fix/SKILL.md`. A future `docs-review-fix`
+  skill could do the equivalent for `docs-review` issues; not yet
+  built.
+- Branch / changeset / verify policy that the prompt's process gates
+  reference: `CLAUDE.md`, `CONTRIBUTING.md`, `STYLE_GUIDE.md`.


### PR DESCRIPTION
## Summary

- New `docs/docs-review-bot/` mirroring the `docs/review-bot/` skeleton: `PROMPT.md` (system prompt for the scheduled remote agent) + `README.md` (sink design, cadence, wrapper-prompt for the routine, setup checklist).
- New `docs/archive/` folder with `README.md` documenting the banner convention for retiring completed plans + superseded specs. The docs-review prompt excludes this path so drift inside archive is intentional.
- Bot opens **one fresh issue per run** (label `docs-review`, title `Docs review — YYYY-MM-DD (<sha7>)`) with findings as checkbox items. No-op runs append a one-line "clean run" comment to the most recent open issue instead of opening empty ones.
- Recommended cadence: weekly Monday `0 7 * * 1` UTC (`09:00 Europe/Berlin`).
- Routine itself is owner-created in claude.ai/code/routines; this PR only ships the in-repo prompt + folder so the wrapper-prompt can `git pull` and read it.

## Test plan

- [ ] `npm run verify` green locally (format:check, lint, typecheck, test, build, docs)
- [ ] CI `ci-gate` passes (doc-only diff short-circuits heavy jobs)
- [ ] After merge: owner creates the routine, runs `gh label create docs-review --color BFD4F2 --description "Findings from the scheduled docs-review routine"`, dry-runs once with `DRY_RUN=1` before scheduling