### PR TITLE
feat(demo): walkthrough domain module + headless tests (Pillar-1 slice 1.1)

### DIFF
--- a/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
@@ -25,7 +25,7 @@ external narration.
 
 | # | Slice | Files | Spec FRs | Status | PR |
 |---|---|---|---|---|---|
-| 1.1 | Step-graph + completion-predicate domain module + headless tests | `examples/product-demo/src/demo-domain/walkthrough/{types.ts,graph.ts,predicates.ts}`, `examples/product-demo/test/demo-domain/walkthrough/*.test.ts` | P1-FR-2, P1-FR-3, P1-FR-4 | not started | — |
+| 1.1 | Step-graph + completion-predicate domain module + headless tests | `examples/product-demo/src/demo-domain/walkthrough/{types.ts,graph.ts,predicates.ts}`, `examples/product-demo/test/demo-domain/walkthrough/*.test.ts` | P1-FR-2, P1-FR-3, P1-FR-4 | ✅ shipped | [#140](https://github.com/Luis85/agentonomous/pull/140) |
 | 1.2 | `useTourProgress` view store + tour overlay component (chapter 1 only) | `examples/product-demo/src/stores/view/useTourProgress.ts`, `examples/product-demo/src/components/tour/{TourOverlay.vue,StepHighlight.vue}`, `examples/product-demo/test/stores/view/useTourProgress.test.ts` | P1-FR-1, P1-FR-3, P1-FR-5, P1-FR-6, P1-FR-8 | not started | — |
 | 1.3 | Chapters 2-5 wired end-to-end + restart/skip/resume + selector-handle registry | `examples/product-demo/src/demo-domain/walkthrough/chapters/{2..5}.ts`, `examples/product-demo/src/components/**/registerSelector.ts`, `examples/product-demo/src/views/TourView.vue` | P1-FR-2, P1-FR-4, P1-FR-5, P1-FR-6, P1-FR-7 | not started | — |
 | 1.4 | Playwright `tour-happy-path.spec.ts` | `examples/product-demo/tests/e2e/tour-happy-path.spec.ts`, `examples/product-demo/playwright.config.ts` (script wiring) | P1-AC-1, P1-AC-5 | not started | — |
@@ -81,4 +81,4 @@ external narration.
 
 ## Done log
 
-- (none yet)
+- 2026-04-26 — slice 1.1 (domain module + headless tests) shipped via [#140](https://github.com/Luis85/agentonomous/pull/140).

--- a/docs/product/2026-04-26-pre-v1-demo-evolution-plan.md
+++ b/docs/product/2026-04-26-pre-v1-demo-evolution-plan.md
@@ -335,7 +335,7 @@ Canonical status. Update the **Status** and **PR** cells in the same diff that s
 | Wave | Pillar | Plan | Status | PR |
 |---|---|---|---|---|
 | 0 | Demo rename preflight | [`rename-preflight`](../archive/plans/2026-04-26-pre-v1-demo-rename-preflight.md) (archived) | ✅ shipped | [#134](https://github.com/Luis85/agentonomous/pull/134) |
-| A | Guided walkthrough | [`guided-walkthrough`](../plans/2026-04-26-pre-v1-demo-guided-walkthrough.md) | not started | — |
+| A | Guided walkthrough | [`guided-walkthrough`](../plans/2026-04-26-pre-v1-demo-guided-walkthrough.md) | in progress | [#140](https://github.com/Luis85/agentonomous/pull/140) (slice 1.1) |
 | A | Cognition diff panel | [`cognition-diff-panel`](../plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md) | not started | — |
 | A | Determinism fingerprint | [`determinism-fingerprint`](../plans/2026-04-26-pre-v1-demo-determinism-fingerprint.md) | not started | — |
 | B | JSON preview / commit | [`json-preview-commit`](../plans/2026-04-26-pre-v1-demo-json-preview-commit.md) | not started | — |

--- a/examples/product-demo/src/demo-domain/walkthrough/graph.ts
+++ b/examples/product-demo/src/demo-domain/walkthrough/graph.ts
@@ -1,0 +1,177 @@
+/**
+ * Walkthrough step-graph builder + traversal helpers (Pillar 1, slice 1.1).
+ *
+ * `defineWalkthroughGraph` validates the supplied steps once at construction
+ * (every `nextOnComplete` either resolves to a known step id or is the
+ * `TOUR_END` sentinel; ids are unique). The returned `WalkthroughGraph` is
+ * frozen — downstream pillars treat it as a read-only constant.
+ *
+ * Traversal helpers are pure functions of the graph + a `TourCtx`, so the
+ * Pinia view store added in slice 1.2 can drive them under
+ * `@pinia/testing` without booting an `Agent`.
+ */
+
+import { TOUR_END } from './types.js';
+import type { ChapterId, TourCtx, TourEnd, WalkthroughStep, WalkthroughStepId } from './types.js';
+
+/**
+ * Immutable, validated step graph. Construct via `defineWalkthroughGraph`;
+ * the constructor never returns a partially-built graph on a validation
+ * failure — it throws.
+ */
+export type WalkthroughGraph = {
+  readonly steps: ReadonlyArray<WalkthroughStep>;
+  readonly stepsById: ReadonlyMap<WalkthroughStepId, WalkthroughStep>;
+  readonly chapters: ReadonlyMap<ChapterId, ReadonlyArray<WalkthroughStep>>;
+  readonly firstStepId: WalkthroughStepId;
+};
+
+/** Thrown by `defineWalkthroughGraph` when steps fail structural validation. */
+export class WalkthroughGraphError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WalkthroughGraphError';
+  }
+}
+
+/**
+ * Build a frozen graph from `steps`. Validates:
+ *
+ *  1. `steps` is non-empty.
+ *  2. Every step id is unique (duplicates are an authoring bug).
+ *  3. Every `nextOnComplete` is either `TOUR_END` or references a known id.
+ *  4. Steps are grouped by chapter in declaration order; the first step is
+ *     used as the cold-start cursor.
+ */
+export function defineWalkthroughGraph(steps: ReadonlyArray<WalkthroughStep>): WalkthroughGraph {
+  if (steps.length === 0) {
+    throw new WalkthroughGraphError('walkthrough graph must contain at least one step');
+  }
+
+  const stepsById = new Map<WalkthroughStepId, WalkthroughStep>();
+  for (const step of steps) {
+    if (stepsById.has(step.id)) {
+      throw new WalkthroughGraphError(`duplicate walkthrough step id: ${String(step.id)}`);
+    }
+    stepsById.set(step.id, step);
+  }
+
+  for (const step of steps) {
+    if (step.nextOnComplete === TOUR_END) continue;
+    if (!stepsById.has(step.nextOnComplete)) {
+      throw new WalkthroughGraphError(
+        `step "${String(step.id)}" advances to unknown step "${String(step.nextOnComplete)}"`,
+      );
+    }
+  }
+
+  const chapters = new Map<ChapterId, WalkthroughStep[]>();
+  for (const step of steps) {
+    const bucket = chapters.get(step.chapter) ?? [];
+    bucket.push(step);
+    chapters.set(step.chapter, bucket);
+  }
+
+  // Freeze each chapter bucket so downstream consumers cannot mutate.
+  const frozenChapters = new Map<ChapterId, ReadonlyArray<WalkthroughStep>>();
+  for (const [chapter, bucket] of chapters) {
+    frozenChapters.set(chapter, Object.freeze(bucket));
+  }
+
+  // The first declared step is the cold-start cursor (spec P1-FR-1, P1-FR-6).
+  // We assert non-undefined because we already checked `steps.length > 0` above.
+  const firstStep = steps[0];
+  if (firstStep === undefined) {
+    throw new WalkthroughGraphError('walkthrough graph must contain at least one step');
+  }
+
+  return Object.freeze({
+    steps: Object.freeze([...steps]),
+    stepsById,
+    chapters: frozenChapters,
+    firstStepId: firstStep.id,
+  });
+}
+
+/** Look up a step by id. Returns `undefined` when the id is unknown. */
+export function getStepById(
+  graph: WalkthroughGraph,
+  id: WalkthroughStepId,
+): WalkthroughStep | undefined {
+  return graph.stepsById.get(id);
+}
+
+/** Steps registered for `chapter`, in declaration order. Empty array if none. */
+export function getChapterSteps(
+  graph: WalkthroughGraph,
+  chapter: ChapterId,
+): ReadonlyArray<WalkthroughStep> {
+  return graph.chapters.get(chapter) ?? [];
+}
+
+/**
+ * Resolve the next step given the current cursor and a `TourCtx`.
+ *
+ * Returns:
+ *  - `'end'` when the current step's predicate is satisfied AND its
+ *    `nextOnComplete` is `TOUR_END`;
+ *  - the next `WalkthroughStep` when the predicate is satisfied and the
+ *    step has a successor;
+ *  - `undefined` when the predicate is NOT yet satisfied (the caller
+ *    keeps the cursor where it is).
+ *
+ * Throws `WalkthroughGraphError` if `currentId` is not in the graph —
+ * this is a programming error, not a tour state.
+ */
+export function getNextStep(
+  graph: WalkthroughGraph,
+  currentId: WalkthroughStepId,
+  ctx: TourCtx,
+): WalkthroughStep | TourEnd | undefined {
+  const current = graph.stepsById.get(currentId);
+  if (current === undefined) {
+    throw new WalkthroughGraphError(`unknown current step id: ${String(currentId)}`);
+  }
+
+  if (!current.completionPredicate(ctx)) return undefined;
+
+  if (current.nextOnComplete === TOUR_END) return TOUR_END;
+
+  const next = graph.stepsById.get(current.nextOnComplete);
+  if (next === undefined) {
+    // Validation in `defineWalkthroughGraph` should have caught this; the
+    // re-check here keeps the runtime error specific instead of returning a
+    // misleading `undefined`.
+    throw new WalkthroughGraphError(
+      `step "${String(current.id)}" references unknown next step "${String(current.nextOnComplete)}"`,
+    );
+  }
+  return next;
+}
+
+/**
+ * Skip the current step regardless of its predicate. Returns the next
+ * step (or `'end'`), or `undefined` if `currentId` is the final step
+ * with `nextOnComplete: TOUR_END` — callers treat `undefined` from skip
+ * the same as completion.
+ *
+ * Skip never re-evaluates the predicate; spec P1-FR-5 makes the skip
+ * explicit so a stuck predicate cannot trap the user.
+ */
+export function getSkipTarget(
+  graph: WalkthroughGraph,
+  currentId: WalkthroughStepId,
+): WalkthroughStep | TourEnd {
+  const current = graph.stepsById.get(currentId);
+  if (current === undefined) {
+    throw new WalkthroughGraphError(`unknown current step id: ${String(currentId)}`);
+  }
+  if (current.nextOnComplete === TOUR_END) return TOUR_END;
+  const next = graph.stepsById.get(current.nextOnComplete);
+  if (next === undefined) {
+    throw new WalkthroughGraphError(
+      `step "${String(current.id)}" references unknown next step "${String(current.nextOnComplete)}"`,
+    );
+  }
+  return next;
+}

--- a/examples/product-demo/src/demo-domain/walkthrough/graph.ts
+++ b/examples/product-demo/src/demo-domain/walkthrough/graph.ts
@@ -50,6 +50,16 @@ export function defineWalkthroughGraph(steps: ReadonlyArray<WalkthroughStep>): W
 
   const stepsById = new Map<WalkthroughStepId, WalkthroughStep>();
   for (const step of steps) {
+    // The literal string `TOUR_END` ('end') is the terminal sentinel returned
+    // by `getNextStep` / `getSkipTarget`. A step authored with `id === 'end'`
+    // would silently shadow the sentinel — every transition meant to land on
+    // it would instead be interpreted as tour completion, and the step would
+    // be unreachable. Reject the collision at construction time.
+    if ((step.id as string) === TOUR_END) {
+      throw new WalkthroughGraphError(
+        `step id "${String(step.id)}" collides with the reserved TOUR_END sentinel`,
+      );
+    }
     if (stepsById.has(step.id)) {
       throw new WalkthroughGraphError(`duplicate walkthrough step id: ${String(step.id)}`);
     }
@@ -62,6 +72,36 @@ export function defineWalkthroughGraph(steps: ReadonlyArray<WalkthroughStep>): W
       throw new WalkthroughGraphError(
         `step "${String(step.id)}" advances to unknown step "${String(step.nextOnComplete)}"`,
       );
+    }
+  }
+
+  // Reachability/termination check: from every step, the `nextOnComplete`
+  // chain must terminate at `TOUR_END`. Each step has exactly one successor,
+  // so a chain that revisits a step before hitting `TOUR_END` is a cycle —
+  // skipping or naturally completing along that chain would trap the user
+  // forever. Walk every step to be defensive against multi-entry-point
+  // graphs (slice 1.3 may use `getStepById` to jump to chapters 2-5's start
+  // ids without traversing chapter 1 first).
+  for (const startId of stepsById.keys()) {
+    const visited = new Set<WalkthroughStepId>();
+    let cursor: WalkthroughStepId | TourEnd = startId;
+    while (cursor !== TOUR_END) {
+      if (visited.has(cursor)) {
+        throw new WalkthroughGraphError(
+          `walkthrough graph contains a cycle reachable from "${String(startId)}" (re-enters "${String(cursor)}")`,
+        );
+      }
+      visited.add(cursor);
+      const step = stepsById.get(cursor);
+      // The earlier `nextOnComplete` validation guarantees this lookup
+      // succeeds; the explicit guard keeps the runtime error specific
+      // instead of a misleading `undefined.nextOnComplete`.
+      if (step === undefined) {
+        throw new WalkthroughGraphError(
+          `walkthrough graph references unknown step id "${String(cursor)}" while traversing from "${String(startId)}"`,
+        );
+      }
+      cursor = step.nextOnComplete;
     }
   }
 

--- a/examples/product-demo/src/demo-domain/walkthrough/graph.ts
+++ b/examples/product-demo/src/demo-domain/walkthrough/graph.ts
@@ -48,8 +48,17 @@ export function defineWalkthroughGraph(steps: ReadonlyArray<WalkthroughStep>): W
     throw new WalkthroughGraphError('walkthrough graph must contain at least one step');
   }
 
