### PR TITLE
refactor(routines): dep-triage-bot to issue-per-run + post-Wave-0 path sweep

### DIFF
--- a/docs/dep-triage-bot/PROMPT.md
+++ b/docs/dep-triage-bot/PROMPT.md
@@ -318,32 +318,51 @@ embedded at the top of the routine's per-PR comment body:
 
 ## Skip check (run at the start of every PR's iteration)
 
-The marker is **only trusted when authored by the routine's own bot
-account**. Any collaborator (or accidental copy/paste of an old
-comment) could otherwise inject a `<!-- dep-triaged:<sha7>:* -->`
+The marker is **only trusted when authored by the configured
+routine login**. Any collaborator (or accidental copy/paste of an
+old comment) could otherwise inject a `<!-- dep-triaged:<sha7>:* -->`
 line into a human comment and silently suppress triage for that PR.
-The skip check therefore filters comment authors to `type == "Bot"`
-*and* a configured bot-login allowlist before reading the marker.
+The skip check therefore matches comment authors against a
+configured login allowlist before reading the marker.
 
-Set `ROUTINE_BOT_LOGIN` at scheduler-config time to the GitHub
-account the routine posts as (the App login, e.g. `claude[bot]` or
-the org's automation account). The check fails loudly if it is not
-set so a misconfigured run cannot accidentally trust unsigned
-markers.
+Set `ROUTINE_GH_LOGIN` at scheduler-config time to the GitHub login
+the routine actually posts as. Two common shapes:
+
+- **PAT-driven cloud routine.** The routine uses a Personal Access
+  Token belonging to a human (e.g. the repo owner). Comments are
+  authored by that human's login (e.g. `Luis85`) with
+  `user.type == "User"`. Set `ROUTINE_GH_LOGIN=<human-login>`.
+- **GitHub App / bot-account routine.** Comments are authored by
+  the App's bot identity (e.g. `claude[bot]`) with
+  `user.type == "Bot"`. Set `ROUTINE_GH_LOGIN=<bot-login>`.
+
+The skip check does NOT constrain `user.type` — a PAT-driven cloud
+routine is a legitimate setup, and constraining to `Bot` would
+silently disable triage idempotency on every PAT-based run. The
+login allowlist is the trust boundary. If anyone other than the
+routine's configured login posts a `<!-- dep-triaged:<sha7>:* -->`
+line, the marker is ignored and the PR is re-triaged on the next
+run — a re-triage is conservative (worst case: the bot posts a
+duplicate triage comment); a silently-skipped triage is dangerous
+(misses verify failures or auto-merge gates).
+
+The check fails loudly if `ROUTINE_GH_LOGIN` is unset so a
+misconfigured run cannot accidentally trust unsigned markers from
+arbitrary commenters.
 
 `gh api` accepts only `--jq <string>` for filtering — it does not
 forward jq CLI flags such as `--arg`. Pipe the raw response to a
-standalone `jq` invocation so SHA + bot-login values can be passed
-in via `--arg` (which jq escapes safely, avoiding shell-quoting
+standalone `jq` invocation so SHA + login values can be passed in
+via `--arg` (which jq escapes safely, avoiding shell-quoting
 pitfalls in the filter string).
 
 ```bash
-: "${ROUTINE_BOT_LOGIN:?ROUTINE_BOT_LOGIN must be set to the bot account login the routine posts as}"
+: "${ROUTINE_GH_LOGIN:?ROUTINE_GH_LOGIN must be set to the GitHub login the routine posts as}"
 HEAD_SHA7="$(gh pr view <pr> --json headRefOid --jq '.headRefOid[0:7]')"
 SKIP="$(gh api "repos/<owner>/<repo>/issues/<pr>/comments" \
-  | jq -r --arg sha "${HEAD_SHA7}" --arg login "${ROUTINE_BOT_LOGIN}" \
+  | jq -r --arg sha "${HEAD_SHA7}" --arg login "${ROUTINE_GH_LOGIN}" \
     '.[]
-     | select(.user.type == "Bot" and .user.login == $login)
+     | select(.user.login == $login)
      | select(.body | startswith("<!-- dep-triaged:" + $sha + ":"))
      | .body' \
   | head -n1)"
@@ -354,8 +373,9 @@ fi
 ```
 
 If a marker for the current head SHA exists **and was authored by
-the routine's bot account**, this PR was already triaged on a prior
-run with no Dependabot rebase since. Add it to the run footer's
+the configured routine login**, this PR was already triaged on a
+prior run with no Dependabot rebase since. Add it to the run
+footer's
 `Skipped` count and move on. A marker authored by anyone else is
 ignored.
 

--- a/docs/dep-triage-bot/PROMPT.md
+++ b/docs/dep-triage-bot/PROMPT.md
@@ -36,12 +36,11 @@ gh pr list \
 ```
 
 Skip every PR whose head SHA was already triaged in a prior run (see
-[Idempotency](#idempotency) below — the "Last triaged SHAs" line on the
-rolling tracker is canonical state).
+[Idempotency](#idempotency) below — a per-PR comment marker is canonical
+state for that PR).
 
-If the search returns zero PRs: append a one-line `YYYY-MM-DD — no-op
-(no open Dependabot PRs)` comment to the rolling tracker and exit
-cleanly. Do NOT open a fresh tracker, do NOT push any branch.
+If the search returns zero PRs: do NOT open an issue, do NOT push any
+branch. Quiet runs leave no trace.
 
 # Triage policy
 
@@ -72,7 +71,7 @@ bumped package.
 | Peer-deps (any magnitude) | Never auto-merge. Comment for owner.                             |
 
 `dev-deps` = anything in `devDependencies` of `package.json` /
-`examples/nurture-pet/package.json`. `runtime` = anything in
+`examples/product-demo/package.json`. `runtime` = anything in
 `dependencies`. `peer` = anything in `peerDependencies`.
 
 A grouped Dependabot PR (per `.github/dependabot.yml` `groups:` block)
@@ -163,32 +162,50 @@ review the diff against <release-url> manually.
   always owner-reviewed.
 - **Never** drop or close a Dependabot PR without explanation. If a
   bump is permanently undesirable (e.g. abandoned package), comment
-  the rationale on the PR and on the rolling tracker, then close.
-- **Never** post `Closes #N` / `Fixes #N` referencing the rolling
-  tracker. The tracker is long-lived.
+  the rationale on the PR and on this run's `dep-triage-bot` issue,
+  then close the Dependabot PR (NOT the run issue — that closes
+  manually once every action it lists is resolved).
+- **Never** post `Closes #N` / `Fixes #N` referencing a
+  `dep-triage-bot` issue. Each per-run issue is a long-lived archive
+  of its own run; close it manually once everything is resolved.
 - **Never** weaken `.github/workflows/*.yml` or `package.json`
   scripts to make a bump pass. If a bump fails CI, the right fix is
   to comment + leave for owner — not to relax the gate.
 
-# Output — append to the rolling tracker
+# Output — open ONE dedicated issue per run
 
-Single rolling issue titled `Dependency triage — develop`, label
-`dep-triage-bot`. One comment per run. Body of the issue holds the
-canonical "Last triaged SHAs" mapping (PR number → triaged head SHA)
-so the next run knows what to skip.
+Each scheduled run opens its **own** issue. There is no rolling log
+and no append-to-existing-issue step. One issue = one triage run =
+one body containing every action taken that run.
 
-## Per-run comment shape
+Sibling pattern of `docs/review-bot/` (issue-per-run for code review)
+and `docs/docs-review-bot/` (issue-per-run for docs drift). The
+canonical per-PR triage state lives on the **Dependabot PR itself**
+as a comment marker (see [Idempotency](#idempotency)), not on the
+run issue.
 
-```
-## YYYY-MM-DD — <run-id>
-Run id: dep-triage-<UTC-iso8601>
-Open Dependabot PRs scanned: <N>
-Auto-merged: <N> | Approved (owner-merge): <N> | Blocked: <N> | Major (owner-review): <N>
+## Issue spec
 
-<per-PR table — see below>
+- **Title:** `Dependency triage — YYYY-MM-DD`
+- **Label:** `dep-triage-bot` (create the label once if missing:
+  `gh label create dep-triage-bot --color FBCA04 --description "Findings from the weekly dep-triage cloud routine"`).
+- **Body:** the full per-run output — header line, action counts,
+  per-PR table, run footer. Format:
 
-<run footer>
-```
+  ```
+  ## YYYY-MM-DD
+  Run id: dep-triage-<UTC-iso8601>
+  Open Dependabot PRs scanned: <N>
+  Auto-merged: <N> | Approved (owner-merge): <N> | Blocked: <N> | Major (owner-review): <N>
+
+  <per-PR table — see below>
+
+  <run footer>
+  ```
+
+- **Assignee:** none. The owner reviews the table, picks any blocked
+  / major / approval-only entries off the list, and closes the issue
+  manually once each row is resolved.
 
 ## Per-PR table
 
@@ -203,18 +220,56 @@ to 60 chars>` or `awaiting Dependabot rebase` — keep concise.
 
 ## Run footer
 
-End the comment with:
+End the issue body with:
 
 - Triaged: `<N>` PRs (`<auto-merged>` auto-merged, `<approved>` approved,
   `<blocked>` blocked, `<major>` major)
 - Skipped (already triaged on same head SHA): `<N>` PRs
 - Counter-argument check: `<which auto-merge tested, kept or reverted>`
-- Last triaged SHAs: `#<n>=<sha7>, #<m>=<sha7>, …` ← persist for next run
 - Not reviewed: `<PRs you skipped + reason>`
 
-The last line is canonical state. After writing the comment, edit the
-issue body so its `Last triaged SHAs:` line reflects the new mapping
-(replace the prior line in place, do NOT append).
+## Open command
+
+```bash
+TITLE="Dependency triage — $(date -u +%F)"
+BODY_FILE=".dep-triage-cache/issue-body-$(date -u +%F).md"
+if [ -n "${DRY_RUN:-}" ]; then
+  printf '[DRY_RUN] would call: gh issue create --title %q --label dep-triage-bot --body-file %q\n' \
+    "${TITLE}" "${BODY_FILE}"
+  printf '[DRY_RUN] body:\n'; cat "${BODY_FILE}"
+else
+  gh issue create \
+    --title "${TITLE}" \
+    --label dep-triage-bot \
+    --body-file "${BODY_FILE}"
+fi
+```
+
+## No-op handling
+
+If the run scans zero open Dependabot PRs, do NOT open an issue.
+Quiet runs leave no trace — same convention as the daily code-review
+bot.
+
+## Closing issues — NOT the bot's job
+
+The bot never closes a `dep-triage-bot` issue. The owner closes
+manually once every blocked / major / approval-only row in the run
+table is resolved. Each new run opens a NEW issue regardless of
+whether prior ones are still open.
+
+## Idempotency at the issue level
+
+If today's run already opened a `dep-triage-bot` issue for the same
+UTC date (search:
+`gh issue list --label dep-triage-bot --state open --search "$(date -u +%F)" --json number,title`),
+do NOT open a duplicate. Either:
+
+- New PRs vs the existing issue body → edit the existing issue body
+  in place to append the delta under a `## Delta — re-run at $(date -u +%FT%TZ)` header.
+- Same set of PRs (same actions on same head SHAs) → exit 0 silently.
+
+`gh issue list` is read-only and runs unguarded in both modes.
 
 ## Counter-argument check
 
@@ -229,9 +284,9 @@ comment. Same convention as the daily code-review bot.
 
 # Process gates
 
-- If the routine cannot reach the rolling tracker issue (auth,
-  network, missing label) → exit 1 with the verbatim error. Do NOT
-  silently auto-merge without a paper trail.
+- If `gh issue create` (the per-run issue) fails (auth, network,
+  missing label) → exit 1 with the verbatim error. Do NOT silently
+  auto-merge without a paper trail.
 - If `gh pr merge --auto` returns "auto-merge not enabled on this
   repo" → fall back to approval-comment for that PR and add a
   `[setup]` finding to the run footer pointing at
@@ -245,27 +300,68 @@ comment. Same convention as the daily code-review bot.
 
   Every login should be `dependabot[bot]` (or whichever bot account
   the org uses). Anything else → block.
-- If `examples/nurture-pet/` has been renamed (see umbrella plan
-  coordination with PR #129) — substitute the new path
-  (`examples/product-demo/`) in the `gh pr diff` filter above. Do
-  NOT pre-rename anywhere else; the rename PR sweeps mechanically.
 
 # Idempotency
 
-- Read `Last triaged SHAs:` from the rolling tracker issue body at
-  the start. Skip any PR whose current head SHA already appears in
-  that mapping for that PR number.
-- A PR's head SHA changes after a `@dependabot rebase` push — that
-  intentionally re-triages it on the next run.
-- If the rolling tracker doesn't exist yet, fall back to triaging
-  every open Dependabot PR (treat the SHA map as empty). Open the
-  tracker on the first run with body:
+Per-PR triage state is stored as a comment marker on the **Dependabot
+PR itself**, not on a rolling tracker. The marker is an HTML comment
+embedded at the top of the routine's per-PR comment body:
 
-  ```
-  Rolling tracker for the weekly `dep-triage-bot` cloud routine.
+```html
+<!-- dep-triaged:<head-sha7>:<action> -->
+```
 
-  Last triaged SHAs: <none>
-  ```
+- `<head-sha7>` is the seven-char prefix of the PR head SHA at the
+  moment the routine triaged it.
+- `<action>` is one of `auto-merged`, `approval-comment`,
+  `blocked-comment`, `major-comment`, `awaiting-rebase`.
+
+## Skip check (run at the start of every PR's iteration)
+
+```bash
+HEAD_SHA7="$(gh pr view <pr> --json headRefOid --jq '.headRefOid[0:7]')"
+SKIP="$(gh pr view <pr> --json comments \
+  --jq --arg sha "${HEAD_SHA7}" '.comments[] | select(.body | startswith("<!-- dep-triaged:" + $sha + ":")) | .body' \
+  | head -n1)"
+if [ -n "${SKIP}" ]; then
+  echo "Skip #<pr> — already triaged at ${HEAD_SHA7}: ${SKIP}"
+  continue
+fi
+```
+
+If the marker exists for the current head SHA, this PR was already
+triaged on a prior run with no Dependabot rebase since. Add it to the
+run footer's `Skipped` count and move on.
+
+## Marker format on the Dependabot PR
+
+Every routine-authored comment on a Dependabot PR (approval, major,
+blocked) MUST start with the marker line, on its own line, before
+any human-readable text:
+
+```
+<!-- dep-triaged:<head-sha7>:<action> -->
+
+<rest of the comment body — approval text / changelog summary /
+verify-failure tail>
+```
+
+For the auto-merge path (where the routine merges the PR rather than
+leaving a comment), still leave the marker comment first, **then**
+call `gh pr merge --auto --squash`. The marker survives the merge
+because GitHub keeps PR comments after merge.
+
+## Re-triage on rebase
+
+A PR's head SHA changes after a `@dependabot rebase` push — that
+intentionally re-triages it on the next run because the new
+`<head-sha7>` won't match any prior marker.
+
+## First-ever run
+
+There is no first-run setup for idempotency. With zero markers on
+any Dependabot PR, the routine triages everything in scope, leaves
+markers, and exits.
 
 # Dry-run mode
 
@@ -281,10 +377,11 @@ with a stdout dump of the would-be call:
 Wraps:
 
 - `gh pr merge` (auto-merge)
-- `gh pr comment` (approval / major / blocked / `@dependabot rebase`)
-- `gh issue comment` (rolling tracker append)
-- `gh issue edit` (rolling tracker body update)
-- `gh issue create` (first-run rolling tracker)
+- `gh pr comment` (approval / major / blocked / `@dependabot rebase` /
+  marker comment)
+- `gh issue create` (per-run issue)
+- `gh issue edit` (delta-append on same-date re-runs, see
+  [Idempotency at the issue level](#idempotency-at-the-issue-level))
 - `gh label create` (first-run label setup)
 
 Reads (`gh pr list`, `gh pr view`, `gh pr diff`, `gh issue list`,
@@ -317,11 +414,13 @@ dumping.
 
 - `gh pr merge --auto` fails (network, perms) → retry once, then
   fall back to approval-comment. Append a footer note `auto-merge
-  retry failed: <err>` to the run comment.
-- `gh issue comment` on the rolling tracker fails → write the
-  intended comment body to `.dep-triage-cache/FAILED-comment-<run-id>.md`
-  and exit 1. Do NOT retry blindly. The cache dir is gitignored
-  (one-time setup, see README).
+  retry failed: <err>` to the run issue body.
+- `gh issue create` for the per-run issue fails → write the intended
+  body to `.dep-triage-cache/FAILED-issue-body-<run-id>.md` and exit 1.
+  Do NOT retry blindly. The cache dir is gitignored (one-time setup,
+  see README).
+- `gh label create` fails because the label already exists → ignore
+  and continue. Skip this call entirely in `DRY_RUN` mode.
 - Any `git`/`gh` command fails with auth → exit 1 with the verbatim
   error. Do not paper over it.
 - In `DRY_RUN` mode, do NOT write `FAILED-*.md` files. Dry runs
@@ -332,11 +431,12 @@ dumping.
 
 - Open PRs. The routine only comments + auto-merges existing
   Dependabot PRs. Never craft its own dependency-bump branch.
-- Edit `package.json` / `package-lock.json` / `examples/nurture-pet/
+- Edit `package.json` / `package-lock.json` / `examples/product-demo/
   package*.json` directly. Bumps come from Dependabot.
-- Post `Closes #N` / `Fixes #N` referencing the rolling tracker.
-- Comment on Dependabot PRs from a prior triaged head SHA (see
-  Idempotency).
+- Post `Closes #N` / `Fixes #N` referencing any `dep-triage-bot`
+  issue. Each per-run issue is a long-lived archive of its own run.
+- Comment on Dependabot PRs whose current head SHA already has a
+  `<!-- dep-triaged:<sha7>:* -->` marker (see Idempotency).
 - Touch `.changeset/*.md`. Dependency bumps don't get a changeset
   entry — they're chore-tier.
 - Bypass any of the Hard rules above to drain the queue faster.

--- a/docs/dep-triage-bot/PROMPT.md
+++ b/docs/dep-triage-bot/PROMPT.md
@@ -318,10 +318,28 @@ embedded at the top of the routine's per-PR comment body:
 
 ## Skip check (run at the start of every PR's iteration)
 
+The marker is **only trusted when authored by the routine's own bot
+account**. Any collaborator (or accidental copy/paste of an old
+comment) could otherwise inject a `<!-- dep-triaged:<sha7>:* -->`
+line into a human comment and silently suppress triage for that PR.
+The skip check therefore filters comment authors to `type == "Bot"`
+*and* a configured bot-login allowlist before reading the marker.
+
+Set `ROUTINE_BOT_LOGIN` at scheduler-config time to the GitHub
+account the routine posts as (the App login, e.g. `claude[bot]` or
+the org's automation account). The check fails loudly if it is not
+set so a misconfigured run cannot accidentally trust unsigned
+markers.
+
 ```bash
+: "${ROUTINE_BOT_LOGIN:?ROUTINE_BOT_LOGIN must be set to the bot account login the routine posts as}"
 HEAD_SHA7="$(gh pr view <pr> --json headRefOid --jq '.headRefOid[0:7]')"
-SKIP="$(gh pr view <pr> --json comments \
-  --jq --arg sha "${HEAD_SHA7}" '.comments[] | select(.body | startswith("<!-- dep-triaged:" + $sha + ":")) | .body' \
+SKIP="$(gh api "repos/<owner>/<repo>/issues/<pr>/comments" \
+  --jq --arg sha "${HEAD_SHA7}" --arg login "${ROUTINE_BOT_LOGIN}" \
+  '.[]
+   | select(.user.type == "Bot" and .user.login == $login)
+   | select(.body | startswith("<!-- dep-triaged:" + $sha + ":"))
+   | .body' \
   | head -n1)"
 if [ -n "${SKIP}" ]; then
   echo "Skip #<pr> — already triaged at ${HEAD_SHA7}: ${SKIP}"
@@ -329,9 +347,11 @@ if [ -n "${SKIP}" ]; then
 fi
 ```
 
-If the marker exists for the current head SHA, this PR was already
-triaged on a prior run with no Dependabot rebase since. Add it to the
-run footer's `Skipped` count and move on.
+If a marker for the current head SHA exists **and was authored by
+the routine's bot account**, this PR was already triaged on a prior
+run with no Dependabot rebase since. Add it to the run footer's
+`Skipped` count and move on. A marker authored by anyone else is
+ignored.
 
 ## Marker format on the Dependabot PR
 

--- a/docs/dep-triage-bot/PROMPT.md
+++ b/docs/dep-triage-bot/PROMPT.md
@@ -331,15 +331,21 @@ the org's automation account). The check fails loudly if it is not
 set so a misconfigured run cannot accidentally trust unsigned
 markers.
 
+`gh api` accepts only `--jq <string>` for filtering — it does not
+forward jq CLI flags such as `--arg`. Pipe the raw response to a
+standalone `jq` invocation so SHA + bot-login values can be passed
+in via `--arg` (which jq escapes safely, avoiding shell-quoting
+pitfalls in the filter string).
+
 ```bash
 : "${ROUTINE_BOT_LOGIN:?ROUTINE_BOT_LOGIN must be set to the bot account login the routine posts as}"
 HEAD_SHA7="$(gh pr view <pr> --json headRefOid --jq '.headRefOid[0:7]')"
 SKIP="$(gh api "repos/<owner>/<repo>/issues/<pr>/comments" \
-  --jq --arg sha "${HEAD_SHA7}" --arg login "${ROUTINE_BOT_LOGIN}" \
-  '.[]
-   | select(.user.type == "Bot" and .user.login == $login)
-   | select(.body | startswith("<!-- dep-triaged:" + $sha + ":"))
-   | .body' \
+  | jq -r --arg sha "${HEAD_SHA7}" --arg login "${ROUTINE_BOT_LOGIN}" \
+    '.[]
+     | select(.user.type == "Bot" and .user.login == $login)
+     | select(.body | startswith("<!-- dep-triaged:" + $sha + ":"))
+     | .body' \
   | head -n1)"
 if [ -n "${SKIP}" ]; then
   echo "Skip #<pr> — already triaged at ${HEAD_SHA7}: ${SKIP}"

--- a/docs/dep-triage-bot/README.md
+++ b/docs/dep-triage-bot/README.md
@@ -72,16 +72,25 @@ code-review bot.
       delta-append), and `contents:read` (clone + checkout PR
       branches). No `contents:write` — the routine never pushes a
       branch.
-- [ ] Set `ROUTINE_BOT_LOGIN` in the routine's env to the GitHub
-      login the routine posts as (e.g. `claude[bot]`, or whichever
-      App / automation account the org uses). The prompt's
+- [ ] Set `ROUTINE_GH_LOGIN` in the routine's env to the GitHub
+      login the routine actually posts as. Two common setups:
+      - **PAT-driven cloud routine** (e.g. Anthropic Cloud routine
+        running under your own Personal Access Token): set
+        `ROUTINE_GH_LOGIN=<your-github-username>` (the comments
+        will appear authored by that human user with
+        `user.type == "User"`).
+      - **GitHub App / dedicated bot account**: set
+        `ROUTINE_GH_LOGIN=<bot-login>` (e.g. `claude[bot]`).
+
+      The prompt's
       [Idempotency skip check](./PROMPT.md#skip-check-run-at-the-start-of-every-prs-iteration)
-      requires this to constrain the trusted-marker filter to
-      bot-authored comments only — without it, an unrelated
-      collaborator could inject a `<!-- dep-triaged:<sha7>:* -->`
-      line into a human comment and silently suppress triage for
-      that PR. The skip check exits non-zero if the env var is
-      unset.
+      uses this login as the trust boundary for accepting
+      `<!-- dep-triaged:<sha7>:* -->` markers. The check
+      deliberately does NOT constrain `user.type` — that would
+      silently disable triage idempotency on PAT-based runs. It
+      exits non-zero if the env var is unset, so a misconfigured
+      run cannot accidentally trust markers from arbitrary
+      commenters.
 - [ ] Confirm Dependabot is configured to group npm minor + patch
       updates per the `npm-non-major` blocks on both npm entries in
       [`.github/dependabot.yml`](../../.github/dependabot.yml).

--- a/docs/dep-triage-bot/README.md
+++ b/docs/dep-triage-bot/README.md
@@ -72,6 +72,16 @@ code-review bot.
       delta-append), and `contents:read` (clone + checkout PR
       branches). No `contents:write` — the routine never pushes a
       branch.
+- [ ] Set `ROUTINE_BOT_LOGIN` in the routine's env to the GitHub
+      login the routine posts as (e.g. `claude[bot]`, or whichever
+      App / automation account the org uses). The prompt's
+      [Idempotency skip check](./PROMPT.md#skip-check-run-at-the-start-of-every-prs-iteration)
+      requires this to constrain the trusted-marker filter to
+      bot-authored comments only — without it, an unrelated
+      collaborator could inject a `<!-- dep-triaged:<sha7>:* -->`
+      line into a human comment and silently suppress triage for
+      that PR. The skip check exits non-zero if the env var is
+      unset.
 - [ ] Confirm Dependabot is configured to group npm minor + patch
       updates per the `npm-non-major` blocks on both npm entries in
       [`.github/dependabot.yml`](../../.github/dependabot.yml).

--- a/docs/dep-triage-bot/README.md
+++ b/docs/dep-triage-bot/README.md
@@ -24,40 +24,43 @@ routine drains the **Dependabot PR pile**.
 
 ## Output sink
 
-**Single rolling issue** titled `Dependency triage — develop`, label
-`dep-triage-bot`. New comment per run; the issue body holds the
-canonical `Last triaged SHAs: …` mapping so the next run knows which
-PR head SHAs to skip.
+**One fresh issue per run.** Title `Dependency triage — YYYY-MM-DD`,
+label `dep-triage-bot`. The issue **body** holds the full per-run
+output: action counts, per-PR table, run footer. There is no rolling
+tracker; each run's issue is a self-contained punch list the owner
+closes manually once every blocked / major / approval-only row is
+resolved.
 
-Same shape as the daily `review-bot` rolling issue (`#87`) — long-
-lived, append-only, body holds canonical resume state. Different from
-`docs-review-bot` (which opens one issue per run).
+Same pattern as the refactored daily `review-bot` (issue per run,
+body holds findings) and `docs-review-bot` (issue per run, body
+holds drift checklist) — long-lived per-run archives, no append-to-
+shared-tracker step.
 
-If a run finds zero open Dependabot PRs, the routine appends a one-
-line `YYYY-MM-DD — no-op (no open Dependabot PRs)` comment to the
-rolling tracker and exits cleanly. Silence is the desired state.
+Per-PR triage state lives on the **Dependabot PR itself** as an HTML
+comment marker `<!-- dep-triaged:<head-sha7>:<action> -->` embedded
+at the top of the routine's per-PR comment body. The routine reads
+that marker on the next run to skip already-triaged PRs unless their
+head SHA has changed (e.g. via `@dependabot rebase`). See the
+prompt's [Idempotency](./PROMPT.md#idempotency) section for the
+exact skip-check shell snippet.
+
+If a run finds zero open Dependabot PRs, the routine does NOT open
+an issue. Quiet runs leave no trace — same convention as the daily
+code-review bot.
 
 ## Setup checklist (one-time)
 
-- [ ] Create the rolling issue `Dependency triage — develop`. Add
-      label `dep-triage-bot`. Seed the body with:
-
-      ```
-      Rolling tracker for the weekly `dep-triage-bot` cloud routine.
-
-      Last triaged SHAs: <none>
-      ```
-
-      (The prompt re-creates the label on first run if missing — this
-      just avoids the create call racing with the issue-open call.)
 - [ ] Add the `dep-triage-bot` label to the repo:
       ```bash
       gh label create dep-triage-bot --color FBCA04 \
         --description "Findings from the weekly dep-triage cloud routine"
       ```
+      (The prompt re-creates the label on first run if missing —
+      this just avoids the create call racing with the issue-open
+      call.)
 - [ ] Add `.dep-triage-cache/` to `.gitignore` (one line). The
-      routine writes a FAILED-comment body file there if the rolling
-      tracker comment-append fails so you can re-submit by hand.
+      routine writes a FAILED-issue-body file there if `gh issue
+      create` fails so you can re-submit by hand.
 - [ ] Enable auto-merge on the repo
       (`Settings → General → Pull Requests → Allow auto-merge`). The
       routine uses `gh pr merge --auto --squash` for the dev-deps
@@ -65,9 +68,10 @@ rolling tracker and exits cleanly. Silence is the desired state.
       approval-comment for every PR (still safe, just slower drain).
 - [ ] Verify the routine has the right GitHub token scopes:
       `pull-requests:write` (comment, merge --auto, label),
-      `issues:write` (rolling tracker comments + body edit), and
-      `contents:read` (clone + checkout PR branches). No
-      `contents:write` — the routine never pushes a branch.
+      `issues:write` (open per-run issue, edit on same-date
+      delta-append), and `contents:read` (clone + checkout PR
+      branches). No `contents:write` — the routine never pushes a
+      branch.
 - [ ] Confirm Dependabot is configured to group npm minor + patch
       updates per the `npm-non-major` blocks on both npm entries in
       [`.github/dependabot.yml`](../../.github/dependabot.yml).
@@ -76,12 +80,11 @@ rolling tracker and exits cleanly. Silence is the desired state.
       most of its value.
 - [ ] Dry-run once with `DRY_RUN=1` set in the routine's env. The
       prompt's Dry-run section guards every `gh pr merge`,
-      `gh pr comment`, `gh issue comment`, `gh issue edit`,
-      `gh issue create`, and `gh label create` call behind a
-      `DRY_RUN` check; in dry-run mode each is replaced by a stdout
-      dump of the would-be call + body. The `npm ci && npm run
-      verify` step still runs locally so verify-pass / verify-fail
-      signals are realistic.
+      `gh pr comment`, `gh issue create`, `gh issue edit`, and
+      `gh label create` call behind a `DRY_RUN` check; in dry-run
+      mode each is replaced by a stdout dump of the would-be call +
+      body. The `npm ci && npm run verify` step still runs locally
+      so verify-pass / verify-fail signals are realistic.
 
 ## Routine wrapper prompt (paste into the routine)
 
@@ -102,10 +105,11 @@ user message):
 >    to triage, the action policy table, hard rules, output format,
 >    persistence, and dry-run rules. Do not re-derive any of that
 >    from this message.
-> 3. After draining the queue and appending the per-run comment to
->    the rolling tracker (or posting the no-op comment), exit
->    cleanly. Do NOT open a PR. Do NOT push to any branch. Do NOT
->    edit any code, manifests, or lockfiles directly.
+> 3. After draining the queue and opening the per-run
+>    `dep-triage-bot` issue (or recognizing a no-op run with zero
+>    open Dependabot PRs and exiting cleanly without opening an
+>    issue), exit cleanly. Do NOT open a PR. Do NOT push to any
+>    branch. Do NOT edit any code, manifests, or lockfiles directly.
 >
 > If `docs/dep-triage-bot/PROMPT.md` does not exist on `develop` for
 > some reason, abort with a clear error — do not improvise a triage
@@ -127,11 +131,11 @@ reasonable cron in UTC:
   hour after Dependabot fires. Gives Dependabot time to actually
   finish opening PRs before the routine scans for them.
 
-The routine no-ops cleanly when there are no open Dependabot PRs, so
-over-scheduling is non-destructive — just noisy in the rolling
-tracker. If the queue stays empty for several weeks (Dependabot
-finds nothing to bump), the routine's runs are a one-line `no-op`
-comment per run; that's the desired silence.
+The routine no-ops cleanly when there are no open Dependabot PRs:
+no issue is opened, no marker comment is left, no PR is touched. If
+the queue stays empty for several weeks (Dependabot finds nothing
+to bump), the `dep-triage-bot` label view simply shows nothing new
+landing — that's the desired silence.
 
 ## Iteration workflow (changing the prompt)
 
@@ -174,15 +178,36 @@ rules, or output-format pain. To change it:
   prompt's [Triage policy](./PROMPT.md#triage-policy).
 - **Verify failures block silently from a CI perspective.** A
   blocked PR sits open with a comment; nothing flags the queue
-  health. Mitigation: weekly run footers always report `Blocked: N`
-  — non-zero N is the signal to triage manually.
+  health. Mitigation: every per-run issue's footer reports
+  `Blocked: N` — non-zero N is the signal to triage manually. The
+  `dep-triage-bot` label view groups every run's issues so the
+  backlog is one click away.
+- **Issue list grows over time.** Each run opens an issue. Close
+  each issue once every blocked / major / approval-only row it
+  carries is resolved. Closed issues drop out of the
+  `dep-triage-bot` label view automatically.
+
+## Bot label convention
+
+Each scheduled cloud routine in this repo owns a dedicated GitHub
+label so its issues group cleanly under one filter:
+
+| Routine                  | Label             |
+| ------------------------ | ----------------- |
+| `docs/review-bot/`       | `review-bot`      |
+| `docs/docs-review-bot/`  | `docs-review`     |
+| `docs/dep-triage-bot/`   | `dep-triage-bot`  |
+
+Each per-run issue carries exactly its routine's label — no
+cross-labelling, no shared `automation` umbrella label. Filter the
+issue list by label to see one routine's full history.
 
 ## Related
 
 - Sibling routines: `docs/review-bot/` (daily code review of
-  `develop` commits, dual sink: rolling issue `#87` + committed
-  daily docs), `docs/docs-review-bot/` (weekly docs-drift audit,
-  fresh issue per run).
+  `develop` commits, dual sink: per-run issue + committed daily
+  docs), `docs/docs-review-bot/` (weekly docs-drift audit, fresh
+  issue per run).
 - Dependabot config: [`.github/dependabot.yml`](../../.github/dependabot.yml)
   — the `npm-non-major` group blocks are what make this routine
   tractable. Without grouping, the queue is N PRs/week.

--- a/docs/plans/2026-04-26-quality-actions-bump-bot.md
+++ b/docs/plans/2026-04-26-quality-actions-bump-bot.md
@@ -49,12 +49,17 @@ Key sections:
    [`resolve_action_sha` helper](./2026-04-26-quality-automation-routines.md#resolve-an-action-tag--commit-sha-peel-aware-helper));
    never alter the trailing `# vX.Y.Z` comment without matching the
    bumped tag.
-5. **Output** — single PR per run, body lists each `(action, old SHA,
-   new SHA, version label)`. No-op runs: open a fresh tracker issue
-   `Action SHA bumps YYYY-MM-DD — <sha7>` (label
-   `actions-bump-bot`) noting the no-op, then exit.
-6. **Failure handling** — verify fails → close branch, open a
-   tracker issue noting the failure.
+5. **Output** — primary sink is a single PR per run, body lists
+   each `(action, old SHA, new SHA, version label)`. **No-op runs
+   leave no trace**: no PR, no issue, exit cleanly. Same convention
+   as the refactored daily review-bot.
+6. **Failure handling** — verify fails after applying bumps → close
+   the branch, open a fresh `Action SHA bumps YYYY-MM-DD — <sha7>`
+   issue (label `actions-bump-bot`) with the failure tail in the
+   body. The owner triages from the `actions-bump-bot` label view.
+   Failure issues are the only ones this routine opens — they group
+   under the dedicated label so a non-empty label view is always a
+   real signal.
 
 - [ ] **Step 3: Write `docs/actions-bump-bot/README.md`**
 

--- a/docs/plans/2026-04-26-quality-automation-routines.md
+++ b/docs/plans/2026-04-26-quality-automation-routines.md
@@ -37,9 +37,9 @@ five CI/cron jobs, three cloud-routine prompt directories.
   action-SHA bumps, plan reconciliation). Same shape as the existing
   `docs/review-bot/` and `docs/docs-review-bot/`.
 - **No core library changes.** All additions live under `.github/`,
-  `docs/`, `tests/determinism/`, and the demo workspace (currently
-  `examples/nurture-pet/`; see [Coordination with PR #129](#coordination-with-pr-129-demo-rename)).
-  No `src/**` edits. No changesets needed (tooling-only PRs).
+  `docs/`, `tests/determinism/`, and the demo workspace
+  (`examples/product-demo/`). No `src/**` edits. No changesets
+  needed (tooling-only PRs).
 
 ## Tech stack
 
@@ -57,44 +57,17 @@ five CI/cron jobs, three cloud-routine prompt directories.
 
 ---
 
-## Coordination with PR #129 (demo rename)
+## Coordination with PR #129 (demo rename) — RESOLVED
 
-PR [#129](https://github.com/Luis85/agentonomous/pull/129) is the
-umbrella tracker for the pre-v1 demo evolution increment. **Wave 0 of
-that increment is an atomic single-PR rename** of
-`examples/nurture-pet/` → `examples/product-demo/` (see
-`docs/plans/2026-04-26-pre-v1-demo-rename-preflight.md` once #129
-merges). The rename PR is responsible for sweeping every reference
-across the repo — scripts, GitHub Pages workflow, README, CI, and (if
-it lands after this increment's demo-smoke row) the Playwright wiring
-that row introduces.
-
-**Path policy across all chunk plans below:**
-
-| Section | What it uses today | After Wave 0 of #129 |
-| --- | --- | --- |
-| Demo-smoke chunk paths | `examples/nurture-pet/...` | `examples/product-demo/...` |
-| `.gitignore` rules touching the demo | `examples/nurture-pet/...` | `examples/product-demo/...` |
-
-**Sequencing rule (decide at the start of the demo-smoke row):**
-
-1. **If Wave 0 has merged into `develop` before the demo-smoke row
-   starts** — pull `develop`, resolve conflicts via
-   `git merge origin/develop` (NOT rebase, per
-   `MEMORY.md → feedback_parallel_pr_plan_conflicts.md`), then
-   substitute `examples/nurture-pet/` → `examples/product-demo/` in
-   every file that row creates or touches.
-2. **If Wave 0 has NOT merged before that row starts** — implement
-   verbatim against `examples/nurture-pet/`. The Wave 0 rename PR will
-   sweep this increment's additions the same way it sweeps every
-   other reference. Add a one-line note on the Wave 0 PR when it
-   opens calling out that this increment introduced new
-   `examples/nurture-pet/` paths so the sweep is complete.
-
-**Do not pre-rename in any chunk plan.** A single mechanical sed in
-the Wave 0 PR converges everything; pre-renaming half-and-half forces
-a manual reconciliation in two places and risks Codex re-flagging
-path mismatches between this plan and `develop` truth.
+> **Status (2026-04-26):** Wave 0 of PR #129 merged as
+> [#134](https://github.com/Luis85/agentonomous/pull/134). The
+> demo workspace lives at `examples/product-demo/` on `develop`.
+> Every chunk plan below now uses that path verbatim — no
+> pre-rename / post-rename sequencing logic remains.
+>
+> The original sequencing-rule section is preserved in git history
+> for context but no longer informs new work. Historical reading:
+> see `docs/archive/plans/2026-04-26-pre-v1-demo-rename-preflight.md`.
 
 ---
 
@@ -152,6 +125,31 @@ Every PR cut from a chunk plan above MUST:
 7. **Codex review** runs automatically on open. Address findings per
    `MEMORY.md → feedback_pr_codex_polling.md` /
    `feedback_codex_signal_endpoints.md`.
+
+### Cloud-routine output convention (rows 2–4 + any future routine)
+
+Any chunk that introduces a scheduled cloud routine (cron-driven
+agent, not a CI workflow) MUST follow the same output shape so
+issues stay groupable and discoverable:
+
+- **Dedicated GitHub label per routine.** No shared `automation`
+  umbrella label, no cross-labelling. Existing labels:
+  `review-bot`, `docs-review`, `dep-triage-bot`. Future rows pick
+  a label that matches their `docs/<bot-name>/` directory (e.g.
+  `actions-bump-bot`, `plan-recon-bot`).
+- **No rolling tracker issues.** Every issue the routine opens is
+  a fresh per-run issue carrying its own findings / failure
+  payload. The owner closes it once everything it lists is
+  resolved. The `<label>` view groups every run's issues for that
+  routine.
+- **Quiet runs leave no trace.** No-op runs do NOT open an issue.
+  An empty label view should mean "nothing happened recently",
+  not "the routine forgot to write".
+- **Per-run state on the artifact, not on a shared tracker.** When
+  a routine triages an external object (e.g. a Dependabot PR),
+  per-object state lives as a comment marker on that object, not
+  in a rolling tracker body. Pattern:
+  `<!-- <bot-name>:<head-sha7>:<action> -->`.
 
 > **Why one-PR-per-chunk now, not one giant PR?** Earlier drafts of
 > this plan bundled all eight rows on a single branch (#130). After
@@ -255,13 +253,11 @@ before continuing.
   uses pinned SHAs. After each chunk merges, the next
   `actions-bump-bot` run will attempt to bump them. That's expected
   — review that bump PR like any other.
-- **Demo rename in flight (PR #129 / Wave 0).** Demo-smoke chunk
-  paths point at `examples/nurture-pet/`. If Wave 0 of PR #129 lands
-  first, every demo-smoke path becomes `examples/product-demo/`.
-  Follow the chunk plan's first step to detect, then substitute
-  mechanically. Do NOT ship `examples/product-demo/` paths from a
-  chunk before Wave 0 has merged — the directory does not exist on
-  `develop` yet.
+- **Demo rename — RESOLVED.** Wave 0 of PR #129 merged as #134
+  on 2026-04-26; the demo lives at `examples/product-demo/` on
+  `develop`. The demo-smoke chunk plan was rewritten to use that
+  path verbatim. Historical sequencing rule retired (see
+  [Coordination with PR #129](#coordination-with-pr-129-demo-rename--resolved)).
 
 ---
 

--- a/docs/plans/2026-04-26-quality-demo-smoke.md
+++ b/docs/plans/2026-04-26-quality-demo-smoke.md
@@ -16,53 +16,40 @@ catches runtime regressions that typecheck + bundle don't (tfjs
 backend probe, `base` URL handling, vite HTML transform regressions
 — see `MEMORY.md → feedback_vite_html_transform`).
 
-## Coordination with PR #129 (demo rename)
+## Coordination with PR #129 (demo rename) — RESOLVED
 
-> **Demo path:** every `examples/nurture-pet/...` reference below
-> uses the pre-rename name. If Wave 0 of PR
-> [#129](https://github.com/Luis85/agentonomous/pull/129) has merged
-> into `develop` before this row starts, swap to
-> `examples/product-demo/...` everywhere (file paths, `cd` targets,
-> `working-directory` keys, `.gitignore` entries, `git add` lines).
-> See [Coordination with PR #129](./2026-04-26-quality-automation-routines.md#coordination-with-pr-129-demo-rename)
-> in the umbrella plan for the full decision rule.
+> Wave 0 of PR #129 merged as
+> [#134](https://github.com/Luis85/agentonomous/pull/134) on
+> 2026-04-26; the demo lives at `examples/product-demo/` on
+> `develop`. Every path below is the post-rename name verbatim — no
+> conditional sequencing remains. The umbrella's
+> [Coordination section](./2026-04-26-quality-automation-routines.md#coordination-with-pr-129-demo-rename--resolved)
+> is the historical reference.
 
 ## Files
 
-- Create: `examples/nurture-pet/playwright.config.ts`
-- Create: `examples/nurture-pet/tests/smoke/golden-path.spec.ts`
+- Create: `examples/product-demo/playwright.config.ts`
+- Create: `examples/product-demo/tests/smoke/golden-path.spec.ts`
 - Create: `.github/workflows/demo-smoke.yml`
-- Modify: `examples/nurture-pet/package.json` — devDep + script
+- Modify: `examples/product-demo/package.json` — devDep + script
 - Modify: `.gitignore`
 
 ## Steps
 
-- [ ] **Step 0: Decide demo path before doing anything else**
-
-```bash
-git fetch origin
-git ls-tree --name-only origin/develop examples/ | sort
-```
-
-If the listing contains `product-demo` (and not `nurture-pet`),
-Wave 0 has landed — substitute the path everywhere in this row
-before running any subsequent step. If the listing still contains
-`nurture-pet`, proceed verbatim and ping the Wave 0 PR when it opens.
-
 - [ ] **Step 1: Add Playwright to the demo**
 
 ```bash
-cd examples/nurture-pet
+cd examples/product-demo
 npm install --save-dev --save-exact @playwright/test@latest
 npx playwright install --with-deps chromium
 cd -
 ```
 
-Pin `@playwright/test` in `examples/nurture-pet/package.json`. Do
+Pin `@playwright/test` in `examples/product-demo/package.json`. Do
 NOT add it to the root `package.json` — the demo manages its own
 deps (`MEMORY.md` notes the `file:../..` EISDIR pitfall on Windows).
 
-- [ ] **Step 2: `examples/nurture-pet/playwright.config.ts`**
+- [ ] **Step 2: `examples/product-demo/playwright.config.ts`**
 
 ```ts
 import { defineConfig, devices } from '@playwright/test';
@@ -136,7 +123,7 @@ Just build the demo synchronously first, then hand control to
 playwright:
 
 ```bash
-cd examples/nurture-pet
+cd examples/product-demo
 npm run build
 npx playwright test --headed --project=chromium
 cd -
@@ -153,7 +140,7 @@ Iterate on selectors until the spec passes. **If the demo lacks
 stable testids on the HUD, add them in this same row** (not a
 separate PR; the smoke depends on them).
 
-- [ ] **Step 5: Add script to `examples/nurture-pet/package.json`**
+- [ ] **Step 5: Add script to `examples/product-demo/package.json`**
 
 ```json
 "smoke": "playwright test"
@@ -162,8 +149,8 @@ separate PR; the smoke depends on them).
 - [ ] **Step 6: Update `.gitignore`**
 
 ```
-examples/nurture-pet/playwright-report/
-examples/nurture-pet/test-results/
+examples/product-demo/playwright-report/
+examples/product-demo/test-results/
 ```
 
 - [ ] **Step 7: Workflow**
@@ -179,7 +166,7 @@ on:
     - cron: '30 3 * * *'   # Daily 03:30 UTC
   pull_request:
     paths:
-      - 'examples/nurture-pet/**'
+      - 'examples/product-demo/**'
       - 'src/**'           # library changes can break demo at runtime
       - '.github/workflows/demo-smoke.yml'
   workflow_dispatch:
@@ -198,22 +185,22 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Install demo deps
-        working-directory: examples/nurture-pet
+        working-directory: examples/product-demo
         run: npm ci --no-audit --no-fund
       - name: Install Playwright browsers
-        working-directory: examples/nurture-pet
+        working-directory: examples/product-demo
         run: npx playwright install --with-deps chromium
       - name: Build demo
-        working-directory: examples/nurture-pet
+        working-directory: examples/product-demo
         run: npm run build
       - name: Smoke (Playwright)
-        working-directory: examples/nurture-pet
+        working-directory: examples/product-demo
         run: npm run smoke
       - uses: actions/upload-artifact@<sha> # v5.0.0
         if: failure()
         with:
           name: playwright-report
-          path: examples/nurture-pet/playwright-report/
+          path: examples/product-demo/playwright-report/
           retention-days: 14
 ```
 
@@ -222,16 +209,16 @@ jobs:
 ```bash
 docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color .github/workflows/demo-smoke.yml
 npm run verify
-( cd examples/nurture-pet && npm run smoke )
+( cd examples/product-demo && npm run smoke )
 ```
 
 - [ ] **Step 9: Commit + push + open PR**
 
 ```bash
-git add examples/nurture-pet/playwright.config.ts \
-        examples/nurture-pet/tests/ \
-        examples/nurture-pet/package.json \
-        examples/nurture-pet/package-lock.json \
+git add examples/product-demo/playwright.config.ts \
+        examples/product-demo/tests/ \
+        examples/product-demo/package.json \
+        examples/product-demo/package-lock.json \
         .github/workflows/demo-smoke.yml \
         .gitignore
 git commit -m "test(demo): nightly Playwright smoke on golden path"
@@ -243,7 +230,7 @@ Tracks: #131
 
 Adds Playwright headless smoke against the built demo: feed → pet →
 sleep, asserts HUD updates and zero console errors. Runs nightly at
-03:30 UTC + on PRs that touch examples/nurture-pet/, src/, or this
+03:30 UTC + on PRs that touch examples/product-demo/, src/, or this
 workflow file. Failed runs upload the playwright-report artifact.
 
 Ticks row 8 of the umbrella tracker."
@@ -258,20 +245,14 @@ Ticks row 8 of the umbrella tracker."
 
 ## Acceptance criteria
 
-- `npm run smoke` (from `examples/nurture-pet/`) passes locally.
+- `npm run smoke` (from `examples/product-demo/`) passes locally.
 - The CI smoke run on PR open is green.
 - `.github/workflows/demo-smoke.yml` is actionlint-clean.
 - Tracker row 8 is `[x]`.
 
-## Rename-coordination follow-up
+## Rename-coordination — RESOLVED
 
-If Wave 0 of PR #129 has NOT yet merged when this PR opens:
-
-1. Add a comment on the Wave 0 PR (whichever PR is the live rename
-   PR at that time) listing the new `examples/nurture-pet/` paths
-   this PR introduces, so the rename PR's sweep covers them.
-2. After Wave 0 merges, do not open a follow-up PR to rename — the
-   Wave 0 PR is responsible.
-
-If Wave 0 has already merged before this PR opens, this PR uses
-`examples/product-demo/` from the start and there is no follow-up.
+Wave 0 of PR #129 merged as
+[#134](https://github.com/Luis85/agentonomous/pull/134) on
+2026-04-26. This row uses `examples/product-demo/` paths verbatim;
+no follow-up rename PR is needed.

--- a/docs/plans/2026-04-26-quality-dep-triage-bot.md
+++ b/docs/plans/2026-04-26-quality-dep-triage-bot.md
@@ -41,7 +41,7 @@ separate ones.
 
 ```yaml
 # Example shape — adapt to existing keys verbatim. Apply to BOTH the
-# root `npm` entry and the `examples/nurture-pet` entry if both exist.
+# root `npm` entry and the `examples/product-demo` entry if both exist.
 - package-ecosystem: "npm"
   directory: "/"
   schedule:

--- a/docs/plans/2026-04-26-quality-plan-recon-bot.md
+++ b/docs/plans/2026-04-26-quality-plan-recon-bot.md
@@ -59,14 +59,18 @@ Sections:
 3. **Hard rules** — never delete plan content; only `git mv`.
    Preserve the date prefix. Never archive a plan that has open rows
    or whose tracker issue is still labelled `in-progress`.
-4. **Output** — open one PR per run with archive moves, body lists
-   each `(plan, last shipped row, archive reason)`. No moves needed:
-   open a fresh tracker issue
-   `Plan reconciliation YYYY-MM-DD — <sha7>` (label
-   `plan-recon-bot`) noting the no-op, then exit.
-5. **Failure handling** — same pattern as the other routines (one
-   issue per run, never push direct to `develop`, body notes the
-   failure).
+4. **Output** — primary sink is one PR per run with archive moves,
+   body lists each `(plan, last shipped row, archive reason)`. **No
+   moves needed → no PR, no issue, exit cleanly.** Same "quiet runs
+   leave no trace" convention as the refactored review-bot,
+   docs-review-bot, and dep-triage-bot.
+5. **Failure handling** — `git mv` fails / verify fails / archive
+   parse breaks → open a fresh
+   `Plan reconciliation YYYY-MM-DD — <sha7>` issue (label
+   `plan-recon-bot`) with the failure tail in the body. Never push
+   direct to `develop`. Failure issues are the only ones this
+   routine opens — they group under the dedicated label so a
+   non-empty label view is always a real signal.
 
 - [ ] **Step 3: Write `docs/plan-recon-bot/README.md`**
 


### PR DESCRIPTION
Tracks: #131

## What changed

The dep-triage-bot prompt landed in #136 with a rolling-tracker pattern (`Dependency triage — develop`, append-comment-per-run, `Last triaged SHAs` mapping in the body). The daily code-review bot has since refactored to issue-per-run (#135) — this PR brings dep-triage-bot in line, and promotes the convention to the umbrella so every future cloud routine inherits it.

### Convention applied

- **Dedicated GitHub label per routine.** No shared `automation` umbrella label.
- **Issue per run.** Body holds the run's full punch list. Owner closes manually once everything in the body is resolved.
- **Quiet runs leave no trace.** No-op runs do NOT open an issue.
- **Per-object state on the artifact, not on a shared tracker.** For dep-triage that means an HTML comment marker `<!-- dep-triaged:<head-sha7>:<action> -->` on the Dependabot PR itself, read at the start of the next run for skip detection.

### Files

- `docs/dep-triage-bot/PROMPT.md` — replaced rolling-tracker output, idempotency, and process-gate sections with issue-per-run + per-PR-comment-marker. Hard-rules + dry-run + failure-handling sections updated to match.
- `docs/dep-triage-bot/README.md` — output sink description, setup checklist, tradeoffs, and a new "Bot label convention" table mapping each routine to its label.
- `docs/plans/2026-04-26-quality-automation-routines.md` (umbrella) — added a new "Cloud-routine output convention" subsection under "Downstream PR contract" so rows 3+ inherit the rule. Updated row 3 + row 4 chunk plans inline so their PRs follow it: no-op leaves no trace, only failures open a labelled per-run issue.
- `docs/plans/2026-04-26-quality-actions-bump-bot.md` — output / failure-handling sections rewritten to the new convention.
- `docs/plans/2026-04-26-quality-plan-recon-bot.md` — same.

### Demo-path sweep (Wave 0 of #129 / merged as #134)

The Wave-0 rename of `examples/nurture-pet/` → `examples/product-demo/` merged on 2026-04-26 (commit `c734d6a`). This PR sweeps the lingering `examples/nurture-pet/` references in the active quality plans + the dep-triage-bot prompt so the chunk plans + cloud routine all point at the post-rename path:

- `docs/dep-triage-bot/PROMPT.md` — three references swapped; the now-stale Wave-0 sequencing conditional dropped.
- `docs/plans/2026-04-26-quality-automation-routines.md` — "Coordination with PR #129" section condensed to a `RESOLVED` stub linking to #134; risk-register row updated.
- `docs/plans/2026-04-26-quality-dep-triage-bot.md` — example-shape comment swapped.
- `docs/plans/2026-04-26-quality-demo-smoke.md` — every path swapped; the "Step 0: Decide demo path" pre-flight + the "Rename-coordination follow-up" footer collapsed to a one-paragraph `RESOLVED` stub.

Other lingering `nurture-pet` references live in archived plans, code JSDoc, and one test file — those are out of scope for this PR (separate cleanup-sweep follow-up if the owner wants the codebase fully aligned).

### Labels created in repo

```
gh label create dep-triage-bot   --color FBCA04 --description "Per-run findings from the weekly dep-triage cloud routine"
gh label create actions-bump-bot --color D93F0B --description "Failure issues from the weekly actions-bump cloud routine"
gh label create plan-recon-bot   --color 1D76DB --description "Failure issues from the monthly plan-recon cloud routine"
```

`review-bot` and `docs-review` were already in place.

## Verification

- `npm run verify` — green locally.
- Doc-only diff (no `src/**`, no changeset).
- No `dep-triage-bot` issues exist yet, so there is no rolling-tracker issue to retire — this lands the convention for the routine's first real run.