### PR TITLE
ci(metrics): weekly bundle-size trend snapshot

### DIFF
--- a/.github/workflows/bundle-size-trend.yml
+++ b/.github/workflows/bundle-size-trend.yml
@@ -47,5 +47,20 @@ jobs:
           if [[ -n "$(git status --porcelain docs/metrics/bundle-trend.jsonl)" ]]; then
             git add docs/metrics/bundle-trend.jsonl
             git commit -m "chore(metrics): bundle-size snapshot $(date -u +%F)"
-            git push origin develop
+            # Rebase + retry: develop may have advanced while npm ci /
+            # build / size-limit ran. The JSONL is append-only and only
+            # this workflow writes it, so rebase conflicts are
+            # vanishingly rare; three attempts is plenty.
+            for attempt in 1 2 3; do
+              git fetch origin develop
+              git pull --rebase --autostash origin develop
+              if git push origin develop; then
+                exit 0
+              fi
+              if [[ "${attempt}" == "3" ]]; then
+                echo "::error::push failed after 3 rebase attempts"
+                exit 1
+              fi
+              sleep 5
+            done
           fi

--- a/.github/workflows/bundle-size-trend.yml
+++ b/.github/workflows/bundle-size-trend.yml
@@ -1,0 +1,51 @@
+name: Bundle-size trend
+
+on:
+  schedule:
+    # Sundays 04:00 UTC. Deliberately offset from the Monday CodeQL
+    # window (Mondays 06:00 UTC) so two cron workflows do not collide
+    # on a single runner pool peak.
+    - cron: '0 4 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: write # commits the snapshot row directly to develop
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: develop
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      # Resolve the SHA from the checked-out tree, NOT from
+      # `github.sha`. On `schedule` runs the event context's SHA
+      # points at the default-branch tip (this repo's default is
+      # `main`) while the checkout above pins `ref: develop`, so the
+      # two diverge and the JSONL row would record a SHA that does
+      # not match the code `size-limit` actually measured.
+      - name: Resolve checked-out SHA
+        id: head
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Append snapshot row
+        env:
+          GITHUB_SHA: ${{ steps.head.outputs.sha }}
+        run: |
+          npx size-limit --json | \
+            node scripts/append-size-snapshot.mjs \
+              --target docs/metrics/bundle-trend.jsonl
+      - name: Commit + push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [[ -n "$(git status --porcelain docs/metrics/bundle-trend.jsonl)" ]]; then
+            git add docs/metrics/bundle-trend.jsonl
+            git commit -m "chore(metrics): bundle-size snapshot $(date -u +%F)"
+            git push origin develop
+          fi

--- a/.github/workflows/bundle-size-trend.yml
+++ b/.github/workflows/bundle-size-trend.yml
@@ -47,10 +47,23 @@ jobs:
       - name: Append snapshot row
         env:
           GITHUB_SHA: ${{ steps.head.outputs.sha }}
+        # `npx size-limit --json` exits non-zero when ANY configured
+        # budget is exceeded — but it still emits a complete JSON
+        # status payload to stdout. Default Actions bash sets
+        # pipefail, so a piped invocation would fail the step in
+        # exactly the weeks the trend matters most (over-budget
+        # weeks). Capture stdout, tolerate the non-zero exit, fail
+        # only if size-limit produced no JSON at all (genuine
+        # tooling failure).
         run: |
-          npx size-limit --json | \
-            node scripts/append-size-snapshot.mjs \
-              --target docs/metrics/bundle-trend.jsonl
+          set +o pipefail
+          out="$(npx size-limit --json || true)"
+          if [[ -z "${out}" ]]; then
+            echo "::error::size-limit produced no JSON output"
+            exit 1
+          fi
+          printf '%s' "${out}" | node scripts/append-size-snapshot.mjs \
+            --target docs/metrics/bundle-trend.jsonl
       - name: Commit + push if changed
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/bundle-size-trend.yml
+++ b/.github/workflows/bundle-size-trend.yml
@@ -8,6 +8,17 @@ on:
     - cron: '0 4 * * 0'
   workflow_dispatch:
 
+# Serialize snapshot runs. The append script's (sha, calendar-date)
+# dedupe relies on exactly one writer at a time — without this, a
+# manual workflow_dispatch fired on the same UTC day as the cron
+# could race past dedupe (both runs read an empty tail, both append).
+# `cancel-in-progress: false` queues the second run instead of
+# cancelling it so a manual retry after a transient failure still
+# completes.
+concurrency:
+  group: bundle-size-trend
+  cancel-in-progress: false
+
 permissions:
   contents: write # commits the snapshot row directly to develop
 