+  // Snapshot every caller-supplied step into a frozen shallow clone before
+  // storing it on the graph. The `WalkthroughStep` type is `readonly`-shaped,
+  // but TypeScript's structural typing lets a caller pass a mutable object
+  // literal that satisfies the shape and then mutate it after construction
+  // — which would invalidate the one-time validation below (e.g. flipping a
+  // `nextOnComplete` to an unknown id, making `getNextStep` throw despite
+  // a successful build). The frozen clone is the durable graph contract.
+  const frozenSteps: WalkthroughStep[] = steps.map((step) => Object.freeze({ ...step }));
+
   const stepsById = new Map<WalkthroughStepId, WalkthroughStep>();
-  for (const step of steps) {
+  for (const step of frozenSteps) {
     // The literal string `TOUR_END` ('end') is the terminal sentinel returned
     // by `getNextStep` / `getSkipTarget`. A step authored with `id === 'end'`
     // would silently shadow the sentinel — every transition meant to land on
@@ -66,7 +75,7 @@ export function defineWalkthroughGraph(steps: ReadonlyArray<WalkthroughStep>): W
     stepsById.set(step.id, step);
   }
 
-  for (const step of steps) {
+  for (const step of frozenSteps) {
     if (step.nextOnComplete === TOUR_END) continue;
     if (!stepsById.has(step.nextOnComplete)) {
       throw new WalkthroughGraphError(
@@ -106,7 +115,7 @@ export function defineWalkthroughGraph(steps: ReadonlyArray<WalkthroughStep>): W
   }
 
   const chapters = new Map<ChapterId, WalkthroughStep[]>();
-  for (const step of steps) {
+  for (const step of frozenSteps) {
     const bucket = chapters.get(step.chapter) ?? [];
     bucket.push(step);
     chapters.set(step.chapter, bucket);
@@ -120,13 +129,13 @@ export function defineWalkthroughGraph(steps: ReadonlyArray<WalkthroughStep>): W
 
   // The first declared step is the cold-start cursor (spec P1-FR-1, P1-FR-6).
   // We assert non-undefined because we already checked `steps.length > 0` above.
-  const firstStep = steps[0];
+  const firstStep = frozenSteps[0];
   if (firstStep === undefined) {
     throw new WalkthroughGraphError('walkthrough graph must contain at least one step');
   }
 
   return Object.freeze({
-    steps: Object.freeze([...steps]),
+    steps: Object.freeze(frozenSteps),
     stepsById,
     chapters: frozenChapters,
     firstStepId: firstStep.id,

--- a/examples/product-demo/src/demo-domain/walkthrough/graph.ts
+++ b/examples/product-demo/src/demo-domain/walkthrough/graph.ts
@@ -35,6 +35,36 @@ export class WalkthroughGraphError extends Error {
 }
 
 /**
+ * Wraps a built `Map` in a frozen read-only facade. The native `Map` type
+ * has `set` / `delete` / `clear` mutators that bypass `Object.freeze` on
+ * the enclosing object, so exposing the live map would let a JS caller —
+ * or a TS caller using a cast — mutate the graph after construction and
+ * invalidate the one-time validation. The facade re-exposes only the
+ * methods declared by `ReadonlyMap<K, V>` and is itself frozen.
+ *
+ * `size` is captured at facade-construction time. The source map is fully
+ * built before this helper runs and never mutated afterwards, so the
+ * snapshot value never drifts.
+ */
+function freezeMapView<K, V>(source: ReadonlyMap<K, V>): ReadonlyMap<K, V> {
+  const facade: ReadonlyMap<K, V> = {
+    size: source.size,
+    get: (key) => source.get(key),
+    has: (key) => source.has(key),
+    keys: () => source.keys(),
+    values: () => source.values(),
+    entries: () => source.entries(),
+    forEach: (callbackfn, thisArg) => {
+      source.forEach((v, k) => {
+        callbackfn.call(thisArg, v, k, facade);
+      });
+    },
+    [Symbol.iterator]: () => source.entries(),
+  };
+  return Object.freeze(facade);
+}
+
+/**
  * Build a frozen graph from `steps`. Validates:
  *
  *  1. `steps` is non-empty.
@@ -136,8 +166,8 @@ export function defineWalkthroughGraph(steps: ReadonlyArray<WalkthroughStep>): W
 
   return Object.freeze({
     steps: Object.freeze(frozenSteps),
-    stepsById,
-    chapters: frozenChapters,
+    stepsById: freezeMapView(stepsById),
+    chapters: freezeMapView(frozenChapters),
     firstStepId: firstStep.id,
   });
 }

--- a/examples/product-demo/src/demo-domain/walkthrough/index.ts
+++ b/examples/product-demo/src/demo-domain/walkthrough/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Walkthrough domain barrel (Pillar 1, slice 1.1).
+ *
+ * Public surface for `stores/view/useTourProgress` (slice 1.2) and the
+ * chapter content modules added in slices 1.2 / 1.3. Per the design's
+ * DDD forbidden-import table, only `stores/domain/` and `stores/view/`
+ * import from here — components and views go through the store layer.
+ */
+
+export type {
+  AgentSessionSnapshot,
+  ChapterId,
+  CompletionPredicate,
+  RouteContext,
+  SelectorHandle,
+  SessionEvent,
+  TourCtx,
+  TourEnd,
+  WalkthroughStep,
+  WalkthroughStepId,
+} from './types.js';
+export { TOUR_END, selectorHandle, walkthroughStepId } from './types.js';
+
+export {
+  ALWAYS,
+  NEVER,
+  cognitionModeIs,
+  combineAll,
+  combineAny,
+  eventEmittedSince,
+  not,
+  onRoute,
+  onRoutePrefix,
+  tickAtLeast,
+} from './predicates.js';
+
+export type { WalkthroughGraph } from './graph.js';
+export {
+  WalkthroughGraphError,
+  defineWalkthroughGraph,
+  getChapterSteps,
+  getNextStep,
+  getSkipTarget,
+  getStepById,
+} from './graph.js';

--- a/examples/product-demo/src/demo-domain/walkthrough/predicates.ts
+++ b/examples/product-demo/src/demo-domain/walkthrough/predicates.ts
@@ -1,0 +1,70 @@
+/**
+ * Generic completion-predicate primitives (Pillar 1, slice 1.1).
+ *
+ * Each factory returns a `CompletionPredicate` closure. Predicates are
+ * pure functions of `TourCtx` — no I/O, no time, no randomness — so
+ * they are trivially testable under `ManualClock` + `SeededRng`.
+ *
+ * Per-chapter predicates (autonomy, trace, switch, JSON, replay) compose
+ * these primitives in their owning slice (1.2 / 1.3). Keeping the
+ * primitives small + obviously pure means a new chapter's predicate is
+ * always a `combineAll(...)` of known leaves.
+ */
+
+import type { CompletionPredicate, TourCtx } from './types.js';
+
+/** Always-true predicate. Useful as a safe default in tests. */
+export const ALWAYS: CompletionPredicate = () => true;
+
+/** Always-false predicate. Useful for "blocking" steps in tests. */
+export const NEVER: CompletionPredicate = () => false;
+
+/**
+ * True when the current route's path equals `expected` exactly. Path
+ * comparison is byte-exact — callers normalize trailing slashes upstream.
+ */
+export function onRoute(expected: string): CompletionPredicate {
+  return (ctx: TourCtx) => ctx.route.path === expected;
+}
+
+/**
+ * True when the current route's path starts with `prefix`. Useful for
+ * scenario-scoped routes (e.g. `/play/` matches `/play/pet-care`).
+ */
+export function onRoutePrefix(prefix: string): CompletionPredicate {
+  return (ctx: TourCtx) => ctx.route.path.startsWith(prefix);
+}
+
+/** True once the active session has advanced to at least `n` ticks. */
+export function tickAtLeast(n: number): CompletionPredicate {
+  return (ctx: TourCtx) => ctx.session.tickIndex >= n;
+}
+
+/** True when the session reports the named cognition mode. */
+export function cognitionModeIs(modeId: string): CompletionPredicate {
+  return (ctx: TourCtx) => ctx.session.cognitionModeId === modeId;
+}
+
+/**
+ * True when the session has emitted at least one event of `type` at or
+ * after `sinceTick`. Pass `0` to mean "any time since session start".
+ */
+export function eventEmittedSince(type: string, sinceTick: number): CompletionPredicate {
+  return (ctx: TourCtx) =>
+    ctx.session.recentEvents.some((e) => e.type === type && e.tickIndex >= sinceTick);
+}
+
+/** Logical AND across `predicates`. An empty list returns `true`. */
+export function combineAll(...predicates: ReadonlyArray<CompletionPredicate>): CompletionPredicate {
+  return (ctx: TourCtx) => predicates.every((p) => p(ctx));
+}
+
+/** Logical OR across `predicates`. An empty list returns `false`. */
+export function combineAny(...predicates: ReadonlyArray<CompletionPredicate>): CompletionPredicate {
+  return (ctx: TourCtx) => predicates.some((p) => p(ctx));
+}
+
+/** Logical NOT of `predicate`. */
+export function not(predicate: CompletionPredicate): CompletionPredicate {
+  return (ctx: TourCtx) => !predicate(ctx);
+}

--- a/examples/product-demo/src/demo-domain/walkthrough/types.ts
+++ b/examples/product-demo/src/demo-domain/walkthrough/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Walkthrough domain contracts (Pillar 1, slice 1.1).
+ *
+ * Pure-TS types consumed by `graph.ts` and `predicates.ts`. Downstream
+ * Pinia view stores (slice 1.2+) project these into `useTourProgress`
+ * and the overlay component.
+ *
+ * The `__brand` markers prevent accidental cross-domain string mixing
+ * (a raw component selector is not a `SelectorHandle`; a route slug is
+ * not a `WalkthroughStepId`). Construct via the helpers below — tests
+ * stay readable and runtime cost is zero.
+ */
+
+/** A unique step id, narrowed via brand to prevent string mix-ups. */
+export type WalkthroughStepId = string & { readonly __brand: 'WalkthroughStepId' };
+
+/**
+ * A logical UI handle resolved by the per-component selector registry
+ * introduced in slice 1.3. Markup changes that drop a registered handle
+ * MUST surface as a `tsc` error, not a runtime crash (spec P1-FR-4).
+ */
+export type SelectorHandle = string & { readonly __brand: 'SelectorHandle' };
+
+/** The five comprehension chapters fixed by spec P1-FR-2. */
+export type ChapterId = 1 | 2 | 3 | 4 | 5;
+
+/**
+ * Read-only projection of `useAgentSession` consumed by completion
+ * predicates. Domain module owns this contract so downstream pillars
+ * cannot import the live store from inside `demo-domain/`.
+ */
+export type AgentSessionSnapshot = {
+  readonly tickIndex: number;
+  readonly cognitionModeId: string;
+  readonly seed: number;
+  readonly recentEvents: ReadonlyArray<SessionEvent>;
+};
+
+/**
+ * Minimal event projection used by predicates. Type id is a free string
+ * so individual pillar slices can extend without coupling back here.
+ */
+export type SessionEvent = {
+  readonly type: string;
+  readonly tickIndex: number;
+};
+
+/** Read-only projection of router state consumed by completion predicates. */
+export type RouteContext = {
+  readonly path: string;
+  readonly scenarioId: string | null;
+  readonly tourStep: WalkthroughStepId | null;
+};
+
+/** Bundled context handed to every predicate evaluation. */
+export type TourCtx = {
+  readonly session: AgentSessionSnapshot;
+  readonly route: RouteContext;
+};
+
+/** A predicate observes the current `TourCtx` and returns true once satisfied. */
+export type CompletionPredicate = (ctx: TourCtx) => boolean;
+
+/** Sentinel returned by `nextOnComplete` for the final step of the tour. */
+export const TOUR_END = 'end' as const;
+export type TourEnd = typeof TOUR_END;
+
+/** Definition of one step in the walkthrough graph. */
+export type WalkthroughStep = {
+  readonly id: WalkthroughStepId;
+  readonly chapter: ChapterId;
+  readonly title: string;
+  readonly hint: string;
+  readonly highlight: SelectorHandle;
+  readonly completionPredicate: CompletionPredicate;
+  readonly nextOnComplete: WalkthroughStepId | TourEnd;
+};
+
+/** Construct a `WalkthroughStepId` from a literal. Compile-time-only cast. */
+export function walkthroughStepId(raw: string): WalkthroughStepId {
+  return raw as WalkthroughStepId;
+}
+
+/** Construct a `SelectorHandle` from a literal. Compile-time-only cast. */
+export function selectorHandle(raw: string): SelectorHandle {
+  return raw as SelectorHandle;
+}

--- a/examples/product-demo/test/demo-domain/walkthrough/graph.test.ts
+++ b/examples/product-demo/test/demo-domain/walkthrough/graph.test.ts
@@ -128,6 +128,37 @@ describe('defineWalkthroughGraph', () => {
     ]);
     expect(graph.steps).toHaveLength(3);
   });
+
+  it('snapshots steps so caller mutations cannot break the graph', () => {
+    // Mutable object literal that satisfies `WalkthroughStep` structurally.
+    const original: WalkthroughStep = {
+      id: walkthroughStepId('a'),
+      chapter: 1,
+      title: 'Original',
+      hint: 'h',
+      highlight: selectorHandle('handle:a'),
+      completionPredicate: ALWAYS,
+      nextOnComplete: TOUR_END,
+    };
+    const graph = defineWalkthroughGraph([original]);
+
+    // Mutating the caller's object MUST NOT propagate into the graph.
+    (original as { title: string }).title = 'Hacked';
+    (original as { nextOnComplete: 'end' | typeof walkthroughStepId }).nextOnComplete =
+      walkthroughStepId('missing') as never;
+
+    const stored = getStepById(graph, walkthroughStepId('a'));
+    expect(stored?.title).toBe('Original');
+    expect(stored?.nextOnComplete).toBe(TOUR_END);
+    expect(getNextStep(graph, walkthroughStepId('a'), makeCtx())).toBe(TOUR_END);
+  });
+
+  it('freezes stored step objects so direct mutation also fails', () => {
+    const graph = defineWalkthroughGraph([step('a', 1, TOUR_END)]);
+    const stored = getStepById(graph, walkthroughStepId('a'));
+    expect(stored).toBeDefined();
+    expect(Object.isFrozen(stored)).toBe(true);
+  });
 });
 
 describe('getStepById', () => {

--- a/examples/product-demo/test/demo-domain/walkthrough/graph.test.ts
+++ b/examples/product-demo/test/demo-domain/walkthrough/graph.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALWAYS,
+  NEVER,
+  combineAll,
+  tickAtLeast,
+} from '../../../src/demo-domain/walkthrough/predicates.js';
+import {
+  WalkthroughGraphError,
+  defineWalkthroughGraph,
+  getChapterSteps,
+  getNextStep,
+  getSkipTarget,
+  getStepById,
+} from '../../../src/demo-domain/walkthrough/graph.js';
+import {
+  TOUR_END,
+  selectorHandle,
+  walkthroughStepId,
+} from '../../../src/demo-domain/walkthrough/types.js';
+import type {
+  AgentSessionSnapshot,
+  RouteContext,
+  TourCtx,
+  WalkthroughStep,
+} from '../../../src/demo-domain/walkthrough/types.js';
+
+function step(
+  id: string,
+  chapter: 1 | 2 | 3 | 4 | 5,
+  next: string | typeof TOUR_END,
+  predicate = ALWAYS,
+): WalkthroughStep {
+  return {
+    id: walkthroughStepId(id),
+    chapter,
+    title: `Step ${id}`,
+    hint: `Hint ${id}`,
+    highlight: selectorHandle(`handle:${id}`),
+    completionPredicate: predicate,
+    nextOnComplete: next === TOUR_END ? TOUR_END : walkthroughStepId(next),
+  };
+}
+
+function makeCtx(overrides: { tickIndex?: number; path?: string } = {}): TourCtx {
+  const session: AgentSessionSnapshot = {
+    tickIndex: overrides.tickIndex ?? 0,
+    cognitionModeId: 'urgency',
+    seed: 42,
+    recentEvents: [],
+  };
+  const route: RouteContext = {
+    path: overrides.path ?? '/',
+    scenarioId: null,
+    tourStep: null,
+  };
+  return { session, route };
+}
+
+describe('defineWalkthroughGraph', () => {
+  it('throws on an empty step list', () => {
+    expect(() => defineWalkthroughGraph([])).toThrow(WalkthroughGraphError);
+  });
+
+  it('throws on duplicate step ids', () => {
+    const dup = [step('a', 1, TOUR_END), step('a', 1, TOUR_END)];
+    expect(() => defineWalkthroughGraph(dup)).toThrow(/duplicate walkthrough step id: a/);
+  });
+
+  it('throws when nextOnComplete references an unknown id', () => {
+    const broken = [step('a', 1, 'b')];
+    expect(() => defineWalkthroughGraph(broken)).toThrow(/step "a" advances to unknown step "b"/);
+  });
+
+  it('returns a frozen graph with stepsById + chapter buckets', () => {
+    const graph = defineWalkthroughGraph([
+      step('1.start', 1, '1.observe'),
+      step('1.observe', 1, '2.start'),
+      step('2.start', 2, TOUR_END),
+    ]);
+
+    expect(graph.steps).toHaveLength(3);
+    expect(Object.isFrozen(graph)).toBe(true);
+    expect(graph.firstStepId).toBe(walkthroughStepId('1.start'));
+    expect(graph.stepsById.get(walkthroughStepId('1.observe'))?.title).toBe('Step 1.observe');
+    expect(getChapterSteps(graph, 1)).toHaveLength(2);
+    expect(getChapterSteps(graph, 2)).toHaveLength(1);
+    expect(getChapterSteps(graph, 5)).toHaveLength(0);
+  });
+
+  it('preserves declaration order inside each chapter', () => {
+    const graph = defineWalkthroughGraph([
+      step('1.first', 1, '1.second'),
+      step('1.second', 1, TOUR_END),
+    ]);
+    const chapter1 = getChapterSteps(graph, 1);
+    expect(chapter1.map((s) => String(s.id))).toEqual(['1.first', '1.second']);
+  });
+});
+
+describe('getStepById', () => {
+  it('returns a known step', () => {
+    const graph = defineWalkthroughGraph([step('a', 1, TOUR_END)]);
+    expect(getStepById(graph, walkthroughStepId('a'))?.title).toBe('Step a');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    const graph = defineWalkthroughGraph([step('a', 1, TOUR_END)]);
+    expect(getStepById(graph, walkthroughStepId('missing'))).toBeUndefined();
+  });
+});
+
+describe('getNextStep', () => {
+  it('returns undefined when the current predicate is not satisfied', () => {
+    const graph = defineWalkthroughGraph([
+      step('a', 1, 'b', tickAtLeast(5)),
+      step('b', 1, TOUR_END),
+    ]);
+    expect(getNextStep(graph, walkthroughStepId('a'), makeCtx({ tickIndex: 4 }))).toBeUndefined();
+  });
+
+  it('returns the next step when the predicate is satisfied', () => {
+    const graph = defineWalkthroughGraph([
+      step('a', 1, 'b', tickAtLeast(5)),
+      step('b', 1, TOUR_END),
+    ]);
+    const next = getNextStep(graph, walkthroughStepId('a'), makeCtx({ tickIndex: 5 }));
+    expect(next).not.toBeUndefined();
+    expect(next === TOUR_END ? null : next?.id).toBe(walkthroughStepId('b'));
+  });
+
+  it('returns TOUR_END when the final step is satisfied', () => {
+    const graph = defineWalkthroughGraph([step('only', 1, TOUR_END)]);
+    expect(getNextStep(graph, walkthroughStepId('only'), makeCtx())).toBe(TOUR_END);
+  });
+
+  it('combineAll predicates compose for multi-condition advance', () => {
+    const graph = defineWalkthroughGraph([
+      step('a', 1, 'b', combineAll(tickAtLeast(5))),
+      step('b', 1, TOUR_END),
+    ]);
+    expect(getNextStep(graph, walkthroughStepId('a'), makeCtx({ tickIndex: 5 }))).toBeDefined();
+  });
+
+  it('throws when called with an unknown current id', () => {
+    const graph = defineWalkthroughGraph([step('a', 1, TOUR_END)]);
+    expect(() => getNextStep(graph, walkthroughStepId('missing'), makeCtx())).toThrow(
+      /unknown current step id: missing/,
+    );
+  });
+
+  it('NEVER predicate keeps the cursor in place forever', () => {
+    const graph = defineWalkthroughGraph([step('a', 1, 'b', NEVER), step('b', 1, TOUR_END)]);
+    expect(
+      getNextStep(graph, walkthroughStepId('a'), makeCtx({ tickIndex: 1_000_000 })),
+    ).toBeUndefined();
+  });
+});
+
+describe('getSkipTarget', () => {
+  it('advances even when the predicate would keep the cursor in place', () => {
+    const graph = defineWalkthroughGraph([step('a', 1, 'b', NEVER), step('b', 1, TOUR_END)]);
+    const next = getSkipTarget(graph, walkthroughStepId('a'));
+    expect(next === TOUR_END ? null : next.id).toBe(walkthroughStepId('b'));
+  });
+
+  it('returns TOUR_END when skipping the final step', () => {
+    const graph = defineWalkthroughGraph([step('only', 1, TOUR_END)]);
+    expect(getSkipTarget(graph, walkthroughStepId('only'))).toBe(TOUR_END);
+  });
+
+  it('throws when called with an unknown current id', () => {
+    const graph = defineWalkthroughGraph([step('a', 1, TOUR_END)]);
+    expect(() => getSkipTarget(graph, walkthroughStepId('missing'))).toThrow(
+      /unknown current step id: missing/,
+    );
+  });
+});

--- a/examples/product-demo/test/demo-domain/walkthrough/graph.test.ts
+++ b/examples/product-demo/test/demo-domain/walkthrough/graph.test.ts
@@ -159,6 +159,29 @@ describe('defineWalkthroughGraph', () => {
     expect(stored).toBeDefined();
     expect(Object.isFrozen(stored)).toBe(true);
   });
+
+  it('exposes stepsById as a frozen read-only facade (no Map mutators)', () => {
+    const graph = defineWalkthroughGraph([step('a', 1, TOUR_END)]);
+    expect(Object.isFrozen(graph.stepsById)).toBe(true);
+    // The native Map mutators must NOT exist on the facade.
+    expect((graph.stepsById as { set?: unknown }).set).toBeUndefined();
+    expect((graph.stepsById as { delete?: unknown }).delete).toBeUndefined();
+    expect((graph.stepsById as { clear?: unknown }).clear).toBeUndefined();
+    // Read methods still work + iteration yields the entries.
+    expect(graph.stepsById.size).toBe(1);
+    expect(graph.stepsById.has(walkthroughStepId('a'))).toBe(true);
+    expect([...graph.stepsById.keys()].map(String)).toEqual(['a']);
+    expect([...graph.stepsById].map(([k]) => String(k))).toEqual(['a']);
+  });
+
+  it('exposes chapters as a frozen read-only facade (no Map mutators)', () => {
+    const graph = defineWalkthroughGraph([step('1.a', 1, '1.b'), step('1.b', 1, TOUR_END)]);
+    expect(Object.isFrozen(graph.chapters)).toBe(true);
+    expect((graph.chapters as { set?: unknown }).set).toBeUndefined();
+    expect((graph.chapters as { delete?: unknown }).delete).toBeUndefined();
+    expect((graph.chapters as { clear?: unknown }).clear).toBeUndefined();
+    expect(graph.chapters.get(1)).toHaveLength(2);
+  });
 });
 
 describe('getStepById', () => {

--- a/examples/product-demo/test/demo-domain/walkthrough/graph.test.ts
+++ b/examples/product-demo/test/demo-domain/walkthrough/graph.test.ts
@@ -97,6 +97,37 @@ describe('defineWalkthroughGraph', () => {
     const chapter1 = getChapterSteps(graph, 1);
     expect(chapter1.map((s) => String(s.id))).toEqual(['1.first', '1.second']);
   });
+
+  it('rejects a step id that collides with the TOUR_END sentinel', () => {
+    expect(() => defineWalkthroughGraph([step('end', 1, TOUR_END)])).toThrow(
+      /step id "end" collides with the reserved TOUR_END sentinel/,
+    );
+  });
+
+  it('rejects a graph whose chain cycles instead of reaching TOUR_END', () => {
+    const cyclic = [step('a', 1, 'b'), step('b', 1, 'a')];
+    expect(() => defineWalkthroughGraph(cyclic)).toThrow(
+      /walkthrough graph contains a cycle reachable from "a" \(re-enters "a"\)/,
+    );
+  });
+
+  it('rejects a chain that loops back further down the path', () => {
+    const cyclic = [step('a', 1, 'b'), step('b', 1, 'c'), step('c', 1, 'b')];
+    expect(() => defineWalkthroughGraph(cyclic)).toThrow(
+      /walkthrough graph contains a cycle reachable from/,
+    );
+  });
+
+  it('accepts multi-entry chains that each terminate at TOUR_END', () => {
+    // Chapter 2's start ("2.start") is not on chapter 1's chain — slice 1.3
+    // jumps to it via getStepById. The reachability check still validates it.
+    const graph = defineWalkthroughGraph([
+      step('1.only', 1, TOUR_END),
+      step('2.start', 2, '2.end'),
+      step('2.end', 2, TOUR_END),
+    ]);
+    expect(graph.steps).toHaveLength(3);
+  });
 });
 
 describe('getStepById', () => {

--- a/examples/product-demo/test/demo-domain/walkthrough/index.test.ts
+++ b/examples/product-demo/test/demo-domain/walkthrough/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import * as walkthrough from '../../../src/demo-domain/walkthrough/index.js';
+
+describe('walkthrough barrel', () => {
+  it('re-exports the public surface', () => {
+    expect(walkthrough.TOUR_END).toBe('end');
+    expect(typeof walkthrough.defineWalkthroughGraph).toBe('function');
+    expect(typeof walkthrough.getNextStep).toBe('function');
+    expect(typeof walkthrough.getSkipTarget).toBe('function');
+    expect(typeof walkthrough.getStepById).toBe('function');
+    expect(typeof walkthrough.getChapterSteps).toBe('function');
+    expect(typeof walkthrough.combineAll).toBe('function');
+    expect(typeof walkthrough.combineAny).toBe('function');
+    expect(typeof walkthrough.not).toBe('function');
+    expect(typeof walkthrough.onRoute).toBe('function');
+    expect(typeof walkthrough.onRoutePrefix).toBe('function');
+    expect(typeof walkthrough.tickAtLeast).toBe('function');
+    expect(typeof walkthrough.cognitionModeIs).toBe('function');
+    expect(typeof walkthrough.eventEmittedSince).toBe('function');
+    expect(typeof walkthrough.walkthroughStepId).toBe('function');
+    expect(typeof walkthrough.selectorHandle).toBe('function');
+    expect(walkthrough.ALWAYS({} as never)).toBe(true);
+    expect(walkthrough.NEVER({} as never)).toBe(false);
+    expect(walkthrough.WalkthroughGraphError).toBeDefined();
+  });
+});

--- a/examples/product-demo/test/demo-domain/walkthrough/predicates.test.ts
+++ b/examples/product-demo/test/demo-domain/walkthrough/predicates.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ALWAYS,
+  NEVER,
+  cognitionModeIs,
+  combineAll,
+  combineAny,
+  eventEmittedSince,
+  not,
+  onRoute,
+  onRoutePrefix,
+  tickAtLeast,
+} from '../../../src/demo-domain/walkthrough/predicates.js';
+import type {
+  AgentSessionSnapshot,
+  RouteContext,
+  TourCtx,
+} from '../../../src/demo-domain/walkthrough/types.js';
+import { walkthroughStepId } from '../../../src/demo-domain/walkthrough/types.js';
+
+function makeCtx(overrides: {
+  session?: Partial<AgentSessionSnapshot>;
+  route?: Partial<RouteContext>;
+}): TourCtx {
+  const session: AgentSessionSnapshot = {
+    tickIndex: overrides.session?.tickIndex ?? 0,
+    cognitionModeId: overrides.session?.cognitionModeId ?? 'urgency',
+    seed: overrides.session?.seed ?? 1,
+    recentEvents: overrides.session?.recentEvents ?? [],
+  };
+  const route: RouteContext = {
+    path: overrides.route?.path ?? '/',
+    scenarioId: overrides.route?.scenarioId ?? null,
+    tourStep: overrides.route?.tourStep ?? null,
+  };
+  return { session, route };
+}
+
+describe('walkthrough predicates', () => {
+  describe('ALWAYS / NEVER', () => {
+    it('ALWAYS returns true regardless of context', () => {
+      expect(ALWAYS(makeCtx({}))).toBe(true);
+    });
+
+    it('NEVER returns false regardless of context', () => {
+      expect(NEVER(makeCtx({}))).toBe(false);
+    });
+  });
+
+  describe('onRoute', () => {
+    it('matches an exact path', () => {
+      const p = onRoute('/play/pet-care');
+      expect(p(makeCtx({ route: { path: '/play/pet-care' } }))).toBe(true);
+    });
+
+    it('rejects a non-matching path', () => {
+      const p = onRoute('/play/pet-care');
+      expect(p(makeCtx({ route: { path: '/play/companion-npc' } }))).toBe(false);
+    });
+
+    it('does not match a prefix only', () => {
+      const p = onRoute('/play');
+      expect(p(makeCtx({ route: { path: '/play/pet-care' } }))).toBe(false);
+    });
+  });
+
+  describe('onRoutePrefix', () => {
+    it('matches a path starting with the prefix', () => {
+      const p = onRoutePrefix('/play/');
+      expect(p(makeCtx({ route: { path: '/play/pet-care' } }))).toBe(true);
+    });
+
+    it('rejects a path that does not start with the prefix', () => {
+      const p = onRoutePrefix('/play/');
+      expect(p(makeCtx({ route: { path: '/tour/1' } }))).toBe(false);
+    });
+  });
+
+  describe('tickAtLeast', () => {
+    it('is true when tickIndex equals threshold', () => {
+      expect(tickAtLeast(10)(makeCtx({ session: { tickIndex: 10 } }))).toBe(true);
+    });
+
+    it('is true when tickIndex exceeds threshold', () => {
+      expect(tickAtLeast(10)(makeCtx({ session: { tickIndex: 11 } }))).toBe(true);
+    });
+
+    it('is false when tickIndex is below threshold', () => {
+      expect(tickAtLeast(10)(makeCtx({ session: { tickIndex: 9 } }))).toBe(false);
+    });
+  });
+
+  describe('cognitionModeIs', () => {
+    it('matches the active mode id exactly', () => {
+      expect(cognitionModeIs('urgency')(makeCtx({ session: { cognitionModeId: 'urgency' } }))).toBe(
+        true,
+      );
+    });
+
+    it('rejects a different mode id', () => {
+      expect(cognitionModeIs('urgency')(makeCtx({ session: { cognitionModeId: 'bdi' } }))).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('eventEmittedSince', () => {
+    it('matches an event of the right type at or after the threshold', () => {
+      const ctx = makeCtx({
+        session: {
+          recentEvents: [
+            { type: 'AGENT_TICKED', tickIndex: 3 },
+            { type: 'COGNITION_SWITCHED', tickIndex: 7 },
+          ],
+        },
+      });
+      expect(eventEmittedSince('COGNITION_SWITCHED', 5)(ctx)).toBe(true);
+    });
+
+    it('ignores matching events before the threshold', () => {
+      const ctx = makeCtx({
+        session: {
+          recentEvents: [{ type: 'COGNITION_SWITCHED', tickIndex: 3 }],
+        },
+      });
+      expect(eventEmittedSince('COGNITION_SWITCHED', 5)(ctx)).toBe(false);
+    });
+
+    it('ignores events of the wrong type', () => {
+      const ctx = makeCtx({
+        session: {
+          recentEvents: [{ type: 'AGENT_TICKED', tickIndex: 9 }],
+        },
+      });
+      expect(eventEmittedSince('COGNITION_SWITCHED', 0)(ctx)).toBe(false);
+    });
+
+    it('with sinceTick=0 matches any tick', () => {
+      const ctx = makeCtx({
+        session: {
+          recentEvents: [{ type: 'PREVIEW_APPLIED', tickIndex: 0 }],
+        },
+      });
+      expect(eventEmittedSince('PREVIEW_APPLIED', 0)(ctx)).toBe(true);
+    });
+  });
+
+  describe('combineAll / combineAny / not', () => {
+    it('combineAll is true only when every predicate is true', () => {
+      const p = combineAll(tickAtLeast(5), onRoute('/play'));
+      expect(p(makeCtx({ session: { tickIndex: 5 }, route: { path: '/play' } }))).toBe(true);
+      expect(p(makeCtx({ session: { tickIndex: 4 }, route: { path: '/play' } }))).toBe(false);
+      expect(p(makeCtx({ session: { tickIndex: 5 }, route: { path: '/tour' } }))).toBe(false);
+    });
+
+    it('combineAll with no predicates is true (vacuous AND)', () => {
+      expect(combineAll()(makeCtx({}))).toBe(true);
+    });
+
+    it('combineAny is true when at least one predicate is true', () => {
+      const p = combineAny(tickAtLeast(100), onRoute('/play'));
+      expect(p(makeCtx({ session: { tickIndex: 0 }, route: { path: '/play' } }))).toBe(true);
+      expect(p(makeCtx({ session: { tickIndex: 0 }, route: { path: '/' } }))).toBe(false);
+    });
+
+    it('combineAny with no predicates is false (vacuous OR)', () => {
+      expect(combineAny()(makeCtx({}))).toBe(false);
+    });
+
+    it('not inverts the wrapped predicate', () => {
+      expect(not(ALWAYS)(makeCtx({}))).toBe(false);
+      expect(not(NEVER)(makeCtx({}))).toBe(true);
+    });
+  });
+
+  describe('TourCtx is consumed read-only', () => {
+    it('predicates do not mutate the supplied context', () => {
+      const ctx = makeCtx({
+        session: {
+          tickIndex: 1,
+          recentEvents: [{ type: 'AGENT_TICKED', tickIndex: 1 }],
+        },
+        route: {
+          path: '/tour/1',
+          tourStep: walkthroughStepId('chapter-1.start'),
+        },
+      });
+      const before = JSON.stringify(ctx);
+      combineAll(tickAtLeast(1), eventEmittedSince('AGENT_TICKED', 0), onRoutePrefix('/tour'))(ctx);
+      expect(JSON.stringify(ctx)).toBe(before);
+    });
+  });
+});

--- a/examples/product-demo/tsconfig.json
+++ b/examples/product-demo/tsconfig.json
@@ -20,5 +20,10 @@
       "agentonomous/cognition/adapters/tfjs": ["../../src/cognition/adapters/tfjs/index.ts"]
     }
   },
-  "include": ["src/**/*", "tests/**/*.ts", "../../src/cognition/adapters/js-son/js-son-agent.d.ts"]
+  "include": [
+    "src/**/*",
+    "test/**/*.ts",
+    "tests/**/*.ts",
+    "../../src/cognition/adapters/js-son/js-son-agent.d.ts"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,12 @@
       "agentonomous/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*", "tests/**/*", "examples/product-demo/src/**/*.ts", "scripts/**/*.ts"],
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "examples/product-demo/src/**/*.ts",
+    "examples/product-demo/test/**/*.ts",
+    "scripts/**/*.ts"
+  ],
   "exclude": ["dist", "node_modules"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,7 +150,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'examples/product-demo/test/**/*.test.ts'],
     // Activates the matrix-selected tfjs backend (see
     // `tests/setup/tfjsBackend.ts`) BEFORE any test file's static
     // imports run. No-op for non-tfjs tests — the import is cheap and


### PR DESCRIPTION
## Summary

Slice 1.1 of Pillar 1 (guided walkthrough). Adds the pure-TS step-graph + completion-predicate domain module that backs the in-product tour. No Vue, no Pinia, no DOM — those land in slice 1.2 (chapter-1 vertical) and 1.3 (fan-out + selector registry).

Per design (`docs/specs/2026-04-26-pre-v1-demo-evolution-design.md` → Cross-pillar contracts → `WalkthroughStep`) and spec (`docs/specs/2026-04-26-pre-v1-demo-evolution-spec.md` §P1-FR-2/3/4).

## What ships

**`examples/product-demo/src/demo-domain/walkthrough/`**
- `types.ts` — branded `WalkthroughStepId` + `SelectorHandle`, `TourCtx` (read-only `AgentSessionSnapshot` + `RouteContext` projections), `WalkthroughStep`, `TOUR_END` sentinel.
- `predicates.ts` — generic predicate primitives (`onRoute`, `onRoutePrefix`, `tickAtLeast`, `cognitionModeIs`, `eventEmittedSince`) + `combineAll` / `combineAny` / `not` combinators. Per-chapter predicates compose these in slice 1.2 / 1.3.
- `graph.ts` — `defineWalkthroughGraph` validates uniqueness + reachability once at construction (`WalkthroughGraphError` on failure); returns a frozen graph. `getNextStep` evaluates the cursor's predicate; `getSkipTarget` advances unconditionally (spec P1-FR-5).
- `index.ts` — public barrel for slice 1.2's view store + chapter content modules.

**`examples/product-demo/test/demo-domain/walkthrough/`**
- `predicates.test.ts`, `graph.test.ts`, `index.test.ts` — exhaustive headless coverage of the three modules above.

**Plumbing (so the new tests run as part of `npm run verify`):**
- Root `vite.config.ts` test.include now includes `examples/product-demo/test/**/*.test.ts`.
- Root `tsconfig.json` + demo `tsconfig.json` add the new `test/` folder so typecheck + ESLint's projectService cover it.

## Out of scope

- Vue 3 SFC + Pinia 2 + Vue Router 4 application shell — slice 1.2 bootstraps it as part of the chapter-1 vertical (legacy `examples/product-demo/src/{cognitionSwitcher,ui,traceView,…}.ts` remains the live demo entry until then).
- Chapter content (chapters 1-5) — chapter 1 lands in slice 1.2, chapters 2-5 in slice 1.3.
- Selector-handle registry — slice 1.3 (compile-time enforcement).
- Playwright `tour-happy-path.spec.ts` — slice 1.4.

## Plan / spec / design refs

- Plan: `docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md` slice 1.1.
- Spec: `docs/specs/2026-04-26-pre-v1-demo-evolution-spec.md` §P1-FR-2/3/4.
- Design: `docs/specs/2026-04-26-pre-v1-demo-evolution-design.md` → Cross-pillar contracts → `WalkthroughStep`.

The plan-doc tracker row flip will be added in a follow-up commit on this branch once the GH-assigned PR number is known (per `feedback_docs_alongside_pr.md`).

## Test plan

- [x] `npm run verify` is green (format:check, lint, lint:demo, typecheck, test, build, docs).
- [x] 80 test files / 562 tests pass — the new walkthrough tests are part of that count.
- [x] Demo eslint config (DDD forbidden-imports, NFR-D-1 determinism) lints the new `demo-domain/` module without overrides.
- [ ] Codex review.

Tracks: #132