### PR TITLE
docs: flip Wave-0 row + harden tracker-row convention (no doc-only follow-ups)

### DIFF
--- a/.claude/memory/feedback_docs_alongside_pr.md
+++ b/.claude/memory/feedback_docs_alongside_pr.md
@@ -18,6 +18,14 @@ and degrades when the plan disagrees with the diff.
 - When implementing a row from `docs/plans/YYYY-MM-DD-<slug>.md`, edit
   the plan in the same PR — mark the row "Shipped (PR #N)" or move it
   under a "What's already shipped" heading.
+- **Tracker-table flips ride with the same PR.** Don't land work with
+  the row at "in review" and chase it with a one-line `docs: flip row
+to ✅` follow-up — that pollutes git history. Instead: open the PR
+  (the GH-assigned number is known immediately), edit the planning doc
+  to set the row to `✅ shipped` with `[#NNN](url)` linked, push the
+  same branch, then squash-merge. The row briefly reads "shipped" while
+  the PR is still open; that is fine — it reflects intent and CI gates
+  prevent a broken merge from leaving the row stale.
 - When a PR changes user-visible surface (new option on a public
   helper, new event on the agent bus, new public type, new export),
   update the relevant doc (`README.md`, `STYLE_GUIDE.md`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,8 +131,11 @@ Full rules in [`STYLE_GUIDE.md`](./STYLE_GUIDE.md). High-frequency ones:
 - Date prefix = first-commit date. Never drop the date; rename via
   `git mv` if the slug changes.
 - **Plan + doc updates ride with the PR that lands the work.** When a
-  PR completes a roadmap row, mark it shipped in the plan (or move it
-  under "What's already shipped") in the same diff. When a PR changes
+  PR completes a roadmap row, mark the row `✅ shipped` with
+  `[#NNN](url)` linked **in the same PR** (use the GH-assigned PR
+  number — it's known the moment the PR is opened, before merge).
+  Don't land at "in review" and chase with a `docs: flip row` follow-up
+  — those one-line PRs pollute git history. When a PR changes
   user-visible surface (new option, new event, new helper), update the
   relevant doc (`README.md`, `STYLE_GUIDE.md`, `PUBLISHING.md`, the
   matching spec) in the same diff. No "docs catch-up" follow-up PRs —

--- a/docs/plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md
@@ -76,7 +76,10 @@ users see — not infer — what changed between modes.
 - Spec criteria P2-AC-1 through P2-AC-4 all met.
 - Tuning constants chosen and recorded in the Done log.
 - Planning-doc tracker table row for "Cognition diff panel" set to ✅
-  with every merged PR linked.
+  shipped with every PR linked **in the same PR that ships each
+  row** (use the GH-assigned PR number; never chase with a `docs:
+  flip row` follow-up — see CLAUDE.md "Plan + doc updates ride with
+  the PR that lands the work").
 
 ## Done log
 

--- a/docs/plans/2026-04-26-pre-v1-demo-determinism-fingerprint.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-determinism-fingerprint.md
@@ -82,8 +82,11 @@ backed by a normalized run fingerprint.
 
 - Spec criteria P3-AC-1 through P3-AC-5 all met.
 - `minSampleFraction` final value chosen and recorded in Done log.
-- Planning-doc tracker table row for "Determinism fingerprint" set to ✅
-  with every merged PR linked.
+- Planning-doc tracker table row for "Determinism fingerprint" set to
+  ✅ shipped with every PR linked **in the same PR that ships each
+  row** (use the GH-assigned PR number; never chase with a `docs:
+  flip row` follow-up — see CLAUDE.md "Plan + doc updates ride with
+  the PR that lands the work").
 
 ## Done log
 

--- a/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
@@ -73,7 +73,10 @@ external narration.
 
 - Spec criteria P1-AC-1 through P1-AC-5 all met.
 - Planning-doc tracker table row for "Guided walkthrough" set to ✅
-  with every merged PR linked.
+  shipped with every PR linked **in the same PR that ships each row**
+  (use the GH-assigned PR number; never chase with a `docs: flip row`
+  follow-up — see CLAUDE.md "Plan + doc updates ride with the PR that
+  lands the work").
 - Issue #132 GH tasklist entries for slices 1.1 - 1.4 ticked.
 
 ## Done log

--- a/docs/plans/2026-04-26-pre-v1-demo-json-preview-commit.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-json-preview-commit.md
@@ -88,7 +88,10 @@ keyed off a whitelist of safely previewable fields.
 - Spec criteria P4-AC-1 through P4-AC-5 all met.
 - OQ-P4 (color cues) decision recorded.
 - Planning-doc tracker table row for "JSON preview/commit" set to ✅
-  with every merged PR linked.
+  shipped with every PR linked **in the same PR that ships each row**
+  (use the GH-assigned PR number; never chase with a `docs: flip row`
+  follow-up — see CLAUDE.md "Plan + doc updates ride with the PR that
+  lands the work").
 
 ## Done log
 

--- a/docs/plans/2026-04-26-pre-v1-demo-second-scenario.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-second-scenario.md
@@ -86,8 +86,11 @@ second scenario.
 
 - Spec criteria P5-AC-1 through P5-AC-5 all met.
 - `companion-npc` locked concept recorded in Done log.
-- Planning-doc tracker table row for "Second scenario" set to ✅ with
-  every merged PR linked.
+- Planning-doc tracker table row for "Second scenario" set to ✅
+  shipped with every PR linked **in the same PR that ships each row**
+  (use the GH-assigned PR number; never chase with a `docs: flip row`
+  follow-up — see CLAUDE.md "Plan + doc updates ride with the PR that
+  lands the work").
 
 ## Done log
 

--- a/docs/product/2026-04-26-pre-v1-demo-evolution-plan.md
+++ b/docs/product/2026-04-26-pre-v1-demo-evolution-plan.md
@@ -27,7 +27,7 @@ The doc set originally landed via [PR #129](https://github.com/Luis85/agentonomo
 Every downstream PR cut from this plan must:
 
 - include the body line `Tracks: #132`,
-- tick its row in the [Tracker table](#tracker-table) in the same diff (per the project rule that plan + doc updates ride with their PR),
+- flip its row in the [Tracker table](#tracker-table) to `✅ shipped` with `[#NNN](url)` **in the same PR** (use the GH-assigned PR number — it is known the moment the PR is opened, before merge). Do NOT land at "in review" and chase with a `docs: flip row` follow-up — those pollute history. The row briefly reads "shipped" while the PR is still open; CI gates prevent a broken merge from leaving the row stale,
 - get added as a row to the GitHub tasklist on issue #132's body so completion auto-flips on merge.
 
 ---

--- a/docs/product/2026-04-26-pre-v1-demo-evolution-plan.md
+++ b/docs/product/2026-04-26-pre-v1-demo-evolution-plan.md
@@ -334,7 +334,7 @@ Canonical status. Update the **Status** and **PR** cells in the same diff that s
 
 | Wave | Pillar | Plan | Status | PR |
 |---|---|---|---|---|
-| 0 | Demo rename preflight | [`rename-preflight`](../archive/plans/2026-04-26-pre-v1-demo-rename-preflight.md) (archived) | in review | _Wave-0 PR_ |
+| 0 | Demo rename preflight | [`rename-preflight`](../archive/plans/2026-04-26-pre-v1-demo-rename-preflight.md) (archived) | ✅ shipped | [#134](https://github.com/Luis85/agentonomous/pull/134) |
 | A | Guided walkthrough | [`guided-walkthrough`](../plans/2026-04-26-pre-v1-demo-guided-walkthrough.md) | not started | — |
 | A | Cognition diff panel | [`cognition-diff-panel`](../plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md) | not started | — |
 | A | Determinism fingerprint | [`determinism-fingerprint`](../plans/2026-04-26-pre-v1-demo-determinism-fingerprint.md) | not started | — |


### PR DESCRIPTION
## Summary

Two things, deliberately bundled in the same PR to demonstrate the corrected pattern:

1. **Wave-0 tracker-row flip** — `docs/product/2026-04-26-pre-v1-demo-evolution-plan.md` row 0 set to `✅ shipped` linking [PR #134](https://github.com/Luis85/agentonomous/pull/134) (squashed as `c734d6a`).
2. **Convention hardening** — `CLAUDE.md`, the umbrella planning doc, the per-pillar plans, the auto-memory feedback file, and the umbrella issue body now all explicitly forbid the "land at 'in review' → chase with a `docs: flip row` follow-up" pattern that the Wave-0 PR accidentally introduced. The tracker-row flip rides with the merging PR, using the GH-assigned PR number (known the moment the PR is opened).

The bundling is intentional: this PR itself would have been two PRs under the old habit (one for the row flip, one for the doc convention). Doing it in one diff shows the rule.

## Test plan

- [x] No code change.
- [x] `npm run format:check` clean on touched files.
- [x] Issue #132 body updated to mirror the new wording.

Tracks: #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)