--- a/docs/plans/2026-04-26-quality-automation-routines.md
+++ b/docs/plans/2026-04-26-quality-automation-routines.md
@@ -84,7 +84,7 @@ merges.
 | 2   | [quality-dep-triage-bot.md](./2026-04-26-quality-dep-triage-bot.md) | Cloud routine prompt + `dependabot.yml` grouping for weekly Dependabot triage | weekly | no | - [x] shipped |
 | 3   | [quality-actions-bump-bot.md](./2026-04-26-quality-actions-bump-bot.md) | Cloud routine prompt that runs `scripts/bump-actions.mjs` weekly + opens a bump PR | weekly | no | - [ ] not started |
 | 4   | [quality-plan-recon-bot.md](./2026-04-26-quality-plan-recon-bot.md) | Cloud routine prompt that archives shipped plans monthly | monthly | no | - [ ] not started |
-| 5   | [quality-bundle-trend.md](./2026-04-26-quality-bundle-trend.md) | Weekly snapshot of `npx size-limit --json` to a committed JSONL trend file | weekly | no | - [ ] not started |
+| 5   | [quality-bundle-trend.md](./2026-04-26-quality-bundle-trend.md) | Weekly snapshot of `npx size-limit --json` to a committed JSONL trend file | weekly | no | - [x] shipped via #144 |
 | 6   | [quality-determinism-replay.md](./2026-04-26-quality-determinism-replay.md) | Weekly + push hash-pinned replay across 8 seeds with committed baseline | weekly + push | no (tests/) | - [ ] not started |
 | 7   | [quality-mutation-testing.md](./2026-04-26-quality-mutation-testing.md) | Weekly StrykerJS mutation run with HTML report artifact | weekly | no | - [ ] not started |
 | 8   | [quality-demo-smoke.md](./2026-04-26-quality-demo-smoke.md) | Nightly Playwright headless smoke against built demo | nightly + PR-path | no (demo/) | - [ ] not started |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,13 @@ export default tseslint.config(
             'scripts/*.mjs',
             'scripts/*.d.mts',
           ],
+          // The default cap of 8 fires once `scripts/` grows past a
+          // handful of one-shot helpers. None of these files are part
+          // of the lib's tsconfig project — type-aware rules are
+          // already turned off for them — so the "this will slow down
+          // linting" warning does not apply. Bump the cap so adding a
+          // new helper does not require editing eslint.config.js.
+          maximumDefaultProjectFileMatchCount_THIS_WILL_SLOW_DOWN_LINTING: 20,
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/scripts/append-size-snapshot.mjs
+++ b/scripts/append-size-snapshot.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Append one JSONL row to a bundle-size trend file.
+//
+// Reads `size-limit --json` output from stdin, builds a single
+// `{iso, sha, entries}` row, and appends it to `--target <path>`.
+//
+// Dedupe policy: if the LAST existing row in the target file has the
+// same `(date-portion-of-iso, sha)` tuple as the new row, skip the
+// append (no-op). Same calendar date + same commit SHA means a
+// cron retry on the same fired run — re-recording would produce a
+// duplicate point in the time series.
+//
+// We do NOT dedupe on identical `entries`. A week where bundle sizes
+// are unchanged from the previous snapshot MUST still produce a row,
+// or the JSONL becomes a change-log instead of a time series and
+// breaks weekly trend analysis.
+//
+// Usage (in the workflow):
+//   npx size-limit --json | \
+//     node scripts/append-size-snapshot.mjs \
+//       --target docs/metrics/bundle-trend.jsonl
+
+import { appendFileSync, readFileSync } from 'node:fs';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--target') {
+      args.target = argv[i + 1];
+      i++;
+    }
+  }
+  if (!args.target) {
+    process.stderr.write('usage: append-size-snapshot.mjs --target <path>\n');
+    process.exit(2);
+  }
+  return args;
+}
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      chunks.push(String(chunk));
+    });
+    process.stdin.on('end', () => {
+      resolve(chunks.join(''));
+    });
+    process.stdin.on('error', reject);
+  });
+}
+
+function readLastJsonlRow(target) {
+  let raw;
+  try {
+    raw = readFileSync(target, 'utf8');
+  } catch {
+    return null;
+  }
+  const lines = raw.split('\n').filter((line) => line.length > 0);
+  if (lines.length === 0) return null;
+  try {
+    return JSON.parse(lines[lines.length - 1]);
+  } catch {
+    return null;
+  }
+}
+
+function isoDate(iso) {
+  // Take the YYYY-MM-DD prefix of an ISO-8601 timestamp.
+  return iso.slice(0, 10);
+}
+
+const { target } = parseArgs(process.argv.slice(2));
+const stdin = await readStdin();
+const sizeLimit = JSON.parse(stdin);
+const entries = sizeLimit.map((entry) => ({
+  name: entry.name,
+  size: entry.size,
+  gzip: entry.gzip,
+}));
+const newRow = {
+  iso: new Date().toISOString(),
+  sha: process.env.GITHUB_SHA ?? '',
+  entries,
+};
+
+const lastRow = readLastJsonlRow(target);
+const sameRunRetry =
+  lastRow?.sha === newRow.sha && isoDate(lastRow?.iso ?? '') === isoDate(newRow.iso);
+
+if (lastRow && sameRunRetry) {
+  // Re-run of the same cron firing on the same UTC day → skip.
+  process.exit(0);
+}
+
+appendFileSync(target, `${JSON.stringify(newRow)}\n`);

