### PR TITLE
refactor(review-bot): one tracker issue per code-review run

### DIFF
--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -7,11 +7,12 @@ description: Ingests one or all open findings from a review-bot tracker issue (o
 
 ## Terminology
 
-- **Tracker issue** — any issue carrying the label `review-bot`.
+- **Tracker issue** — any open issue carrying the label `review-bot`.
   Each scheduled bot run opens its own issue; the body holds that
-  run's full findings block. Sweep mode targets the newest issue;
-  single mode scans every issue (open + closed) for the requested
-  finding ID. **Never closed by this skill.**
+  run's full findings block. Sweep mode targets the newest open
+  issue; single mode scans every open issue for the requested
+  finding ID. Closed issues are out of scope — they are treated as
+  archived and never re-opened by this skill.
 - **Finding** — one `[BLOCKER] / [MAJOR] / [MINOR] / [NIT]` checklist
   item inside a tracker issue's body.
 - **Finding ID** — `<head-sha[:7]>.<idx>` (e.g. `682b557.3`). Embedded
@@ -75,7 +76,7 @@ Confirm with the user:
 1. **Finding ID (single mode only)** — exact form `<sha7>.<idx>`. If
    they paste a free-text description instead, refuse and ask them to
    grab the ID from
-   `gh issue list --label review-bot --limit 5` then
+   `gh issue list --label review-bot --state open --limit 5` then
    `gh issue view <n>`. In sweep mode (no-arg invocation), skip this
    check.
 2. **Already shipped?** — if the tracker line for the chosen ID renders
@@ -110,19 +111,18 @@ The recipe below dodges four real footguns:
    sure the JSON shape is the issue list output (objects with
    `number`, `body`, `url`, `createdAt`), not the PR list.
 
-Fetch every review-bot issue once into the project-local cache:
+Fetch every open review-bot issue once into the project-local cache:
 
 ```bash
 mkdir -p .review-fix-cache
-gh issue list --label review-bot --state all \
+gh issue list --label review-bot --state open \
   --json number,body,url,createdAt --limit 50 \
   > .review-fix-cache/issues.json
 ```
 
 **Single-finding mode.** Pass the ID via `--id`. The parser scans
-every issue in the cache (newest first) for that marker, so backlog
-findings on older tracker issues stay reachable — sweep mode only
-ever picks the newest issue, but single mode must not.
+every issue in the cache (newest first) for that marker. Sweep mode
+only ever picks the newest issue.
 
 ```bash
 ID="<sha7>.<idx>"            # e.g. 682b557.3
@@ -135,11 +135,11 @@ Parser exit codes (single mode):
 
 - `0` → match written to `finding.json` as
   `{issueNumber, issueUrl, createdAt, finding: {…}}`.
-- `1` → ID not found in any review-bot issue. Refuse with
-  `Finding ${ID} not found in any review-bot issue`.
+- `1` → ID not found in any open review-bot issue. Refuse with
+  `Finding ${ID} not found in any open review-bot issue`.
 - `2` → bad CLI args (e.g. user pasted a free-text description).
   Refuse and ask them to grab the ID from
-  `gh issue list --label review-bot --limit 5`.
+  `gh issue list --label review-bot --state open --limit 5`.
 - `3` → ID found but already shipped. The script's stderr already
   says `Finding <id> already shipped in #<PR>`; surface it and stop.
 

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -1,22 +1,25 @@
 ---
 name: review-fix
-description: Ingests one or all open findings from the rolling daily-code-review tracker issue (`#87 Daily code review — develop`) and produces a worktree-isolated topic branch + implementation plan per finding. Use when the user says "fix review finding <id>", "pick a finding", "/review-fix <id>", names a finding-ID like `682b557.3`, OR invokes `/review-fix` with no argument (sweeps every unshipped finding in the latest tracker comment). Does NOT close the tracker issue — the tracker is append-only and the auto-flip workflow handles shipped state.
+description: Ingests one or all open findings from a review-bot tracker issue (one issue per scheduled run, label `review-bot`) and produces a worktree-isolated topic branch + implementation plan per finding. Use when the user says "fix review finding <id>", "pick a finding", "/review-fix <id>", names a finding-ID like `682b557.3`, OR invokes `/review-fix` with no argument (sweeps every unshipped finding in the newest review-bot issue). Does NOT close any tracker issue — every issue stays open as the run's archive and the auto-flip workflow handles shipped state.
 ---
 
 # review-fix — turn tracker finding(s) into worktree(s) + plan(s)
 
 ## Terminology
 
-- **Tracker issue** — `#87 Daily code review — develop`. Long-lived,
-  one comment per scheduled bot run, body holds the canonical
-  `Last reviewed SHA`. **Never closed by this skill.**
+- **Tracker issue** — any issue carrying the label `review-bot`.
+  Each scheduled bot run opens its own issue; the body holds that
+  run's full findings block. Sweep mode targets the newest issue;
+  single mode scans every issue (open + closed) for the requested
+  finding ID. **Never closed by this skill.**
 - **Finding** — one `[BLOCKER] / [MAJOR] / [MINOR] / [NIT]` checklist
-  item inside a bot comment.
+  item inside a tracker issue's body.
 - **Finding ID** — `<head-sha[:7]>.<idx>` (e.g. `682b557.3`). Embedded
   as an HTML comment on each finding's checklist line.
-- **Magic line** — `Refs #87 finding:<id>` in a PR body. The
-  contract between this skill's output and the
-  `review-fix-shipped` Action.
+- **Magic line** — `Refs #<issue-number> finding:<id>` in a PR body.
+  The contract between this skill's output and the
+  `review-fix-shipped` Action. The issue number varies per finding
+  — it is always the tracker issue that holds that finding's body.
 
 ## Modes
 
@@ -25,8 +28,8 @@ description: Ingests one or all open findings from the rolling daily-code-review
   Step 7 (post-merge cleanup) is user-driven and happens after the
   PR ships.
 - **Sweep mode** — user invokes the skill with no argument. Pull the
-  most recent comment on `#87` that contains finding markers (skip
-  no-op comments), parse every `<!-- f:<id> -->` marker, skip ones
+  newest tracker issue (label `review-bot`, sorted by createdAt),
+  parse every `<!-- f:<id> -->` marker in its body, skip ones
   already rendered `- [x]`, and run steps 2 → 5 once per remaining
   finding. Each finding still gets its own worktree + branch + plan
   (one finding = one branch = one PR — sweep just batches the _setup_,
@@ -54,14 +57,15 @@ they run after the PR merges:
 4. npm run verify                   ← pre-PR gate
 
 5. gh pr create --base develop ...
-     PR body MUST include the magic line: Refs #87 finding:<id>
+     PR body MUST include the magic line: Refs #<issue> finding:<id>
+     (issue number is captured by this skill into the plan frontmatter)
 
 6. Codex review → resolve threads → owner merges PR to develop
 
 7. Post-merge cleanup (this skill, §7 below)
      prune worktree · delete branch · refresh develop
      `review-fix-shipped` Action ticks the tracker line and appends
-     `(shipped in #<PR>)` automatically — do NOT edit the comment.
+     `(shipped in #<PR>)` automatically — do NOT edit the issue.
 ```
 
 ## Before you start
@@ -70,11 +74,13 @@ Confirm with the user:
 
 1. **Finding ID (single mode only)** — exact form `<sha7>.<idx>`. If
    they paste a free-text description instead, refuse and ask them to
-   grab the ID from `gh issue view 87 --comments`. In sweep mode
-   (no-arg invocation), skip this check.
+   grab the ID from
+   `gh issue list --label review-bot --limit 5` then
+   `gh issue view <n>`. In sweep mode (no-arg invocation), skip this
+   check.
 2. **Already shipped?** — if the tracker line for the chosen ID renders
    `- [x]`, refuse (single mode) or silently skip (sweep mode) and tell
-   them which PR shipped it (the comment line carries `(shipped in #N)`).
+   them which PR shipped it (the line carries `(shipped in #N)`).
 3. **Worktree clear?** — if `.worktrees/fix-review-<slug>` already
    exists, refuse (single mode) or skip that finding with a logged
    warning (sweep mode). The user resolves collisions via
@@ -86,42 +92,41 @@ Confirm with the user:
 
 Both modes share the same fetch step. Node 22 is a hard project
 requirement (`.nvmrc`), so the parser is a checked-in script at
-`scripts/review-fix-parse.mjs`. **Do not** try to filter the comments
+`scripts/review-fix-parse.mjs`. **Do not** try to filter the issues
 JSON inline with `gh --jq`, `jq`, `node -e` heredocs, or `grep | sed`.
-The recipe below dodges five real footguns:
+The recipe below dodges four real footguns:
 
-1. `gh api --paginate --slurp --jq` is rejected by current `gh`
-   versions ("the `--slurp` option is not supported with `--jq` or
-   `--template`"). Slurp must run with no `--jq` filter.
-2. `--slurp` returns an array-of-pages (`[[...page1...], [...page2...]]`),
-   not a flat comment list. The script flattens; do not assume flat.
-3. `jq` is not installed by default on Windows or many CI images, so
+1. `jq` is not installed by default on Windows or many CI images, so
    the skill must not depend on it.
-4. Windows Git Bash maps `/tmp` for shell builtins but native Node
+2. Windows Git Bash maps `/tmp` for shell builtins but native Node
    resolves the same path to `D:\tmp` (which usually does not exist).
    Cache files therefore live under `.review-fix-cache/` in the repo
    root (gitignored), not `/tmp` or `${HOME}`.
-5. Finding-marker text can appear inside another finding's
+3. Finding-marker text can appear inside another finding's
    `<details>` body or quoted diff. The script only treats top-level
    checklist lines (`^- \[[ x]\] `) as finding boundaries.
+4. Issues with `--label review-bot` may include the cosmetic PR
+   label too; `gh issue list` only returns true issues, but make
+   sure the JSON shape is the issue list output (objects with
+   `number`, `body`, `url`, `createdAt`), not the PR list.
 
-Fetch every comment once into the project-local cache:
+Fetch every review-bot issue once into the project-local cache:
 
 ```bash
-REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 mkdir -p .review-fix-cache
-gh api "repos/${REPO}/issues/87/comments" --paginate --slurp \
-  > .review-fix-cache/comments.json
+gh issue list --label review-bot --state all \
+  --json number,body,url,createdAt --limit 50 \
+  > .review-fix-cache/issues.json
 ```
 
-**Single-finding mode.** Pass the ID via `--id`. The parser searches
-the **full comment history** (newest first) for that marker, so
-backlog findings on older tracker comments stay reachable — sweep
-mode only ever picks the newest comment, but single mode must not.
+**Single-finding mode.** Pass the ID via `--id`. The parser scans
+every issue in the cache (newest first) for that marker, so backlog
+findings on older tracker issues stay reachable — sweep mode only
+ever picks the newest issue, but single mode must not.
 
 ```bash
 ID="<sha7>.<idx>"            # e.g. 682b557.3
-node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
+node scripts/review-fix-parse.mjs .review-fix-cache/issues.json \
   --id "${ID}" \
   > .review-fix-cache/finding.json
 ```
@@ -129,26 +134,27 @@ node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
 Parser exit codes (single mode):
 
 - `0` → match written to `finding.json` as
-  `{commentId, commentUrl, createdAt, finding: {…}}`.
-- `1` → ID not found in any comment. Refuse with
-  `Finding ${ID} not found in #87 comments`.
+  `{issueNumber, issueUrl, createdAt, finding: {…}}`.
+- `1` → ID not found in any review-bot issue. Refuse with
+  `Finding ${ID} not found in any review-bot issue`.
 - `2` → bad CLI args (e.g. user pasted a free-text description).
   Refuse and ask them to grab the ID from
-  `gh issue view 87 --comments`.
+  `gh issue list --label review-bot --limit 5`.
 - `3` → ID found but already shipped. The script's stderr already
   says `Finding <id> already shipped in #<PR>`; surface it and stop.
 
 **Sweep mode (no argument).** Run the parser without `--id` to get
-every finding from the most recent comment that contains markers:
+every finding from the newest tracker issue:
 
 ```bash
-node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
+node scripts/review-fix-parse.mjs .review-fix-cache/issues.json \
   > .review-fix-cache/parsed.json
 ```
 
-Sweep output: `{commentId, commentUrl, createdAt, findings: [Finding, …]}`.
-Exit 1 with `No comment on the tracker contains findings` if every
-comment is a no-op summary — surface that to the user and stop.
+Sweep output: `{issueNumber, issueUrl, createdAt, findings: [Finding, …]}`.
+Exit 1 with `No review-bot issue contains findings — nothing to sweep`
+if every issue body is empty or summary-only — surface that to the
+user and stop.
 
 For each entry in `parsed.json` `.findings[]`:
 
@@ -178,17 +184,24 @@ For each entry in `parsed.json` `.findings[]`:
 `{id, shipped, shippedPr, severity, path, title, body}`. Read those
 fields from `.review-fix-cache/finding.json` `.finding` (single mode)
 or from `.review-fix-cache/parsed.json` `.findings[i]` (sweep mode).
-Do not re-parse the comment body by hand — the regex lives in the
+Do not re-parse the issue body by hand — the regex lives in the
 script.
 
 The parser already hard-fails single mode on `shipped === true`
 (exit 3). In sweep mode, you must perform the equivalent skip
 yourself (step 1).
 
+Capture `issueNumber` from the same JSON — it is the tracker issue
+that holds this finding, and step 5 / 6 substitute it into the plan
+frontmatter and PR magic line. Sweep mode shares one
+`issueNumber` across every finding (they all come from the same
+newest issue); single mode's `issueNumber` is whichever issue the
+matching finding lives in.
+
 ### 3. Compute slug + paths
 
 The slug always ends with the finding's `<sha7>-<idx>` so two
-findings in the same tracker comment that happen to share a
+findings in the same tracker issue that happen to share a
 severity + first-4-title-words prefix get distinct paths. Without
 that suffix, sweep mode would create the worktree for finding A,
 then silently skip finding B as an "existing worktree" collision.
@@ -234,7 +247,7 @@ body. The `tracker` value MUST be quoted — `#` opens a YAML comment.
 date: YYYY-MM-DD
 slug: review-bot-<slug>
 finding-id: <sha7>.<idx>
-tracker: '#87'
+tracker: '#<issueNumber>'
 severity: <BLOCKER|MAJOR|MINOR|NIT>
 ---
 
@@ -242,7 +255,7 @@ severity: <BLOCKER|MAJOR|MINOR|NIT>
 
 ## Source
 
-From `#87` comment <comment-id>, finding `<id>`:
+From `#<issueNumber>` (<issueUrl>), finding `<id>`:
 
 > **[<SEVERITY>]** `<path>` — <title>
 >
@@ -259,8 +272,8 @@ From `#87` comment <comment-id>, finding `<id>`:
 
 - Branch: `fix/review-bot-<slug>` (already cut by review-fix skill).
 - PR base: `develop`.
-- PR body MUST contain on its own line: `Refs #87 finding:<id>`.
-- PR body MUST NOT contain `Closes #87` / `Fixes #87`.
+- PR body MUST contain on its own line: `Refs #<issueNumber> finding:<id>`.
+- PR body MUST NOT contain `Closes #<issueNumber>` / `Fixes #<issueNumber>`.
 - Changeset required if behavior changes (`npm run changeset`).
 ```
 
@@ -274,8 +287,8 @@ Use these exact headings — they're what the user scans for.
 
 ```text
 ✅ Done by /review-fix:
-  - Cached tracker comments to .review-fix-cache/comments.json
-  - Picked finding <id> from comment <comment-id> (<commentUrl>)
+  - Cached review-bot issues to .review-fix-cache/issues.json
+  - Picked finding <id> from #<issueNumber> (<issueUrl>)
   - Cut branch <branch> off origin/develop
   - Created worktree at <worktree-dir> (npm install complete)
   - Wrote plan at <plan-path>
@@ -287,20 +300,20 @@ Use these exact headings — they're what the user scans for.
   4. npm run verify                                    (pre-PR gate)
   5. gh pr create --base develop  --title "..."  --body "..."
        PR body MUST include this line on its own:
-         Refs #87 finding:<id>
+         Refs #<issueNumber> finding:<id>
   6. After PR merges: run the cleanup commands in §7 of the skill
      (or re-invoke /review-fix; the skill prints them again).
 
 ℹ️ What happens automatically:
   - The `review-fix-shipped` Action ticks the tracker line `[x]` and
     appends `(shipped in #<your-pr>)` once the PR merges. Do NOT
-    edit the tracker comment yourself.
+    edit the tracker issue body yourself.
 ```
 
 **Sweep mode.** One block listing every plan + every skip:
 
 ```text
-Sweep of #87 latest comment: <N> findings processed.
+Sweep of #<issueNumber>: <N> findings processed.
 
 ✅ Plans written:
   - <id-1>  →  <plan-path-1>  (branch <branch-1>, worktree <worktree-dir-1>)
@@ -352,12 +365,12 @@ git fetch --prune origin
 **Sweep cleanup.** If multiple PRs merged in a batch, repeat the
 block above per `<slug>`. The user can list candidate worktrees
 with `git worktree list` and cross-check against `gh pr list
---state merged --search "Refs #87 finding:" --limit 20`.
+--state merged --search "Refs # finding:" --limit 20`.
 
 **What the skill does NOT touch:**
 
-- The tracker comment on `#87`. The `review-fix-shipped` Action edits
-  it post-merge. Manual edits race the Action and corrupt the
+- The tracker issue body. The `review-fix-shipped` Action edits it
+  post-merge. Manual edits race the Action and corrupt the
   `(shipped in #N)` rendering.
 - The `.review-fix-cache/` directory. It's gitignored and cheap to
   rebuild on the next run; leaving it speeds up the next sweep.
@@ -366,10 +379,11 @@ with `git worktree list` and cross-check against `gh pr list
 
 - Do NOT open the PR. PR creation belongs to the implementation
   session, not the plan session.
-- Do NOT close the tracker issue. Do NOT add `Closes #87` / `Fixes #87`
-  anywhere.
-- Do NOT edit the tracker comment from the skill — only the
-  `review-fix-shipped` Action edits comments, and only post-merge.
+- Do NOT close any tracker issue. Do NOT add
+  `Closes #<issueNumber>` / `Fixes #<issueNumber>` anywhere.
+- Do NOT edit the tracker issue body from the skill — only the
+  `review-fix-shipped` Action edits issue bodies, and only
+  post-merge.
 - Do NOT batch findings into a single branch / PR. One finding = one
   branch = one PR. Sweep mode produces N branches + N plans, never a
   combined plan.

--- a/.claude/skills/review-fix/SKILL.md
+++ b/.claude/skills/review-fix/SKILL.md
@@ -111,12 +111,16 @@ The recipe below dodges four real footguns:
    sure the JSON shape is the issue list output (objects with
    `number`, `body`, `url`, `createdAt`), not the PR list.
 
-Fetch every open review-bot issue once into the project-local cache:
+Fetch every open review-bot issue once into the project-local cache.
+The `--limit 1000` is gh's effective cap; one issue per scheduled run
+makes this several years of headroom. If the repo ever gets close
+to this number it's a process signal (close stale tracker issues),
+not a parser one — there is no pagination fallback by design.
 
 ```bash
 mkdir -p .review-fix-cache
 gh issue list --label review-bot --state open \
-  --json number,body,url,createdAt --limit 50 \
+  --json number,body,url,createdAt --limit 1000 \
   > .review-fix-cache/issues.json
 ```
 

--- a/.github/workflows/review-fix-shipped.yml
+++ b/.github/workflows/review-fix-shipped.yml
@@ -2,10 +2,10 @@ name: review-fix-shipped
 
 on:
   # `pull_request_target` runs in the base-repo context with a write-
-  # capable GITHUB_TOKEN. We need that to PATCH the tracker comment on
-  # merges from fork PRs, where the standard `pull_request` event fires
-  # with a read-only token. This is safe because the workflow does NOT
-  # check out or execute any PR-supplied code — it only reads
+  # capable GITHUB_TOKEN. We need that to PATCH the tracker issue body
+  # on merges from fork PRs, where the standard `pull_request` event
+  # fires with a read-only token. This is safe because the workflow
+  # does NOT check out or execute any PR-supplied code — it only reads
   # `context.payload.pull_request.body` (already present in the event
   # payload) and calls the GitHub REST API.
   pull_request_target:
@@ -17,19 +17,20 @@ permissions:
 
 concurrency:
   # Global group across all PRs: every job in this workflow reads + rewrites
-  # the same tracker comment body. Keying by PR number would let two merged
-  # PRs run in parallel, both read a pre-flip body, and the later write
-  # would silently revert the earlier flip. cancel-in-progress: false
-  # preserves the earlier run; the later run queues until it finishes.
+  # a review-bot issue body. Keying by PR number would let two merged
+  # PRs targeting the same review-bot issue run in parallel, both read a
+  # pre-flip body, and the later write would silently revert the earlier
+  # flip. cancel-in-progress: false preserves the earlier run; the later
+  # run queues until it finishes.
   group: review-fix-shipped
   cancel-in-progress: false
 
 jobs:
   flip-tracker-checkbox:
-    # Only fire on PRs merged INTO develop. The tracker (#87
-    # "Daily code review — develop") is explicitly scoped to that
-    # branch. A hotfix-to-main or demo-promotion PR carrying a copied
-    # `Refs #87 finding:<id>` line would otherwise flip the tracker
+    # Only fire on PRs merged INTO develop. Each `review-bot`-labelled
+    # issue is scoped to that branch's review history. A hotfix-to-main
+    # or demo-promotion PR carrying a copied
+    # `Refs #<n> finding:<id>` line would otherwise flip a tracker
     # even though the fix never landed on develop, creating a false
     # shipped state.
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
@@ -54,9 +55,9 @@ jobs:
             // run fails at the end if any flip could not be persisted or
             // any non-404 API error masked a flip. Only "expected content
             // misses" stay soft:
-            //   - listComments 404 (target issue does not exist — PR-body
+            //   - issues.get 404 (target issue does not exist — PR-body
             //     content bug, not an automation problem),
-            //   - finding not present in the comment body,
+            //   - finding not present in the issue body,
             //   - line already shipped or shape unexpected.
             // Everything else (403/429/5xx/network on either read or write)
             // increments hardFailures and triggers core.setFailed at the end.
@@ -69,25 +70,16 @@ jobs:
               const marker = `<!-- f:${findingId} -->`;
 
               try {
-                core.info(`Looking for ${marker} in #${issueNumber} comments...`);
+                core.info(`Looking for ${marker} in #${issueNumber} body...`);
 
-                const iterator = github.paginate.iterator(
-                  github.rest.issues.listComments,
-                  {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issueNumber,
-                    per_page: 100,
-                  },
-                );
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                });
 
-                let hit = null;
-                for await (const { data: page } of iterator) {
-                  hit = page.find((c) => c.body && c.body.includes(marker));
-                  if (hit) break;
-                }
-
-                if (!hit) {
+                const issueBody = issue.body || '';
+                if (!issueBody.includes(marker)) {
                   core.warning(`Finding ${findingId} not found in #${issueNumber}. Skipping.`);
                   continue;
                 }
@@ -95,11 +87,11 @@ jobs:
                 // Locate the line containing the marker by string ops (no
                 // regex escaping needed). Markers are unique per finding ID,
                 // so a single substring search is sufficient.
-                const markerIdx = hit.body.indexOf(marker);
-                const lineStart = hit.body.lastIndexOf('\n', markerIdx) + 1;
-                const lineEndRaw = hit.body.indexOf('\n', markerIdx);
-                const lineEnd = lineEndRaw === -1 ? hit.body.length : lineEndRaw;
-                const line = hit.body.slice(lineStart, lineEnd);
+                const markerIdx = issueBody.indexOf(marker);
+                const lineStart = issueBody.lastIndexOf('\n', markerIdx) + 1;
+                const lineEndRaw = issueBody.indexOf('\n', markerIdx);
+                const lineEnd = lineEndRaw === -1 ? issueBody.length : lineEndRaw;
+                const line = issueBody.slice(lineStart, lineEnd);
 
                 if (line.startsWith('- [x] ')) {
                   core.warning(`Finding ${findingId} already shipped. Skipping.`);
@@ -113,16 +105,16 @@ jobs:
                 const newLine = line
                   .replace('- [ ] ', '- [x] ')
                   .replace(` ${marker}`, ` (shipped in #${prNumber}) ${marker}`);
-                const newBody = hit.body.slice(0, lineStart) + newLine + hit.body.slice(lineEnd);
+                const newBody = issueBody.slice(0, lineStart) + newLine + issueBody.slice(lineEnd);
 
                 // Inner try/catch: write failures (missing perms, rate
                 // limit, 5xx) MUST surface as a failed run; otherwise
                 // shipped-state silently drifts.
                 try {
-                  await github.rest.issues.updateComment({
+                  await github.rest.issues.update({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
-                    comment_id: hit.id,
+                    issue_number: issueNumber,
                     body: newBody,
                   });
                   core.info(`Flipped finding ${findingId} -> shipped in #${prNumber}.`);
@@ -131,7 +123,7 @@ jobs:
                   core.error(`Failed to write flip for ${findingId} in #${issueNumber}: ${writeErr.message}`);
                 }
               } catch (readErr) {
-                // 404 on listComments = "target issue does not exist" =
+                // 404 on issues.get = "target issue does not exist" =
                 // soft (PR-body content bug). Anything else (403, 429,
                 // 5xx, network) is a transient/permissions failure that
                 // would silently drop a valid flip — fail loudly.
@@ -139,11 +131,11 @@ jobs:
                   core.warning(`Issue #${issueNumber} not found (finding ${findingId}). Skipping.`);
                 } else {
                   hardFailures++;
-                  core.error(`Failed to read comments for #${issueNumber} (finding ${findingId}): ${readErr.message} (status ${readErr.status ?? 'n/a'})`);
+                  core.error(`Failed to read #${issueNumber} (finding ${findingId}): ${readErr.message} (status ${readErr.status ?? 'n/a'})`);
                 }
               }
             }
 
             if (hardFailures > 0) {
-              core.setFailed(`${hardFailures} flip(s) failed (read or write); tracker comment is out of sync. Review run logs and re-run after fixing the underlying issue.`);
+              core.setFailed(`${hardFailures} flip(s) failed (read or write); tracker issue is out of sync. Review run logs and re-run after fixing the underlying issue.`);
             }

--- a/docs/plans/2026-04-26-quality-actions-bump-bot.md
+++ b/docs/plans/2026-04-26-quality-actions-bump-bot.md
@@ -50,10 +50,11 @@ Key sections:
    never alter the trailing `# vX.Y.Z` comment without matching the
    bumped tag.
 5. **Output** — single PR per run, body lists each `(action, old SHA,
-   new SHA, version label)`. No-op runs: post a one-line comment on
-   the tracker issue `Action SHA bumps — develop` and exit.
-6. **Failure handling** — verify fails → close branch, comment on
-   tracker.
+   new SHA, version label)`. No-op runs: open a fresh tracker issue
+   `Action SHA bumps YYYY-MM-DD — <sha7>` (label
+   `actions-bump-bot`) noting the no-op, then exit.
+6. **Failure handling** — verify fails → close branch, open a
+   tracker issue noting the failure.
 
 - [ ] **Step 3: Write `docs/actions-bump-bot/README.md`**
 

--- a/docs/plans/2026-04-26-quality-dep-triage-bot.md
+++ b/docs/plans/2026-04-26-quality-dep-triage-bot.md
@@ -27,10 +27,11 @@ cat docs/docs-review-bot/README.md
 cat .github/dependabot.yml
 ```
 
-The dep-triage routine MUST mirror the existing review-bot /
-docs-review-bot prose conventions: rolling tracker issue, append
-comments per run, idempotency via "last triaged SHA", never push
-direct to develop.
+The dep-triage routine MUST mirror the existing review-bot prose
+conventions: one tracker issue per scheduled run (label
+`dep-triage-bot`), findings/summary in the issue body, idempotency
+via "last triaged SHA" persisted to a committed daily doc, never
+push direct to develop.
 
 - [ ] **Step 2: Update `.github/dependabot.yml`**
 
@@ -72,19 +73,23 @@ Sections to include (mirror `docs/review-bot/PROMPT.md`):
 4. **Hard rules** — never merge a PR that touches `src/**` (means
    Dependabot generated more than a manifest bump, suspicious);
    never bypass `--no-verify`; never amend the Dependabot commit.
-5. **Output** — append a one-comment summary on a rolling tracker
-   issue `Dependency triage — develop` (label `dep-triage-bot`).
+5. **Output** — open one tracker issue per run titled
+   `Dependency triage YYYY-MM-DD — <head-sha[:7]>` (label
+   `dep-triage-bot`); the body holds that run's summary.
 6. **Failure handling** — verify fails → comment "verify failed:
-   \<err tail\>" on the Dependabot PR + tracker, do NOT merge.
+   \<err tail\>" on the Dependabot PR + create the tracker issue
+   noting the failure, do NOT merge.
 
 Use the same idempotency pattern as `docs/review-bot/PROMPT.md`
-(rolling issue, append comments, never push direct to develop).
+(one issue per run, body holds findings, last-triaged SHA lives in
+the committed daily doc, never push direct to develop).
 
 - [ ] **Step 4: Write `docs/dep-triage-bot/README.md`**
 
 Mirror `docs/review-bot/README.md`: how the routine consumes the
-prompt, where output lives (the rolling tracker issue), how to evolve
-the prompt (edit on a topic branch, open a PR, next run picks it up).
+prompt, where output lives (a fresh tracker issue per run), how to
+evolve the prompt (edit on a topic branch, open a PR, next run
+picks it up).
 
 - [ ] **Step 5: Verify**
 

--- a/docs/plans/2026-04-26-quality-plan-recon-bot.md
+++ b/docs/plans/2026-04-26-quality-plan-recon-bot.md
@@ -61,10 +61,12 @@ Sections:
    or whose tracker issue is still labelled `in-progress`.
 4. **Output** — open one PR per run with archive moves, body lists
    each `(plan, last shipped row, archive reason)`. No moves needed:
-   post a one-line comment on the tracker issue `Plan reconciliation`
-   (label `plan-recon-bot`) and exit.
-5. **Failure handling** — same pattern as the other routines (rolling
-   issue, never push direct to `develop`, comment on failure).
+   open a fresh tracker issue
+   `Plan reconciliation YYYY-MM-DD — <sha7>` (label
+   `plan-recon-bot`) noting the no-op, then exit.
+5. **Failure handling** — same pattern as the other routines (one
+   issue per run, never push direct to `develop`, body notes the
+   failure).
 
 - [ ] **Step 3: Write `docs/plan-recon-bot/README.md`**
 

--- a/docs/review-bot/PROMPT.md
+++ b/docs/review-bot/PROMPT.md
@@ -20,8 +20,8 @@ Review commits on `develop` since the last reviewed SHA (or the last 24h
 if this is the first run).
 
 If no new commits: output `No new commits since <SHA>. Skipping.` and
-exit cleanly without writing a doc or opening a PR — only post a one-line
-no-op comment to the rolling issue.
+exit cleanly without writing a doc, opening a PR, or creating an issue.
+Quiet days leave no trace.
 
 Diff commands:
 
@@ -146,11 +146,16 @@ End the comment with the run footer:
 
 # Persistence (dual sink)
 
-## Sink 1: GitHub issue (rolling log)
+## Sink 1: GitHub issue (one per run)
 
-- Find or create the issue titled `Daily code review — develop` (label:
-  `review-bot`).
-- Append today's findings as a new comment, format:
+Each scheduled run opens its **own** issue. There is no rolling log
+and no append-to-existing-comment step. One issue = one review = one
+body containing every finding for that range.
+
+- Title: `Code review YYYY-MM-DD — <head-sha[:7]>`
+- Labels: `review-bot`
+- Body: same content the daily doc carries (header line, severity
+  counts, checklist of findings, run footer). Format:
 
   ```
   ## YYYY-MM-DD — <head-sha>
@@ -162,10 +167,10 @@ End the comment with the run footer:
   <run footer>
   ```
 
-- If no new commits: append a one-line comment
-  `YYYY-MM-DD — no-op (head still <sha>)`.
-- Update the issue body's `Last reviewed SHA: <head-sha>` line. This is
-  canonical state — read it at the start of the next run.
+- The `review-fix-shipped` Action edits this body in place when each
+  finding's PR merges (`- [ ]` → `- [x]` plus a `(shipped in #N)`
+  suffix). Do NOT post a new comment to record shipped state.
+- If no new commits: do NOT open an issue. Quiet days leave no trace.
 
 ## Sink 2: Daily review doc (committed)
 
@@ -181,43 +186,53 @@ End the comment with the run footer:
   majors: <N>
   minors: <N>
   nits: <N>
+  issue: <issue-number>
   ---
   ```
 
-- Body: full findings block (same content as the issue comment —
-  checklist of findings + run footer).
-- The daily doc is an immutable snapshot of that run; the
-  `review-fix-shipped` Action edits the rolling issue comment only,
-  never the daily doc.
+  The `range` end SHA is the canonical "Last reviewed SHA" the next
+  run reads to resume. The `issue` field cross-links the run's
+  GitHub issue — `review-fix` uses it as a fast lookup, but the
+  authoritative state lives in the file.
+- Body: full findings block (same checklist + run footer the issue
+  body carries).
+- The daily doc is an immutable snapshot; only the issue body is
+  edited post-merge by the `review-fix-shipped` Action.
 - If no new commits: skip file creation. Do NOT commit an empty doc.
 
 ## Commit + PR flow (NEVER push direct to develop)
 
 1. `git fetch origin && git switch -c chore/daily-review-YYYY-MM-DD origin/develop`
-2. Write `docs/daily-reviews/YYYY-MM-DD.md`.
-3. `git add docs/daily-reviews/YYYY-MM-DD.md`
-4. `git commit -m "docs(reviews): daily review YYYY-MM-DD"`
+2. `gh issue create --title "Code review YYYY-MM-DD — <sha7>" --label review-bot --body "<full findings block>"` → capture the new issue number.
+3. Write `docs/daily-reviews/YYYY-MM-DD.md` (include `issue: <n>` in frontmatter).
+4. `git add docs/daily-reviews/YYYY-MM-DD.md`
+5. `git commit -m "docs(reviews): daily review YYYY-MM-DD"`
    (no `--no-verify`, no `Co-Authored-By` unless the owner sets one).
-5. `git push -u origin chore/daily-review-YYYY-MM-DD`
-6. `gh pr create --base develop --title "docs(reviews): daily review YYYY-MM-DD" --body "Automated daily review. See <issue-link>#issuecomment-<id> for findings. Doc-only change, skip changeset."`
-7. If repo has auto-merge enabled, run `gh pr merge --auto --squash` on
+6. `git push -u origin chore/daily-review-YYYY-MM-DD`
+7. `gh pr create --base develop --title "docs(reviews): daily review YYYY-MM-DD" --body "Automated daily review. Findings tracked in #<issue-number>. Doc-only change, skip changeset."`
+8. If repo has auto-merge enabled, run `gh pr merge --auto --squash` on
    the PR. Otherwise leave it for the owner to merge.
 
 ## Idempotency
 
-- Read `Last reviewed SHA` from the issue body at the start. If unset,
-  fall back to `git log --since="24 hours ago" origin/develop`.
-- If `docs/daily-reviews/YYYY-MM-DD.md` already exists on `develop`,
-  today's run already happened — append the delta as a new comment to
-  the issue, but do NOT open a second PR for the same date. Either
-  reuse the existing branch with a follow-up commit or skip the doc
-  write.
+- Resolve `Last reviewed SHA` at start: read the most recent file
+  matching `docs/daily-reviews/*.md` on `origin/develop`, parse the
+  `range:` line in its frontmatter, take the SHA after `..`. If no
+  such doc exists, fall back to
+  `git log --since="24 hours ago" origin/develop`.
+- If `docs/daily-reviews/YYYY-MM-DD.md` already exists on `origin/develop`,
+  today's run already happened — exit cleanly without opening a
+  second issue or PR. The previous run's issue stays the
+  authoritative tracker for that date.
 
 ## Failure handling
 
-- `gh pr create` fails (e.g. no diff) → still post the issue comment
-  with findings; skip the PR.
-- `git push` fails (perm, network) → retry once, then post an issue
-  comment noting `doc commit failed: <err>`, continue.
-- Findings empty + no commits → single issue comment "no-op"; no
-  branch, no PR.
+- `gh issue create` fails → abort the run. Without an issue, the
+  `review-fix` skill cannot ingest findings; better to bail than
+  ship a daily doc whose `issue:` field points nowhere.
+- `gh pr create` fails (e.g. no diff) → keep the issue, log the
+  error, exit non-zero.
+- `git push` fails (perm, network) → retry once, then comment on the
+  freshly-created issue noting `doc commit failed: <err>` and exit
+  non-zero so the cron flags the run.
+- Findings empty + no commits → no issue, no branch, no PR.

--- a/docs/review-bot/README.md
+++ b/docs/review-bot/README.md
@@ -12,14 +12,18 @@ per weekday and persists findings to two sinks.
 
 ## Output sinks
 
-1. **Rolling GitHub issue** — title `Daily code review — develop`,
-   label `review-bot`. New comment per run. Issue body holds the
-   canonical `Last reviewed SHA` so the next run knows where to
-   resume.
+1. **GitHub issue per run** — title
+   `Code review YYYY-MM-DD — <head-sha[:7]>`, label `review-bot`.
+   Each scheduled run opens a fresh issue whose **body** holds the
+   full findings block. There is no rolling tracker and no
+   append-to-comments step; the `review-fix-shipped` Action edits
+   the body in place when individual findings ship.
 2. **Committed daily docs** — `docs/daily-reviews/YYYY-MM-DD.md`
-   (one file per UTC day, frontmatter + findings body). Reaches
-   `develop` via an automated PR `chore/daily-review-YYYY-MM-DD`,
-   never a direct push.
+   (one file per UTC day, frontmatter + findings body, plus an
+   `issue: <n>` cross-link). Reaches `develop` via an automated PR
+   `chore/daily-review-YYYY-MM-DD`, never a direct push. The doc's
+   `range:` end SHA is the canonical "Last reviewed SHA" the next
+   run reads to resume.
 
 ## Ingesting findings via `review-fix`
 
@@ -35,43 +39,50 @@ line. `head-sha[:7]` is the seven-char prefix of the head SHA
 reviewed in that run; `idx` is the 1-based position of the finding
 within the run.
 
-IDs do not deduplicate across reruns: tomorrow's run on a new SHA
+IDs do not deduplicate across runs: tomorrow's run on a new SHA
 emits a fresh set of IDs even for findings that were already
-unshipped. The unshipped checkbox on the prior comment still flips
-when the eventual PR ships.
+unshipped, and they live on a different issue. The unshipped
+checkbox on the prior issue still flips when the eventual PR ships.
 
 ### Workflow
 
 ```text
-gh issue view 87 --comments       # find a finding ID
-/review-fix pick <id>             # creates worktree + plan
-/superpowers:writing-plans <plan> # expand plan into chunked tasks
-/superpowers:executing-plans …    # implement, verify, open PR
+gh issue list --label review-bot --limit 5     # find the latest issue
+gh issue view <n>                              # read the body, pick a finding ID
+/review-fix pick <id>                          # creates worktree + plan
+/superpowers:writing-plans <plan>              # expand plan into chunked tasks
+/superpowers:executing-plans …                 # implement, verify, open PR
 ```
 
 The PR body MUST contain, on its own line:
 
 ```
-Refs #87 finding:<sha7>.<idx>
+Refs #<issue-number> finding:<sha7>.<idx>
 ```
 
-Trailing whitespace is tolerated; trailing punctuation breaks the
-match. The PR body MUST NOT contain `Closes #87` / `Fixes #87` —
-the tracker is long-lived and stays open.
+`<issue-number>` is the review-bot issue that holds the matching
+finding (the `review-fix` skill writes it into the plan
+frontmatter). Trailing whitespace is tolerated; trailing
+punctuation breaks the match. The PR body MUST NOT contain
+`Closes #<n>` / `Fixes #<n>` for the review-bot issue — those
+issues are long-lived archives of each run, even after every
+finding ships.
 
 ### Auto-flip on merge
 
 `.github/workflows/review-fix-shipped.yml` triggers on
-`pull_request: closed && merged`, regexes the PR body for the magic
-line, locates the matching tracker comment, and edits the body so
-the checklist item becomes:
+`pull_request: closed && merged`, regexes the PR body for every
+`Refs #<n> finding:<sha7>.<idx>` line, fetches each referenced
+issue's body, and edits the matching checklist item in place:
 
 ```markdown
 - [x] **[BLOCKER]** `path/to/file.ts:42` — short title (shipped in #N) <!-- f:<sha7>.<idx> -->
 ```
 
 The Action does not block merges; it observes them. If the magic
-line is missing, it logs and exits 0.
+line is missing or the referenced issue does not exist, it logs and
+exits 0. Read failures (403/429/5xx) fail the run loudly so a
+silently-dropped flip never goes unnoticed.
 
 ## CI behavior on the daily PR
 
@@ -105,11 +116,16 @@ invariants, or output-format pain. To change it:
 
 ## Initial setup checklist (one-time)
 
-- [ ] Create the rolling issue `Daily code review — develop`. Add label
-      `review-bot`. Seed the body with `Last reviewed SHA: <none>` so
-      the first run falls back to `--since="24 hours ago"`.
-- [ ] Add a PR label `review-bot` (cosmetic — lets you filter the
-      automated PRs out of the human review queue).
+- [ ] Create the `review-bot` label (issue + PR scope). Issue scope
+      lets the bot tag every per-run issue and lets `review-fix`
+      query them with `gh issue list --label review-bot`. PR scope
+      is cosmetic — filters automated review-fix PRs out of the
+      human queue.
+- [ ] Confirm the first run will fall back to
+      `git log --since="24 hours ago"` because no
+      `docs/daily-reviews/*.md` exists yet on `develop`. After the
+      first run lands, the doc's `range:` end SHA becomes the
+      resume point automatically.
 - [ ] Enable auto-merge on the repo (`Settings → General → Pull
       Requests → Allow auto-merge`). The routine sets
       `gh pr merge --auto --squash`.
@@ -137,10 +153,11 @@ just noisy in the rolling issue.
 
 ## Known tradeoffs
 
-- **Rolling issue grows forever.** Rotate quarterly: close the current
-  issue, open `Daily code review — develop (QN YYYY)`. Add a step to the
-  routine that opens a new issue once the active one passes 500
-  comments.
+- **Issue list grows over time.** Each run opens an issue; close
+  them once every finding is shipped (or auto-close via a
+  separate routine if you want zero backlog). Active +
+  partially-shipped issues stay open and remain reachable to
+  `review-fix`.
 - **Doc PR still costs CI minutes** for `format-check`, `actionlint`,
   `audit`, and `ci-gate`. Acceptable — combined under a minute.
 - **Auto-merge requires green CI on `develop`'s protection rules.** If

--- a/docs/review-bot/README.md
+++ b/docs/review-bot/README.md
@@ -47,11 +47,11 @@ checkbox on the prior issue still flips when the eventual PR ships.
 ### Workflow
 
 ```text
-gh issue list --label review-bot --limit 5     # find the latest issue
-gh issue view <n>                              # read the body, pick a finding ID
-/review-fix pick <id>                          # creates worktree + plan
-/superpowers:writing-plans <plan>              # expand plan into chunked tasks
-/superpowers:executing-plans …                 # implement, verify, open PR
+gh issue list --label review-bot --state open --limit 5  # find the latest issue
+gh issue view <n>                                        # read the body, pick a finding ID
+/review-fix pick <id>                                    # creates worktree + plan
+/superpowers:writing-plans <plan>                        # expand plan into chunked tasks
+/superpowers:executing-plans …                           # implement, verify, open PR
 ```
 
 The PR body MUST contain, on its own line:
@@ -153,11 +153,11 @@ just noisy in the rolling issue.
 
 ## Known tradeoffs
 
-- **Issue list grows over time.** Each run opens an issue; close
-  them once every finding is shipped (or auto-close via a
-  separate routine if you want zero backlog). Active +
-  partially-shipped issues stay open and remain reachable to
-  `review-fix`.
+- **Issue list grows over time.** Each run opens an issue. Close
+  each issue once every finding it carries has shipped — closed
+  issues drop out of `review-fix`'s scope automatically. The
+  `review-fix-shipped` Action does not auto-close; do it manually
+  or wire a separate routine when the backlog warrants one.
 - **Doc PR still costs CI minutes** for `format-check`, `actionlint`,
   `audit`, and `ci-gate`. Acceptable — combined under a minute.
 - **Auto-merge requires green CI on `develop`'s protection rules.** If

--- a/scripts/review-fix-parse.mjs
+++ b/scripts/review-fix-parse.mjs
@@ -1,53 +1,55 @@
 #!/usr/bin/env node
 /**
- * review-fix tracker comment parser.
+ * review-fix tracker parser.
  *
- * Reads the raw `gh api ... --paginate --slurp` output for issue #87
- * comments and emits a structured JSON description of either:
- *   - the most recent comment that contains finding markers (sweep
+ * Reads a JSON list of `review-bot`-labelled issues (one issue per
+ * scheduled bot run, findings live in the issue body) and emits a
+ * structured description of either:
+ *   - the most recent issue that contains finding markers (sweep
  *     mode, default), or
- *   - the comment that contains a specific finding ID (single mode,
- *     `--id <sha7>.<idx>`), searching the full comment history so
- *     backlog findings on older comments stay reachable.
+ *   - the issue whose body holds a specific finding ID (single mode,
+ *     `--id <sha7>.<idx>`), scanning every issue in the input so
+ *     backlog findings on older issues stay reachable.
+ *
+ * Input shape — array of GitHub issue objects:
+ *   [
+ *     { "number": 142, "body": "...", "url": "...", "createdAt": "ISO8601" },
+ *     { "number":  87, "body": "...", "url": "...", "createdAt": "ISO8601" },
+ *     ...
+ *   ]
+ *
+ * The caller fetches this via:
+ *   gh issue list --label review-bot --state all \
+ *     --json number,body,url,createdAt --limit 50 \
+ *     > .review-fix-cache/issues.json
+ *
+ * A single-issue object (no array wrapper) is also accepted for
+ * convenience — it is wrapped into a one-element list before parsing.
  *
  * Used by the `review-fix` skill to sidestep platform-specific shell
  * pitfalls:
  *   - Windows Git Bash maps `/tmp` to `D:\tmp` for native binaries,
  *     breaking Node `fs.readFileSync('/tmp/...')`.
- *   - `gh --paginate --slurp` rejects `--jq` / `--template` flags.
  *   - `jq` is not installed by default on Windows or many CI images.
  *
  * Node is a hard project requirement (TypeScript library, ESM, Node 22
  * per `.nvmrc`), so this script is the canonical parser the skill
  * shells out to.
  *
- * Usage:
- *   gh api "repos/<owner>/<repo>/issues/87/comments" --paginate --slurp \
- *     > .review-fix-cache/comments.json
- *
- *   # Sweep mode — newest comment with markers
- *   node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
- *     > .review-fix-cache/parsed.json
- *
- *   # Single mode — specific finding ID, any comment in history
- *   node scripts/review-fix-parse.mjs .review-fix-cache/comments.json \
- *     --id 682b557.3 \
- *     > .review-fix-cache/finding.json
- *
  * Sweep-mode output:
  *   {
- *     "commentId":  <number>,
- *     "commentUrl": <string>,
- *     "createdAt":  <iso8601>,
- *     "findings":   [Finding, ...]
+ *     "issueNumber": <number>,
+ *     "issueUrl":    <string>,
+ *     "createdAt":   <iso8601>,
+ *     "findings":    [Finding, ...]
  *   }
  *
  * Single-mode output:
  *   {
- *     "commentId":  <number>,
- *     "commentUrl": <string>,
- *     "createdAt":  <iso8601>,
- *     "finding":    Finding
+ *     "issueNumber": <number>,
+ *     "issueUrl":    <string>,
+ *     "createdAt":   <iso8601>,
+ *     "finding":     Finding
  *   }
  *
  * Finding shape:
@@ -63,7 +65,7 @@
  *
  * Exit codes:
  *   0  success
- *   1  no comment / no finding matched
+ *   1  no issue / no finding matched
  *   2  bad CLI arguments
  *   3  finding matched but already shipped (single mode only)
  */
@@ -82,7 +84,7 @@ for (let i = 1; i < args.length; i += 1) {
 }
 
 if (!inputPath) {
-  stderr.write('usage: review-fix-parse.mjs <comments.json> [--id <sha7>.<idx>]\n');
+  stderr.write('usage: review-fix-parse.mjs <issues.json> [--id <sha7>.<idx>]\n');
   exit(2);
 }
 if (targetId !== null && !/^[A-Za-z0-9]+\.[0-9]+$/.test(targetId)) {
@@ -91,48 +93,39 @@ if (targetId !== null && !/^[A-Za-z0-9]+\.[0-9]+$/.test(targetId)) {
 }
 
 const raw = JSON.parse(readFileSync(inputPath, 'utf8'));
-// `gh --paginate --slurp` returns an array of pages (one entry per
-// page), not a flat list of comments. Flatten one level so callers
-// can stay agnostic.
-const comments = (Array.isArray(raw) ? raw : [raw]).flat();
+// Accept either an array of issues or a single issue object.
+const issues = Array.isArray(raw) ? raw : [raw];
 
-// Filter by parsed checklist findings, NOT by raw `<!-- f:` substring.
-// A no-op summary comment may quote a previous finding's marker inside
-// its body or in a `<details>` block; if we keyed the sweep on
-// `body.includes('<!-- f:')` and the newest match happened to be such
-// a quote-only comment, sweep would emit an empty `findings: []` and
-// silently skip every older comment with real, actionable findings.
-// Pre-parsing here also lets us reuse the result downstream.
-const withFindings = comments
-  .filter((c) => typeof c.body === 'string')
-  .map((c) => ({ comment: c, findings: parseFindings(c.body) }))
-  .filter((c) => c.findings.length > 0)
-  .sort((a, b) => new Date(a.comment.created_at) - new Date(b.comment.created_at));
+// Pre-parse every issue body. Sort newest-first so sweep picks the
+// freshest tracker without another pass.
+const withFindings = issues
+  .filter((iss) => typeof iss.body === 'string')
+  .map((iss) => ({ issue: iss, findings: parseFindings(iss.body) }))
+  .filter((entry) => entry.findings.length > 0)
+  .sort((a, b) => new Date(b.issue.createdAt) - new Date(a.issue.createdAt));
 
 if (withFindings.length === 0) {
-  stderr.write('No comment on the tracker contains findings — nothing to sweep\n');
+  stderr.write('No review-bot issue contains findings — nothing to sweep\n');
   exit(1);
 }
 
 if (targetId === null) {
-  // Sweep: emit every finding from the newest comment that has any.
-  const newest = withFindings[withFindings.length - 1];
+  // Sweep: every finding from the newest issue that has any.
+  const newest = withFindings[0];
   emit({
-    commentId: newest.comment.id,
-    commentUrl: newest.comment.html_url,
-    createdAt: newest.comment.created_at,
+    issueNumber: newest.issue.number,
+    issueUrl: newest.issue.url,
+    createdAt: newest.issue.createdAt,
     findings: newest.findings,
   });
   exit(0);
 }
 
-// Single: scan the full history (newest first) for the target ID so a
-// backlog finding on an older comment stays reachable. The first
-// match wins; duplicate IDs across comments would only happen if the
-// review bot re-emitted an old finding, in which case the freshest
-// occurrence is what the user wants.
-for (let i = withFindings.length - 1; i >= 0; i -= 1) {
-  const { comment, findings } = withFindings[i];
+// Single: scan newest-first across every issue. The first match wins;
+// duplicate IDs across issues would only happen if the bot re-emitted
+// an old finding, in which case the freshest occurrence is what the
+// user wants.
+for (const { issue, findings } of withFindings) {
   const match = findings.find((f) => f.id === targetId);
   if (!match) continue;
   if (match.shipped) {
@@ -140,15 +133,15 @@ for (let i = withFindings.length - 1; i >= 0; i -= 1) {
     exit(3);
   }
   emit({
-    commentId: comment.id,
-    commentUrl: comment.html_url,
-    createdAt: comment.created_at,
+    issueNumber: issue.number,
+    issueUrl: issue.url,
+    createdAt: issue.createdAt,
     finding: match,
   });
   exit(0);
 }
 
-stderr.write(`Finding ${targetId} not found in any tracker comment\n`);
+stderr.write(`Finding ${targetId} not found in any review-bot issue\n`);
 exit(1);
 
 function emit(obj) {
@@ -156,7 +149,7 @@ function emit(obj) {
 }
 
 /**
- * Parses one comment body into individual finding entries.
+ * Parses one issue body into individual finding entries.
  *
  * A finding header is a top-level checklist line (no leading
  * whitespace) shaped like:
@@ -172,7 +165,7 @@ function emit(obj) {
  * Quoted finding-marker text inside a `<details>` body is ignored —
  * only top-level checklist lines mark finding boundaries. The body
  * for each finding is every line between its header and the next
- * header (or end-of-comment), with leading/trailing blank lines
+ * header (or end-of-issue), with leading/trailing blank lines
  * trimmed.
  */
 function parseFindings(body) {
@@ -190,10 +183,10 @@ function parseFindings(body) {
   return headers.map((h, idx) => {
     const nextIndex = headers[idx + 1]?.index ?? lines.length;
     const slice = lines.slice(h.index + 1, nextIndex);
-    // The last header's slice runs through the comment's trailing
+    // The last header's slice runs through the issue's trailing
     // summary (counter-arguments, "Reviewed range", footer). Cut at
     // the first standalone `---` so a finding body never absorbs
-    // metadata that belongs to the comment as a whole.
+    // metadata that belongs to the issue as a whole.
     const ruleAt = slice.findIndex((line) => /^---\s*$/.test(line));
     const bodyLines = ruleAt >= 0 ? slice.slice(0, ruleAt) : slice;
     while (bodyLines.length > 0 && bodyLines[0].trim() === '') {

--- a/scripts/review-fix-parse.mjs
+++ b/scripts/review-fix-parse.mjs
@@ -20,7 +20,7 @@
  *
  * The caller fetches this via:
  *   gh issue list --label review-bot --state open \
- *     --json number,body,url,createdAt --limit 50 \
+ *     --json number,body,url,createdAt --limit 1000 \
  *     > .review-fix-cache/issues.json
  *
  * A single-issue object (no array wrapper) is also accepted for

--- a/scripts/review-fix-parse.mjs
+++ b/scripts/review-fix-parse.mjs
@@ -8,8 +8,8 @@
  *   - the most recent issue that contains finding markers (sweep
  *     mode, default), or
  *   - the issue whose body holds a specific finding ID (single mode,
- *     `--id <sha7>.<idx>`), scanning every issue in the input so
- *     backlog findings on older issues stay reachable.
+ *     `--id <sha7>.<idx>`), scanning every issue in the input
+ *     newest-first.
  *
  * Input shape — array of GitHub issue objects:
  *   [
@@ -19,7 +19,7 @@
  *   ]
  *
  * The caller fetches this via:
- *   gh issue list --label review-bot --state all \
+ *   gh issue list --label review-bot --state open \
  *     --json number,body,url,createdAt --limit 50 \
  *     > .review-fix-cache/issues.json
  *
@@ -105,7 +105,7 @@ const withFindings = issues
   .sort((a, b) => new Date(b.issue.createdAt) - new Date(a.issue.createdAt));
 
 if (withFindings.length === 0) {
-  stderr.write('No review-bot issue contains findings — nothing to sweep\n');
+  stderr.write('No open review-bot issue contains findings — nothing to sweep\n');
   exit(1);
 }
 
@@ -141,7 +141,7 @@ for (const { issue, findings } of withFindings) {
   exit(0);
 }
 
-stderr.write(`Finding ${targetId} not found in any review-bot issue\n`);
+stderr.write(`Finding ${targetId} not found in any open review-bot issue\n`);
 exit(1);
 
 function emit(obj) {


### PR DESCRIPTION
## Summary

- Scheduled code-review routine now opens **one fresh GitHub issue per run** (`Code review YYYY-MM-DD — <sha7>`, label `review-bot`) instead of appending a comment to a single rolling tracker. Each issue's **body** holds that run's full findings block; the existing `review-fix-shipped` Action edits the body in place when individual finding PRs merge.
- `Last reviewed SHA` state moves out of the issue body and onto the committed daily-review doc — the latest `docs/daily-reviews/*.md` frontmatter `range:` end SHA is the canonical resume point. Daily docs gain an `issue: <n>` cross-link.
- `review-fix` skill drops every hardcoded `#87` reference. Sweep mode targets the newest `review-bot`-labelled issue; single-finding mode scans the full issue history (open + closed) so backlog findings stay reachable. Plan frontmatter + PR magic line take the issue number captured per finding.
- Parse script (`scripts/review-fix-parse.mjs`) input shape switches from `gh api .../issues/87/comments` (paginated comments array) to `gh issue list --json number,body,url,createdAt` (issues array). Output keys rename `commentId/commentUrl` → `issueNumber/issueUrl`.
- Workflow (`.github/workflows/review-fix-shipped.yml`) switches from `listComments` + `updateComment` to `issues.get` + `issues.update`. Concurrency guard + hard-failure semantics preserved. Per-PR regex `Refs #(\d+) finding:...` already supported arbitrary issue numbers — only the surrounding read/write calls changed.

## Test plan

- [x] `npm run verify` green on this branch (format:check, lint, typecheck, 523 tests, build, docs).
- [ ] Codex review acknowledged or rebutted on each thread.
- [ ] After merge: existing `#87` is left open as historical archive; the next scheduled run will create the first per-run issue under the new design. No data migration required — old findings on `#87` remain reachable to `review-fix --id` because the parser scans every `review-bot`-labelled issue.

## Notes for review

- No library behavior changes → no changeset (per `CLAUDE.md`).
- Existing daily-review docs (`docs/daily-reviews/2026-04-25.md`, `2026-04-26.md`) lack the new `issue:` frontmatter field. The first run under the new prompt will write a doc with the field; older docs are untouched. Resume logic only reads `range:`, which is already present everywhere.