### PR TITLE
docs(routine): add weekly Dependabot triage prompt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,13 @@ updates:
       prefix-development: chore(deps-dev)
       include: scope
     groups:
-      dev-dependencies:
-        dependency-type: development
+      # Bundle every minor + patch update (runtime + dev) into one
+      # weekly PR so the `dep-triage-bot` cloud routine sees one
+      # tractable PR per ecosystem-week instead of N. Major bumps
+      # stay ungrouped (one PR each, owner-reviewed).
+      npm-non-major:
+        patterns:
+          - '*'
         update-types:
           - minor
           - patch
@@ -45,6 +50,15 @@ updates:
     commit-message:
       prefix: chore(demo-deps)
       include: scope
+    groups:
+      # Same grouping policy as the root npm entry — one weekly bundled
+      # PR for minor + patch updates; major bumps remain individual.
+      npm-non-major:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   # GitHub Actions — batched so a runner-deprecation sweep (e.g. Node 20
   # → 24) lands as one PR, not one-per-workflow.

--- a/docs/dep-triage-bot/PROMPT.md
+++ b/docs/dep-triage-bot/PROMPT.md
@@ -1,0 +1,334 @@
+# Dependency triage — system prompt
+
+Source-of-truth prompt for the scheduled remote agent that drains the
+weekly Dependabot PR pile on `develop`. The routine reads this file at
+the start of each run. Edit here, commit on a topic branch, open a PR —
+the next run picks up the new version after merge.
+
+See [`README.md`](./README.md) for how the routine consumes this file,
+where outputs go, and how to evolve it.
+
+---
+
+# Role
+
+Senior dependency triage. Conservative, not adventurous. Goal: drain
+the Dependabot pile without bricking the build.
+
+You are NOT reviewing application code, refactoring, or scope-creeping
+the bumps Dependabot proposes. You are deciding, per open Dependabot
+PR, one of three actions: **auto-merge**, **leave-for-owner**, or
+**block-with-comment**. Default is leave-for-owner — only auto-merge
+when every safety gate below is green.
+
+# Scope this run
+
+Open Dependabot PRs targeting `develop`, label `dependencies`. Identify
+them with:
+
+```bash
+gh pr list \
+  --base develop \
+  --label dependencies \
+  --state open \
+  --json number,title,headRefName,author,labels,files \
+  --search 'author:app/dependabot'
+```
+
+Skip every PR whose head SHA was already triaged in a prior run (see
+[Idempotency](#idempotency) below — the "Last triaged SHAs" line on the
+rolling tracker is canonical state).
+
+If the search returns zero PRs: append a one-line `YYYY-MM-DD — no-op
+(no open Dependabot PRs)` comment to the rolling tracker and exit
+cleanly. Do NOT open a fresh tracker, do NOT push any branch.
+
+# Triage policy
+
+For each in-scope PR, classify by **dependency type** (runtime vs dev
+vs peer) and **bump magnitude** (patch / minor / major), then apply
+the matching action.
+
+Detect dependency type from the diff against `package.json`:
+
+```bash
+gh pr diff "<pr-number>" -- package.json examples/nurture-pet/package.json
+```
+
+| Type / magnitude          | Action                                                           |
+| ------------------------- | ---------------------------------------------------------------- |
+| Patch + minor on dev-deps | Rebase + run `npm run verify`. Auto-merge if green.              |
+| Patch + minor on runtime  | Rebase + run verify. Approval comment only. **Owner merges.**    |
+| Major (any dep type)      | Comment with changelog + breaking-change bullet list. No merge.  |
+| Peer-deps (any magnitude) | Never auto-merge. Comment for owner.                             |
+
+`dev-deps` = anything in `devDependencies` of `package.json` /
+`examples/nurture-pet/package.json`. `runtime` = anything in
+`dependencies`. `peer` = anything in `peerDependencies`.
+
+A grouped Dependabot PR (per `.github/dependabot.yml` `groups:` block)
+is treated as the **strictest** member: if any member is runtime or
+peer or major, the whole group inherits that classification. A
+group-PR that mixes runtime + dev minors is "runtime minor" → approval
+comment, no auto-merge.
+
+## Rebase + verify gate
+
+For every PR in scope (regardless of intended action):
+
+1. Rebase the PR branch onto current `develop`:
+   `gh pr comment <pr> --body "@dependabot rebase"` and wait for
+   Dependabot to push, OR fetch + rebase locally if the PR is stale
+   beyond Dependabot's auto-rebase window.
+2. After the rebase lands, run the same gate humans run:
+
+   ```bash
+   gh pr checkout <pr>
+   npm ci
+   npm run verify
+   ```
+
+3. If `npm run verify` fails → switch to **block-with-comment** below
+   regardless of what the table says.
+
+Never push to a Dependabot branch yourself — Dependabot's bot account
+owns it. Trigger rebases via the `@dependabot rebase` comment only.
+
+## Auto-merge command
+
+When and only when every gate is green AND the table says auto-merge:
+
+```bash
+gh pr merge <pr> --squash --auto --delete-branch
+```
+
+`--auto` defers the actual merge to GitHub's branch-protection-aware
+queue, so a stale required-check failure can still block the merge.
+Never use `--admin`.
+
+## Approval-comment text (runtime minor / patch)
+
+```
+Verified: rebased + `npm run verify` green at <head-sha>.
+Owner approval required (runtime dep). Re-run `npm run verify`
+locally before merging if more than a day passes.
+```
+
+## Major-bump comment text
+
+Open the changelog for the bumped package, summarize the breaking
+changes as a bullet list (≤ 5 bullets), and post:
+
+```
+Major bump: <pkg> <old> → <new>.
+
+Breaking changes (from upstream changelog):
+- <bullet>
+- <bullet>
+- <bullet>
+
+Owner: review breaking changes before merge. Do not auto-merge.
+```
+
+If the upstream package publishes no changelog, say so explicitly:
+
+```
+No upstream CHANGELOG located at <repo-url>; owner will need to
+review the diff against <release-url> manually.
+```
+
+# Hard rules
+
+- **Never** merge a Dependabot PR that touches `src/**`. Dependabot
+  generates manifest + lockfile bumps only — touching `src/**` means
+  something else is going on. Block with comment, owner investigates.
+- **Never** bypass `--no-verify` to land a green-CI claim. If
+  `npm run verify` fails locally, the PR is blocked.
+- **Never** amend or rewrite the Dependabot commit. Triage operates
+  via comments on Dependabot's own commits; the bot account owns the
+  branch history.
+- **Never** push directly to `develop`, `main`, or `demo`.
+- **Never** auto-merge a peer-dep bump. Peer-dep semantics are
+  consumer-visible by definition; owner reviews.
+- **Never** auto-merge a major bump, even on dev-deps. Major is
+  always owner-reviewed.
+- **Never** drop or close a Dependabot PR without explanation. If a
+  bump is permanently undesirable (e.g. abandoned package), comment
+  the rationale on the PR and on the rolling tracker, then close.
+- **Never** post `Closes #N` / `Fixes #N` referencing the rolling
+  tracker. The tracker is long-lived.
+- **Never** weaken `.github/workflows/*.yml` or `package.json`
+  scripts to make a bump pass. If a bump fails CI, the right fix is
+  to comment + leave for owner — not to relax the gate.
+
+# Output — append to the rolling tracker
+
+Single rolling issue titled `Dependency triage — develop`, label
+`dep-triage-bot`. One comment per run. Body of the issue holds the
+canonical "Last triaged SHAs" mapping (PR number → triaged head SHA)
+so the next run knows what to skip.
+
+## Per-run comment shape
+
+```
+## YYYY-MM-DD — <run-id>
+Run id: dep-triage-<UTC-iso8601>
+Open Dependabot PRs scanned: <N>
+Auto-merged: <N> | Approved (owner-merge): <N> | Blocked: <N> | Major (owner-review): <N>
+
+<per-PR table — see below>
+
+<run footer>
+```
+
+## Per-PR table
+
+| PR | Title | Class | Verify | Action | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `#<n>` | `<short title>` | dev-minor / runtime-patch / major / peer | green / red / skipped | auto-merged #<n> / approval-comment / blocked-comment / major-comment | one-line note |
+
+`Class` is the classification from the [Triage policy](#triage-policy)
+table. `Verify` is the result of `npm run verify` against the PR head
+after rebase. `Notes` may say e.g. `verify failed: <err tail trimmed
+to 60 chars>` or `awaiting Dependabot rebase` — keep concise.
+
+## Run footer
+
+End the comment with:
+
+- Triaged: `<N>` PRs (`<auto-merged>` auto-merged, `<approved>` approved,
+  `<blocked>` blocked, `<major>` major)
+- Skipped (already triaged on same head SHA): `<N>` PRs
+- Counter-argument check: `<which auto-merge tested, kept or reverted>`
+- Last triaged SHAs: `#<n>=<sha7>, #<m>=<sha7>, …` ← persist for next run
+- Not reviewed: `<PRs you skipped + reason>`
+
+The last line is canonical state. After writing the comment, edit the
+issue body so its `Last triaged SHAs:` line reflects the new mapping
+(replace the prior line in place, do NOT append).
+
+## Counter-argument check
+
+Before posting, pick the riskiest auto-merge of the run and write one
+paragraph:
+
+`Counter-argument to my own auto-merge of #<n>: <strongest case this
+breaks something>`
+
+If the counter holds, downgrade that PR from auto-merge to approval-
+comment. Same convention as the daily code-review bot.
+
+# Process gates
+
+- If the routine cannot reach the rolling tracker issue (auth,
+  network, missing label) → exit 1 with the verbatim error. Do NOT
+  silently auto-merge without a paper trail.
+- If `gh pr merge --auto` returns "auto-merge not enabled on this
+  repo" → fall back to approval-comment for that PR and add a
+  `[setup]` finding to the run footer pointing at
+  [`README.md`](./README.md) one-time setup.
+- If a Dependabot PR has a non-bot co-author (suspicious commit) →
+  block with comment, owner investigates. Sniff via:
+
+  ```bash
+  gh pr view <pr> --json commits --jq '.commits[].authors[].login'
+  ```
+
+  Every login should be `dependabot[bot]` (or whichever bot account
+  the org uses). Anything else → block.
+- If `examples/nurture-pet/` has been renamed (see umbrella plan
+  coordination with PR #129) — substitute the new path
+  (`examples/product-demo/`) in the `gh pr diff` filter above. Do
+  NOT pre-rename anywhere else; the rename PR sweeps mechanically.
+
+# Idempotency
+
+- Read `Last triaged SHAs:` from the rolling tracker issue body at
+  the start. Skip any PR whose current head SHA already appears in
+  that mapping for that PR number.
+- A PR's head SHA changes after a `@dependabot rebase` push — that
+  intentionally re-triages it on the next run.
+- If the rolling tracker doesn't exist yet, fall back to triaging
+  every open Dependabot PR (treat the SHA map as empty). Open the
+  tracker on the first run with body:
+
+  ```
+  Rolling tracker for the weekly `dep-triage-bot` cloud routine.
+
+  Last triaged SHAs: <none>
+  ```
+
+# Dry-run mode
+
+If the env var `DRY_RUN` is set non-empty, every write is replaced
+with a stdout dump of the would-be call:
+
+```text
+[DRY_RUN] would call: gh <subcommand> <args…>
+[DRY_RUN] body:
+<verbatim body that would have been sent>
+```
+
+Wraps:
+
+- `gh pr merge` (auto-merge)
+- `gh pr comment` (approval / major / blocked / `@dependabot rebase`)
+- `gh issue comment` (rolling tracker append)
+- `gh issue edit` (rolling tracker body update)
+- `gh issue create` (first-run rolling tracker)
+- `gh label create` (first-run label setup)
+
+Reads (`gh pr list`, `gh pr view`, `gh pr diff`, `gh issue list`,
+`gh issue view`) MAY still run in dry-run mode — they have no side
+effects.
+
+The local `npm ci && npm run verify` SHOULD still run in dry-run mode
+so the run produces realistic verify-pass / verify-fail signals — but
+under no circumstances trigger `gh pr merge` or `gh pr comment` from
+that path.
+
+In dry-run mode, do NOT write any cache files. Dry runs leave zero
+filesystem side effects beyond the cache reads above. Exit 0 after
+dumping.
+
+# Failure handling
+
+- `npm run verify` fails on a Dependabot PR → block-with-comment:
+
+  ```
+  `npm run verify` failed at <head-sha>:
+
+  ```
+  <last 20 lines of verify output, fenced>
+  ```
+
+  Owner: investigate before merge. If the failure is unrelated to
+  the bump, comment `@dependabot rebase` to refresh.
+  ```
+
+- `gh pr merge --auto` fails (network, perms) → retry once, then
+  fall back to approval-comment. Append a footer note `auto-merge
+  retry failed: <err>` to the run comment.
+- `gh issue comment` on the rolling tracker fails → write the
+  intended comment body to `.dep-triage-cache/FAILED-comment-<run-id>.md`
+  and exit 1. Do NOT retry blindly. The cache dir is gitignored
+  (one-time setup, see README).
+- Any `git`/`gh` command fails with auth → exit 1 with the verbatim
+  error. Do not paper over it.
+- In `DRY_RUN` mode, do NOT write `FAILED-*.md` files. Dry runs
+  leave zero filesystem side effects beyond the existing cache
+  reads.
+
+# Do NOT
+
+- Open PRs. The routine only comments + auto-merges existing
+  Dependabot PRs. Never craft its own dependency-bump branch.
+- Edit `package.json` / `package-lock.json` / `examples/nurture-pet/
+  package*.json` directly. Bumps come from Dependabot.
+- Post `Closes #N` / `Fixes #N` referencing the rolling tracker.
+- Comment on Dependabot PRs from a prior triaged head SHA (see
+  Idempotency).
+- Touch `.changeset/*.md`. Dependency bumps don't get a changeset
+  entry — they're chore-tier.
+- Bypass any of the Hard rules above to drain the queue faster.
+  Slow + safe is the contract.

--- a/docs/dep-triage-bot/PROMPT.md
+++ b/docs/dep-triage-bot/PROMPT.md
@@ -49,11 +49,20 @@ For each in-scope PR, classify by **dependency type** (runtime vs dev
 vs peer) and **bump magnitude** (patch / minor / major), then apply
 the matching action.
 
-Detect dependency type from the diff against `package.json`:
+Detect dependency type from the diff against `package.json`. `gh pr
+diff` does not accept pathspecs after `--` (only `--exclude` glob
+filtering), so use the REST `pulls/<num>/files` endpoint and filter
+the response with `jq`:
 
 ```bash
-gh pr diff "<pr-number>" -- package.json examples/nurture-pet/package.json
+gh api "repos/Luis85/agentonomous/pulls/<pr-number>/files" \
+  --jq '.[] | select(.filename | endswith("package.json")) | {file: .filename, patch: .patch}'
 ```
+
+Each entry's `.patch` is the unified diff GitHub stores for that
+file. Inspect the `+`/`-` lines under `"dependencies"`,
+`"devDependencies"`, or `"peerDependencies"` keys to classify the
+bumped package.
 
 | Type / magnitude          | Action                                                           |
 | ------------------------- | ---------------------------------------------------------------- |

--- a/docs/dep-triage-bot/README.md
+++ b/docs/dep-triage-bot/README.md
@@ -1,0 +1,192 @@
+# `dep-triage-bot/` — weekly Dependabot triage routine
+
+Source files for the scheduled remote agent that drains the weekly
+Dependabot PR pile on `develop`. Once Dependabot's grouped PRs land
+(per the `npm-non-major` group blocks in
+[`.github/dependabot.yml`](../../.github/dependabot.yml)), this
+routine runs every Monday morning, classifies each PR, runs the
+`npm run verify` gate, and either auto-merges (dev-deps minor/patch),
+leaves an approval comment for the owner (runtime minor/patch), or
+blocks with an explanatory comment (majors, peer-deps, verify
+failures).
+
+Sibling of `docs/review-bot/` and `docs/docs-review-bot/` — same
+skeleton, different target. Where `review-bot/` reviews **code
+commits** and `docs-review-bot/` reviews **docs drift**, this
+routine drains the **Dependabot PR pile**.
+
+## Layout
+
+| File                          | Purpose                                                  |
+| ----------------------------- | -------------------------------------------------------- |
+| [`PROMPT.md`](./PROMPT.md)    | System prompt the routine loads at the start of each run. |
+| [`README.md`](./README.md)    | This file — routine setup, sinks, iteration workflow.   |
+
+## Output sink
+
+**Single rolling issue** titled `Dependency triage — develop`, label
+`dep-triage-bot`. New comment per run; the issue body holds the
+canonical `Last triaged SHAs: …` mapping so the next run knows which
+PR head SHAs to skip.
+
+Same shape as the daily `review-bot` rolling issue (`#87`) — long-
+lived, append-only, body holds canonical resume state. Different from
+`docs-review-bot` (which opens one issue per run).
+
+If a run finds zero open Dependabot PRs, the routine appends a one-
+line `YYYY-MM-DD — no-op (no open Dependabot PRs)` comment to the
+rolling tracker and exits cleanly. Silence is the desired state.
+
+## Setup checklist (one-time)
+
+- [ ] Create the rolling issue `Dependency triage — develop`. Add
+      label `dep-triage-bot`. Seed the body with:
+
+      ```
+      Rolling tracker for the weekly `dep-triage-bot` cloud routine.
+
+      Last triaged SHAs: <none>
+      ```
+
+      (The prompt re-creates the label on first run if missing — this
+      just avoids the create call racing with the issue-open call.)
+- [ ] Add the `dep-triage-bot` label to the repo:
+      ```bash
+      gh label create dep-triage-bot --color FBCA04 \
+        --description "Findings from the weekly dep-triage cloud routine"
+      ```
+- [ ] Add `.dep-triage-cache/` to `.gitignore` (one line). The
+      routine writes a FAILED-comment body file there if the rolling
+      tracker comment-append fails so you can re-submit by hand.
+- [ ] Enable auto-merge on the repo
+      (`Settings → General → Pull Requests → Allow auto-merge`). The
+      routine uses `gh pr merge --auto --squash` for the dev-deps
+      minor/patch path. Without this, the routine falls back to
+      approval-comment for every PR (still safe, just slower drain).
+- [ ] Verify the routine has the right GitHub token scopes:
+      `pull-requests:write` (comment, merge --auto, label),
+      `issues:write` (rolling tracker comments + body edit), and
+      `contents:read` (clone + checkout PR branches). No
+      `contents:write` — the routine never pushes a branch.
+- [ ] Confirm Dependabot is configured to group npm minor + patch
+      updates per the `npm-non-major` blocks on both npm entries in
+      [`.github/dependabot.yml`](../../.github/dependabot.yml).
+      Without grouping, the queue is N PRs/week instead of one
+      tractable bundle and the routine's auto-merge cadence loses
+      most of its value.
+- [ ] Dry-run once with `DRY_RUN=1` set in the routine's env. The
+      prompt's Dry-run section guards every `gh pr merge`,
+      `gh pr comment`, `gh issue comment`, `gh issue edit`,
+      `gh issue create`, and `gh label create` call behind a
+      `DRY_RUN` check; in dry-run mode each is replaced by a stdout
+      dump of the would-be call + body. The `npm ci && npm run
+      verify` step still runs locally so verify-pass / verify-fail
+      signals are realistic.
+
+## Routine wrapper prompt (paste into the routine)
+
+The routine itself only needs a tiny wrapper that points at this
+file and lets the system prompt do the heavy lifting. Paste this
+exact text into the routine's `events[].data.message.content` (one
+user message):
+
+> You are running the scheduled `dep-triage-bot` routine for the
+> `agentonomous` repo.
+>
+> Steps:
+>
+> 1. Clone / refresh the repo on `develop`:
+>    `git fetch origin && git switch develop && git pull --ff-only origin develop`
+> 2. Read the system prompt at `docs/dep-triage-bot/PROMPT.md` and
+>    follow it verbatim. That file is the source of truth for what
+>    to triage, the action policy table, hard rules, output format,
+>    persistence, and dry-run rules. Do not re-derive any of that
+>    from this message.
+> 3. After draining the queue and appending the per-run comment to
+>    the rolling tracker (or posting the no-op comment), exit
+>    cleanly. Do NOT open a PR. Do NOT push to any branch. Do NOT
+>    edit any code, manifests, or lockfiles directly.
+>
+> If `docs/dep-triage-bot/PROMPT.md` does not exist on `develop` for
+> some reason, abort with a clear error — do not improvise a triage
+> policy without the prompt.
+
+That wrapper is intentionally short. The system prompt is versioned
+in-repo so changes go through PR review like any other doc change —
+the routine itself doesn't need to be re-edited every time the
+prompt evolves.
+
+## Cadence
+
+Recommended: **weekly, Monday morning**, after Dependabot has opened
+its grouped weekly PRs (Dependabot itself runs at 06:00 UTC Monday
+per [`.github/dependabot.yml`](../../.github/dependabot.yml)). A
+reasonable cron in UTC:
+
+- `0 8 * * 1` — every Monday at 08:00 UTC (10:00 Europe/Berlin), one
+  hour after Dependabot fires. Gives Dependabot time to actually
+  finish opening PRs before the routine scans for them.
+
+The routine no-ops cleanly when there are no open Dependabot PRs, so
+over-scheduling is non-destructive — just noisy in the rolling
+tracker. If the queue stays empty for several weeks (Dependabot
+finds nothing to bump), the routine's runs are a one-line `no-op`
+comment per run; that's the desired silence.
+
+## Iteration workflow (changing the prompt)
+
+The prompt evolves as you discover false positives, missed hard
+rules, or output-format pain. To change it:
+
+1. Cut a topic branch from `develop`
+   (`docs/dep-triage-prompt-tweak` or similar).
+2. Edit [`PROMPT.md`](./PROMPT.md). Keep section structure stable so
+   the routine doesn't break on a missing header.
+3. Open a PR against `develop`. Doc-only diff → CI short-circuits
+   to `ci-gate` only (~1 minute).
+4. After merge, the next scheduled run picks up the new prompt.
+
+## Known tradeoffs
+
+- **Auto-merge is conservative on purpose.** Only dev-deps minor/
+  patch auto-merges; everything else waits for owner approval. If
+  you find the queue still piling up because grouped PRs always
+  contain at least one runtime bump (so the whole group inherits
+  "runtime minor" → approval-comment), consider splitting npm into
+  two ecosystem entries per
+  [Dependabot grouping docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)
+  — one runtime, one dev — so the dev-only group can auto-merge
+  cleanly. Don't relax the policy.
+- **`@dependabot rebase` is asynchronous.** The routine triggers a
+  rebase via comment, then has to wait for Dependabot's bot to
+  actually push the rebased commit. If Dependabot is slow or rate-
+  limited, the routine may need to defer that PR to next week's run.
+  That's logged as `awaiting Dependabot rebase` in the per-PR table
+  notes — not a bug.
+- **Major bumps never auto-merge.** Even on dev-deps. The bot only
+  posts a changelog summary + breaking-change bullets and leaves the
+  PR open. The owner reviews and merges (or closes) the major PR
+  manually.
+- **Group-PRs inherit the strictest classification.** Dependabot's
+  `npm-non-major` group bundles runtime + dev minors into one PR.
+  The routine treats the whole bundle as runtime-minor → approval-
+  comment, no auto-merge. This is a deliberate safety bias; see the
+  prompt's [Triage policy](./PROMPT.md#triage-policy).
+- **Verify failures block silently from a CI perspective.** A
+  blocked PR sits open with a comment; nothing flags the queue
+  health. Mitigation: weekly run footers always report `Blocked: N`
+  — non-zero N is the signal to triage manually.
+
+## Related
+
+- Sibling routines: `docs/review-bot/` (daily code review of
+  `develop` commits, dual sink: rolling issue `#87` + committed
+  daily docs), `docs/docs-review-bot/` (weekly docs-drift audit,
+  fresh issue per run).
+- Dependabot config: [`.github/dependabot.yml`](../../.github/dependabot.yml)
+  — the `npm-non-major` group blocks are what make this routine
+  tractable. Without grouping, the queue is N PRs/week.
+- Branch / changeset / verify policy that the prompt's hard rules
+  reference: `CLAUDE.md`, `CONTRIBUTING.md`, `STYLE_GUIDE.md`.
+- Umbrella tracker for the quality-automation increment that
+  introduced this routine: [Issue #131](https://github.com/Luis85/agentonomous/issues/131).

--- a/docs/plans/2026-04-26-quality-automation-routines.md
+++ b/docs/plans/2026-04-26-quality-automation-routines.md
@@ -108,7 +108,7 @@ merges.
 | #   | Chunk plan | Scope (one-line) | Cadence | Touches `src/`? | Status |
 | --- | --- | --- | --- | --- | --- |
 | 1   | [quality-codeql.md](./2026-04-26-quality-codeql.md) | Weekly + push CodeQL JS/TS scan, `security-and-quality` query suite | weekly + push | no | - [x] shipped |
-| 2   | [quality-dep-triage-bot.md](./2026-04-26-quality-dep-triage-bot.md) | Cloud routine prompt + `dependabot.yml` grouping for weekly Dependabot triage | weekly | no | - [ ] not started |
+| 2   | [quality-dep-triage-bot.md](./2026-04-26-quality-dep-triage-bot.md) | Cloud routine prompt + `dependabot.yml` grouping for weekly Dependabot triage | weekly | no | - [x] shipped |
 | 3   | [quality-actions-bump-bot.md](./2026-04-26-quality-actions-bump-bot.md) | Cloud routine prompt that runs `scripts/bump-actions.mjs` weekly + opens a bump PR | weekly | no | - [ ] not started |
 | 4   | [quality-plan-recon-bot.md](./2026-04-26-quality-plan-recon-bot.md) | Cloud routine prompt that archives shipped plans monthly | monthly | no | - [ ] not started |
 | 5   | [quality-bundle-trend.md](./2026-04-26-quality-bundle-trend.md) | Weekly snapshot of `npx size-limit --json` to a committed JSONL trend file | weekly | no | - [ ] not started |


### PR DESCRIPTION
Tracks: #130
Tracks: #131

Adds the weekly Dependabot triage cloud-routine prompt + README scaffold under `docs/dep-triage-bot/`. Mirrors the existing `docs/review-bot/` and `docs/docs-review-bot/` shape (system prompt + README + rolling tracker issue, idempotency via canonical SHA list in issue body).

## What's in the diff

- `docs/dep-triage-bot/PROMPT.md` — system prompt: role, scope, triage policy table (dev-deps minor/patch auto-merge; runtime minor/patch approval-comment; majors + peer-deps owner-only), hard rules, output format (rolling tracker + per-PR table), idempotency, dry-run guard, failure handling.
- `docs/dep-triage-bot/README.md` — routine setup, sinks, iteration workflow, known tradeoffs.
- `.github/dependabot.yml` — added `npm-non-major` group block to BOTH npm ecosystem entries (root + `examples/nurture-pet`) so minor + patch updates land as one weekly bundled PR per ecosystem instead of N. Replaced the prior `dev-dependencies` group on the root entry — the new group covers both runtime + dev minors/patches under the same bundling policy. Major bumps remain ungrouped (one PR per major, owner-reviewed). GitHub Actions ecosystem grouping (`actions:`) is unchanged.
- `docs/plans/2026-04-26-quality-automation-routines.md` — ticked row 2 (this row) to `- [x] shipped` per the umbrella's tick rule.

## Out-of-repo follow-up (does NOT gate merge)

Once this PR lands, the owner needs to:

1. Create the rolling tracker issue `Dependency triage — develop` with label `dep-triage-bot` and the seed body documented in `docs/dep-triage-bot/README.md` setup checklist.
2. Schedule the cloud routine (Claude Cloud) at `0 8 * * 1` (Monday 08:00 UTC, one hour after Dependabot fires) using the wrapper prompt in the README.
3. Ensure repo allows auto-merge (`Settings → General → Pull Requests → Allow auto-merge`) so the dev-deps minor/patch path can actually `gh pr merge --auto --squash`.

All three are spelled out in the README's Setup checklist.

## Verification

- `npm run verify` — green locally on this branch.
- Doc-only diff (plus a config grouping change in `.github/dependabot.yml`); no `src/**`, no changeset.

Ticks row 2 of the umbrella tracker.