--- a/scripts/append-size-snapshot.test.mjs
+++ b/scripts/append-size-snapshot.test.mjs
@@ -1,0 +1,55 @@
+// scripts/append-size-snapshot.test.mjs
+import { test, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function run(target, fixture, sha) {
+  return spawnSync(process.execPath, ['scripts/append-size-snapshot.mjs', '--target', target], {
+    input: fixture,
+    env: { ...process.env, GITHUB_SHA: sha },
+  });
+}
+
+test('appends one JSONL row from size-limit JSON on stdin', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sizesnap-'));
+  const target = join(dir, 'bundle-trend.jsonl');
+  writeFileSync(target, ''); // empty
+  const fixture = JSON.stringify([
+    { name: 'core', size: 1234, gzip: 567 },
+    { name: 'integrations/excalibur', size: 200, gzip: 100 },
+  ]);
+  const out = run(target, fixture, 'abcdef0');
+  expect(out.status).toBe(0);
+  const rows = readFileSync(target, 'utf8').trim().split('\n').filter(Boolean);
+  expect(rows).toHaveLength(1);
+  const row = JSON.parse(rows[0]);
+  expect(row.sha).toBe('abcdef0');
+  expect(row.entries).toHaveLength(2);
+  expect(row.iso).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+});
+
+test('dedupes a same-day same-sha re-run (workflow_dispatch retry)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sizesnap-'));
+  const target = join(dir, 'bundle-trend.jsonl');
+  writeFileSync(target, '');
+  const fixture = JSON.stringify([{ name: 'core', size: 100, gzip: 50 }]);
+  expect(run(target, fixture, 'cafef00').status).toBe(0);
+  expect(run(target, fixture, 'cafef00').status).toBe(0); // same (sha, date)
+  const rows = readFileSync(target, 'utf8').trim().split('\n').filter(Boolean);
+  expect(rows).toHaveLength(1); // second invocation was a no-op
+});
+
+test('appends a new row when entries are unchanged but sha differs', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'sizesnap-'));
+  const target = join(dir, 'bundle-trend.jsonl');
+  writeFileSync(target, '');
+  // Identical bundle payload week-over-week MUST still produce a
+  // new row — the JSONL is a snapshot time series, not a changelog.
+  const fixture = JSON.stringify([{ name: 'core', size: 100, gzip: 50 }]);
+  expect(run(target, fixture, 'aaaaaaa').status).toBe(0);
+  expect(run(target, fixture, 'bbbbbbb').status).toBe(0);
+  const rows = readFileSync(target, 'utf8').trim().split('\n').filter(Boolean);
+  expect(rows).toHaveLength(2);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -150,7 +150,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'scripts/**/*.test.mjs'],
     // Activates the matrix-selected tfjs backend (see
     // `tests/setup/tfjsBackend.ts`) BEFORE any test file's static
     // imports run. No-op for non-tfjs tests — the import is cheap and


### PR DESCRIPTION
Tracks: #130
Tracks: #131

Adds a Sundays-04:00-UTC weekly workflow that snapshots npx size-limit
--json for the develop tip into docs/metrics/bundle-trend.jsonl. SHA
is resolved from the checked-out tree (git rev-parse HEAD), NOT
github.sha (which would point at the default-branch tip on schedule
events). Dedupe policy: same (sha, calendar-date) re-run is a no-op;
identical-payload week-over-week with a new sha appends a new row.

Ticks row 5 of the umbrella tracker.