### PR TITLE
ci(codeql): add weekly + push CodeQL JS/TS scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+  schedule:
+    # Mondays 06:00 UTC — same window as docs-review weekly cadence.
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: ${{ matrix.language }}
+          # security-and-quality is the broadest default suite that GA
+          # supports. security-extended would also work; quality-only
+          # would miss CWE-079/CWE-094 patterns we want flagged.
+          queries: security-and-quality
+      - uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/docs/plans/2026-04-26-quality-automation-routines.md
+++ b/docs/plans/2026-04-26-quality-automation-routines.md
@@ -107,7 +107,7 @@ merges.
 
 | #   | Chunk plan | Scope (one-line) | Cadence | Touches `src/`? | Status |
 | --- | --- | --- | --- | --- | --- |
-| 1   | [quality-codeql.md](./2026-04-26-quality-codeql.md) | Weekly + push CodeQL JS/TS scan, `security-and-quality` query suite | weekly + push | no | - [ ] not started |
+| 1   | [quality-codeql.md](./2026-04-26-quality-codeql.md) | Weekly + push CodeQL JS/TS scan, `security-and-quality` query suite | weekly + push | no | - [x] shipped |
 | 2   | [quality-dep-triage-bot.md](./2026-04-26-quality-dep-triage-bot.md) | Cloud routine prompt + `dependabot.yml` grouping for weekly Dependabot triage | weekly | no | - [ ] not started |
 | 3   | [quality-actions-bump-bot.md](./2026-04-26-quality-actions-bump-bot.md) | Cloud routine prompt that runs `scripts/bump-actions.mjs` weekly + opens a bump PR | weekly | no | - [ ] not started |
 | 4   | [quality-plan-recon-bot.md](./2026-04-26-quality-plan-recon-bot.md) | Cloud routine prompt that archives shipped plans monthly | monthly | no | - [ ] not started |


### PR DESCRIPTION
Tracks: #130
Tracks: #131

## Summary

Adds a CodeQL JS/TS scan that runs on every push and PR to develop/main
plus a Mondays-06:00-UTC weekly cron, using the `security-and-quality`
query suite. All actions pinned to 40-char commit SHAs per the repo's
supply-chain rule.

Ticks row 1 of the umbrella tracker.

## Test plan

- [x] `npm run verify` green (523/523 tests, lint/typecheck/build all pass)
- [x] `actionlint` clean on `.github/workflows/codeql.yml`
- [x] Action SHAs resolved via the umbrella's `resolve_action_sha` peel-aware helper (annotated tags handled)
- [ ] Post-merge: confirm `CodeQL / Analyze (javascript-typescript)` job runs green on the merge push to `develop`