### PR TITLE
docs(plan): recycle legacy nurture-pet logic across pillars

### DIFF
--- a/docs/plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md
@@ -15,11 +15,23 @@ users see — not infer — what changed between modes.
 
 ## Pre-flight
 
-- Blocked by: rename preflight.
+- Blocked by: rename preflight + Pillar-1 slice 1.2a (depends on
+  `useAgentSession` + `demo-domain/scenarios/petCare/cognition/` salvage).
 - `DiffMetric<T>` contract is fixed in the design doc; no per-pillar
   variant.
 - Initial confidence-label thresholds are placeholders (**OQ-P2**);
   tune in slice 2.4 after the first soak.
+- **Legacy recycle.** Pillar-1 slice 1.2a `git mv`-relocated the
+  pet-care cognition modes (`heuristic.ts`, `bt.ts`, `bdi.ts`,
+  `learning.ts`, `index.ts`, `learning.network.json`) into
+  `examples/product-demo/src/demo-domain/scenarios/petCare/cognition/`. The legacy
+  `cognitionSwitcher.ts` (46 KB; probe + dropdown + reasoner reconstruct
+  + train button + softmax viz), `lossSparkline.ts`, and
+  `predictionStrip.ts` are PRESERVED on `develop` after slice 1.2b
+  specifically so Pillar 2 can port them rather than rebuild. Slice 2.3
+  ports the SVG renderers as-is into thin Vue SFCs (logic stays pure);
+  slice 2.5 ports the switcher into a `<CognitionSwitcher>` SFC and
+  moves its mode-construction logic into `useAgentSession.setMode()`.
 
 ## Roadmap
 
@@ -29,6 +41,7 @@ users see — not infer — what changed between modes.
 | 2.2 | Domain-store wiring to `AGENT_TICKED` (no UI) | `examples/product-demo/src/stores/domain/useAgentSession.ts` (subscriber wiring), `examples/product-demo/src/stores/view/useDiffPanelView.ts`, `examples/product-demo/test/stores/**` | P2-FR-4, P2-FR-5 | not started | — |
 | 2.3 | Diff card component + "What changed" summary on mode swap | `examples/product-demo/src/components/diff/{DiffCard.vue,MetricRow.vue,WhatChangedSummary.vue}`, `examples/product-demo/src/views/DiffView.vue` | P2-FR-3, P2-FR-6 | not started | — |
 | 2.4 | Confidence labels, sample-window thresholds, soak-tuned defaults | `examples/product-demo/src/demo-domain/diff/confidence.ts`, tests + tuning notes in this plan's Done log | P2-FR-2, P2-AC-2 | not started | — |
+| 2.5 | Port legacy `cognitionSwitcher.ts` → `<CognitionSwitcher>` Vue SFC + `useAgentSession.setMode()` action; port `lossSparkline.ts` / `predictionStrip.ts` pure renderers into `<LossSparkline>` / `<PredictionStrip>` SFCs; **delete** `examples/product-demo/src/{cognitionSwitcher.ts,lossSparkline.ts,predictionStrip.ts}` | `examples/product-demo/src/components/cognition/{CognitionSwitcher.vue,LossSparkline.vue,PredictionStrip.vue,TrainButton.vue}`, `examples/product-demo/src/stores/domain/useAgentSession.ts` (extend with `setMode` + learner-readout polling), `examples/product-demo/test/components/cognition/*.test.ts`, `examples/product-demo/eslint.config.js` (drop deleted paths) | P2-FR-3, P2-FR-5 | not started | — |
 
 ## Slice notes
 
@@ -62,6 +75,26 @@ users see — not infer — what changed between modes.
   labels and tune the constants.
 - Document the chosen values in this plan's Done log so the rationale
   survives the PR description.
+
+### 2.5 — Legacy switcher port (recycle, do not rebuild)
+
+- The legacy `cognitionSwitcher.ts` is the largest single demo file
+  (46 KB). Don't rewrite it from scratch — port it. Keep the existing
+  semantics: peer-dep probe at mount, disabled-option tooltip
+  (`Install <peerName> to enable`), one-shot construct on selection,
+  learner-readout poll loop with `LEARNER_BATCH_SIZE = 50` +
+  `LEARNER_READOUT_POLL_MS = 200`, train button with synthetic dataset.
+- The pure SVG renderers (`lossSparkline.ts`, `predictionStrip.ts`) are
+  already DOM-pure — extract their compute helpers (polyline points,
+  bar heights) into `examples/product-demo/src/demo-domain/scenarios/petCare/
+  cognition/{lossSparkline,predictionStrip}.ts` and let the Vue SFCs
+  consume them. The SFCs render the SVG via `<template>` markup.
+- Mode-construction logic moves to `useAgentSession.setMode(modeId)` —
+  the action probes, constructs, swaps the agent's reasoner, and
+  emits a `COGNITION_SWITCHED` event so the diff panel (slice 2.3) and
+  fingerprint scope (Pillar 3) react.
+- Delete the legacy three files in this PR; update
+  `examples/product-demo/eslint.config.js` `ignores` accordingly.
 
 ## Verification gates
 

--- a/docs/plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md
@@ -28,10 +28,10 @@ users see — not infer — what changed between modes.
   `cognitionSwitcher.ts` (46 KB; probe + dropdown + reasoner reconstruct
   + train button + softmax viz), `lossSparkline.ts`, and
   `predictionStrip.ts` are PRESERVED on `develop` after slice 1.2b
-  specifically so Pillar 2 can port them rather than rebuild. Slice 2.3
-  ports the SVG renderers as-is into thin Vue SFCs (logic stays pure);
-  slice 2.5 ports the switcher into a `<CognitionSwitcher>` SFC and
-  moves its mode-construction logic into `useAgentSession.setMode()`.
+  specifically so Pillar 2 can port them rather than rebuild. Slice 2.5
+  ports all three together: the SVG renderers as-is into thin Vue SFCs
+  (logic stays pure) and the switcher into a `<CognitionSwitcher>` SFC
+  whose mode-construction logic moves into `useAgentSession.setMode()`.
 
 ## Roadmap
 

--- a/docs/plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-cognition-diff-panel.md
@@ -16,7 +16,13 @@ users see — not infer — what changed between modes.
 ## Pre-flight
 
 - Blocked by: rename preflight + Pillar-1 slice 1.2a (depends on
-  `useAgentSession` + `demo-domain/scenarios/petCare/cognition/` salvage).
+  `useAgentSession` + `demo-domain/scenarios/petCare/cognition/`
+  salvage) + Pillar-1 slice **1.2b** (slice 2.5 deletes
+  `src/cognitionSwitcher.ts`, `src/lossSparkline.ts`, and
+  `src/predictionStrip.ts`; the legacy `src/main.ts` imports those
+  modules and the Wave-0 bridge keeps `src/main.ts` live until 1.2b
+  swaps `src/app/main.ts` to mount Vue. Running 2.5 before 1.2b
+  would break the build).
 - `DiffMetric<T>` contract is fixed in the design doc; no per-pillar
   variant.
 - Initial confidence-label thresholds are placeholders (**OQ-P2**);

--- a/docs/plans/2026-04-26-pre-v1-demo-determinism-fingerprint.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-determinism-fingerprint.md
@@ -16,11 +16,22 @@ backed by a normalized run fingerprint.
 
 ## Pre-flight
 
-- Blocked by: rename preflight.
+- Blocked by: rename preflight + Pillar-1 slice 1.2a (consumes
+  `useAgentSession.subscribe(AGENT_TICKED)`).
 - Hash function (`sha-256` truncated to 128 bits) and normalized input
   set are fixed in the design — do not relitigate per slice.
 - `minSampleFraction` initial value `0.95` is **OQ-P3**; tune in slice
   3.4 after first soak.
+- **Legacy recycle.** The legacy `seed.ts loadSeed()` localStorage
+  helper was absorbed into `useAgentSession` in Pillar-1 slice 1.2a;
+  the storage key migrates from `agentonomous/seed` to
+  `demo.v2.session.lastSeed.<scenarioId>` per the design's STO
+  contract (no migration — pre-v1 clean break). The legacy
+  `mountSeedPanel` UI (copy-seed / new-seed / replay-from-seed buttons)
+  was deleted in 1.2b without an immediate Vue port; slice 3.3 below
+  reintroduces it as `<SeedPanel>` alongside the replay report. The
+  copy/new/replay button labels + behavior port verbatim from the
+  legacy module.
 
 ## Roadmap
 
@@ -28,7 +39,7 @@ backed by a normalized run fingerprint.
 |---|---|---|---|---|---|
 | 3.1 | Normalizer + hash function (pure domain) + scope-key encoder | `examples/product-demo/src/demo-domain/fingerprint/{types.ts,normalize.ts,hash.ts,scopeKey.ts}`, `examples/product-demo/test/demo-domain/fingerprint/*.test.ts` | P3-FR-1, P3-FR-6 | not started | — |
 | 3.2 | `useFingerprintRecorder` domain store + persistence shape | `examples/product-demo/src/stores/domain/useFingerprintRecorder.ts`, `examples/product-demo/test/stores/domain/useFingerprintRecorder.test.ts` | P3-FR-1, P3-FR-4, P3-FR-5 | not started | — |
-| 3.3 | `<FingerprintBadge>` + `<ReplayReport>` components + copy action | `examples/product-demo/src/components/fingerprint/{FingerprintBadge.vue,ReplayReport.vue,CopyReportButton.vue}`, `examples/product-demo/src/views/ReplayView.vue` | P3-FR-2, P3-FR-3 | not started | — |
+| 3.3 | `<FingerprintBadge>` + `<ReplayReport>` components + copy action + `<SeedPanel>` (port of legacy `mountSeedPanel`'s copy/new/replay buttons against `useAgentSession`) | `examples/product-demo/src/components/fingerprint/{FingerprintBadge.vue,ReplayReport.vue,CopyReportButton.vue}`, `examples/product-demo/src/components/shell/SeedPanel.vue`, `examples/product-demo/src/views/ReplayView.vue` | P3-FR-2, P3-FR-3 | not started | — |
 | 3.4 | Known-good script + Playwright `replay-determinism.spec.ts` + tuning | `examples/product-demo/src/demo-domain/fingerprint/knownGoodScripts.ts`, `examples/product-demo/tests/e2e/replay-determinism.spec.ts` | P3-FR-7, P3-AC-1, P3-AC-2, P3-AC-3, P3-AC-4, P3-AC-5 | not started | — |
 
 ## Slice notes

--- a/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
@@ -37,7 +37,7 @@ external narration.
 |---|---|---|---|---|---|
 | 1.1 | Step-graph + completion-predicate domain module + headless tests | `examples/product-demo/src/demo-domain/walkthrough/{types.ts,graph.ts,predicates.ts}`, `examples/product-demo/test/demo-domain/walkthrough/*.test.ts` | P1-FR-2, P1-FR-3, P1-FR-4 | ✅ shipped | [#140](https://github.com/Luis85/agentonomous/pull/140) |
 | 1.2a | Vue 3 / Pinia 2 / Vue Router 4 shell bootstrap + `git mv` salvage of pure legacy modules into `demo-domain/scenarios/petCare/` + `useAgentSession` domain store wrapping `buildAgent` factory | `examples/product-demo/package.json` (vue/pinia/vue-router/@vue/test-utils/@pinia/testing/@vue/eslint-parser/eslint-plugin-vue), `examples/product-demo/src/{app/App.vue,app/main.ts,routes/index.ts,views/IntroView.vue,views/PlayView.vue,components/shell/AppHeader.vue,stores/domain/useAgentSession.ts,composables/}`, `git mv` of `examples/product-demo/src/{species.ts,constants.ts,cognition/**,skills/**}` → `examples/product-demo/src/demo-domain/scenarios/petCare/{species.ts,constants.ts,cognition/**,skills/**}`, new `examples/product-demo/src/demo-domain/scenarios/petCare/buildAgent.ts` (random-event defs + skill registry wiring extracted from legacy `main.ts`), `examples/product-demo/eslint.config.js` (drop relocated paths from `ignores`, add Vue SFC parser), `examples/product-demo/test/stores/domain/useAgentSession.test.ts` | P1-FR-1 (CTA scaffolding) | not started | — |
-| 1.2b | Chapter-1 vertical: port `mountHud`→`<HudPanel>` + `mountTraceView`→`<TracePanel>`, introduce `useTourProgress` view store + `<TourOverlay>` + `<StepHighlight>`, chapter-1 (autonomy) step content, **delete** legacy `examples/product-demo/src/{ui.ts,traceView.ts,seed.ts,main.ts}` (their logic now lives in SFCs+stores). `cognitionSwitcher.ts`, `lossSparkline.ts`, `predictionStrip.ts`, `speciesConfig.ts` are explicitly NOT deleted here — Pillar 2 slice 2.5 deletes the first three after porting them; Pillar 4 slice 4.3 deletes `speciesConfig.ts` after relocating its pure logic. | `examples/product-demo/src/components/{shell/HudPanel.vue,trace/TracePanel.vue,tour/TourOverlay.vue,tour/StepHighlight.vue}`, `examples/product-demo/src/stores/view/useTourProgress.ts`, `examples/product-demo/src/demo-domain/walkthrough/chapters/1.ts`, `examples/product-demo/test/stores/view/useTourProgress.test.ts`, `examples/product-demo/test/components/{HudPanel,TracePanel,TourOverlay}.test.ts`, `examples/product-demo/src/copy/tour.ts` | P1-FR-1, P1-FR-3, P1-FR-5, P1-FR-6, P1-FR-8 | not started | — |
+| 1.2b | Chapter-1 vertical: port `mountHud`→`<HudPanel>`, `mountSpeedPicker`→`<SpeedPicker>`, `mountResetButton`→`<ResetButton>`, `mountExportImport`→`<ExportImportPanel>`, `mountTraceView`→`<TracePanel>`; introduce `useTourProgress` view store + `<TourOverlay>` + `<StepHighlight>`; chapter-1 (autonomy) step content; rewrite `app/main.ts` to mount Vue (replaces Wave-0 `await import('../main.js')` bridge); **delete** legacy `examples/product-demo/src/{ui.ts,traceView.ts,seed.ts,main.ts}` (their logic now lives in SFCs+stores). `cognitionSwitcher.ts`, `lossSparkline.ts`, `predictionStrip.ts`, `speciesConfig.ts` are explicitly NOT deleted here — Pillar 2 slice 2.5 deletes the first three after porting them; Pillar 4 slice 4.3 deletes `speciesConfig.ts` after relocating its pure logic. | `examples/product-demo/src/app/main.ts` (bridge swap), `examples/product-demo/src/components/{shell/HudPanel.vue,shell/SpeedPicker.vue,shell/ResetButton.vue,shell/ExportImportPanel.vue,trace/TracePanel.vue,tour/TourOverlay.vue,tour/StepHighlight.vue}`, `examples/product-demo/src/stores/view/useTourProgress.ts`, `examples/product-demo/src/demo-domain/walkthrough/chapters/1.ts`, `examples/product-demo/test/stores/view/useTourProgress.test.ts`, `examples/product-demo/test/components/{HudPanel,SpeedPicker,ResetButton,ExportImportPanel,TracePanel,TourOverlay}.test.ts`, `examples/product-demo/src/copy/tour.ts` | P1-FR-1, P1-FR-3, P1-FR-5, P1-FR-6, P1-FR-8 | not started | — |
 | 1.3 | Chapters 2-5 wired end-to-end + restart/skip/resume + selector-handle registry | `examples/product-demo/src/demo-domain/walkthrough/chapters/{2..5}.ts`, `examples/product-demo/src/components/**/registerSelector.ts`, `examples/product-demo/src/views/TourView.vue` | P1-FR-2, P1-FR-4, P1-FR-5, P1-FR-6, P1-FR-7 | not started | — |
 | 1.4 | Playwright `tour-happy-path.spec.ts` | `examples/product-demo/tests/e2e/tour-happy-path.spec.ts`, `examples/product-demo/playwright.config.ts` (script wiring) | P1-AC-1, P1-AC-5 | not started | — |
 
@@ -76,11 +76,17 @@ external narration.
   `subscribe` for view stores. Storage key `demo.v2.session.lastSeed.<scenarioId>`
   per design's STO contract (the legacy `agentonomous/seed` +
   `whiskers` keys are NOT migrated — pre-v1 clean break).
-- **`app/main.ts` rewrite:** replaces the `await import('../main.js')`
-  bridge with the Vue app mount (`createApp(App).use(pinia).use(router)
-  .mount(...)`). The STO-3 legacy-key purge stays as the first step.
-- **Legacy `main.ts` deletion is deferred to 1.2b** so the live demo
-  keeps booting via the bridge until the chapter-1 vertical replaces it.
+- **`app/main.ts` is NOT rewired in this slice.** The Wave-0 bridge
+  (`await import('../main.js')`) keeps booting the legacy demo so the
+  live URL stays functional while the Vue infrastructure is added in
+  parallel. The STO-3 purge stays as the first step. The actual swap
+  (replace bridge with `createApp(App).use(pinia).use(router).mount(...)`
+  and delete legacy `src/main.ts`) happens in 1.2b once the
+  chapter-1 vertical is wired and renders something the user can see.
+- **`App.vue` + `routes/index.ts` + `views/{IntroView,PlayView}.vue`
+  scaffold land here** but are not the live entry yet — they are
+  importable, type-checkable, and unit-testable; switching the entry
+  point is what 1.2b does.
 - **eslint.config.js update:** the `ignores` list drops the relocated
   paths; the `*.vue` SFC parser is wired (no-op until the first SFC
   arrives in 1.2b but eliminates the parser-mismatch surprise).
@@ -94,6 +100,15 @@ external narration.
   `INTERACTION_BUTTONS`, `STAGE_LABELS`, `LIFETIME_COUNTERS` data tables
   verbatim; the per-need bar markup becomes a `<template v-for>` over
   `NEEDS` (already relocated to `demo-domain/scenarios/petCare/constants.ts`).
+- **`<SpeedPicker>` + `<ResetButton>` + `<ExportImportPanel>`** port
+  the remaining `mountSpeedPicker` / `mountResetButton` /
+  `mountExportImport` legacy mounts from `ui.ts` — these are not
+  chapter-1-specific but the shell needs them to remain functional
+  once the bridge is removed. Logic ports verbatim against
+  `useAgentSession` actions (`setSpeed`, `replayFromSnapshot(null)`,
+  `exportSnapshot` / `importSnapshot`). The legacy
+  `agentonomous/speed` storage key is NOT migrated (pre-v1 clean
+  break) — `<SpeedPicker>` writes `demo.v2.session.speed` instead.
 - **`<TracePanel>`** ports `mountTraceView` from legacy `traceView.ts`
   — keeps the four-section computation (summary / needs / candidates /
   selected) but lets Vue handle reactivity; the legacy "near-zero DOM
@@ -112,9 +127,14 @@ external narration.
 - **Tour copy tone (OQ-P1) settled here** — pick friendly-informal
   vs. terse-instructional vs. presenter-narration, record the choice
   in this plan's Done log + apply to chapter-1 copy.
-- **Legacy file deletion (clean break per pre-v1 policy):** delete
+- **Bridge swap + legacy file deletion (clean break per pre-v1
+  policy):** rewrite `app/main.ts` to swap the Wave-0
+  `await import('../main.js')` bridge for the Vue app mount
+  (`createApp(App).use(pinia).use(router).mount(...)`) AS THE FIRST
+  STEP of this slice — once the new shell renders, delete the
+  now-orphaned legacy files
   `examples/product-demo/src/{ui.ts, traceView.ts, seed.ts, main.ts}`
-  in this slice — their logic now lives in the SFCs and stores above.
+  in the same diff. Their logic lives in the SFCs and stores above.
   `cognitionSwitcher.ts`, `lossSparkline.ts`, `predictionStrip.ts`,
   `speciesConfig.ts` are deliberately NOT deleted here: Pillar 2 slice
   2.5 deletes the first three after porting them, Pillar 4 slice 4.3

--- a/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
@@ -37,7 +37,7 @@ external narration.
 |---|---|---|---|---|---|
 | 1.1 | Step-graph + completion-predicate domain module + headless tests | `examples/product-demo/src/demo-domain/walkthrough/{types.ts,graph.ts,predicates.ts}`, `examples/product-demo/test/demo-domain/walkthrough/*.test.ts` | P1-FR-2, P1-FR-3, P1-FR-4 | ✅ shipped | [#140](https://github.com/Luis85/agentonomous/pull/140) |
 | 1.2a | Vue 3 / Pinia 2 / Vue Router 4 shell bootstrap + `git mv` salvage of pure legacy modules into `demo-domain/scenarios/petCare/` + `useAgentSession` domain store wrapping `buildAgent` factory | `examples/product-demo/package.json` (vue/pinia/vue-router/@vue/test-utils/@pinia/testing/@vue/eslint-parser/eslint-plugin-vue), `examples/product-demo/src/{app/App.vue,app/main.ts,routes/index.ts,views/IntroView.vue,views/PlayView.vue,components/shell/AppHeader.vue,stores/domain/useAgentSession.ts,composables/}`, `git mv` of `examples/product-demo/src/{species.ts,constants.ts,cognition/**,skills/**}` → `examples/product-demo/src/demo-domain/scenarios/petCare/{species.ts,constants.ts,cognition/**,skills/**}`, new `examples/product-demo/src/demo-domain/scenarios/petCare/buildAgent.ts` (random-event defs + skill registry wiring extracted from legacy `main.ts`), `examples/product-demo/eslint.config.js` (drop relocated paths from `ignores`, add Vue SFC parser), `examples/product-demo/test/stores/domain/useAgentSession.test.ts` | P1-FR-1 (CTA scaffolding) | not started | — |
-| 1.2b | Chapter-1 vertical: port `mountHud`→`<HudPanel>` + `mountTraceView`→`<TracePanel>`, introduce `useTourProgress` view store + `<TourOverlay>` + `<StepHighlight>`, chapter-1 (autonomy) step content, **delete** legacy `examples/product-demo/src/{ui.ts,traceView.ts,seed.ts,speciesConfig.ts,cognitionSwitcher.ts,lossSparkline.ts,predictionStrip.ts,main.ts}` (their logic now lives in SFCs+stores OR is preserved for the Pillar 2 / 4 ports — see "Recycle deferral" below) | `examples/product-demo/src/components/{shell/HudPanel.vue,trace/TracePanel.vue,tour/TourOverlay.vue,tour/StepHighlight.vue}`, `examples/product-demo/src/stores/view/useTourProgress.ts`, `examples/product-demo/src/demo-domain/walkthrough/chapters/1.ts`, `examples/product-demo/test/stores/view/useTourProgress.test.ts`, `examples/product-demo/test/components/{HudPanel,TracePanel,TourOverlay}.test.ts`, `examples/product-demo/src/copy/tour.ts` | P1-FR-1, P1-FR-3, P1-FR-5, P1-FR-6, P1-FR-8 | not started | — |
+| 1.2b | Chapter-1 vertical: port `mountHud`→`<HudPanel>` + `mountTraceView`→`<TracePanel>`, introduce `useTourProgress` view store + `<TourOverlay>` + `<StepHighlight>`, chapter-1 (autonomy) step content, **delete** legacy `examples/product-demo/src/{ui.ts,traceView.ts,seed.ts,main.ts}` (their logic now lives in SFCs+stores). `cognitionSwitcher.ts`, `lossSparkline.ts`, `predictionStrip.ts`, `speciesConfig.ts` are explicitly NOT deleted here — Pillar 2 slice 2.5 deletes the first three after porting them; Pillar 4 slice 4.3 deletes `speciesConfig.ts` after relocating its pure logic. | `examples/product-demo/src/components/{shell/HudPanel.vue,trace/TracePanel.vue,tour/TourOverlay.vue,tour/StepHighlight.vue}`, `examples/product-demo/src/stores/view/useTourProgress.ts`, `examples/product-demo/src/demo-domain/walkthrough/chapters/1.ts`, `examples/product-demo/test/stores/view/useTourProgress.test.ts`, `examples/product-demo/test/components/{HudPanel,TracePanel,TourOverlay}.test.ts`, `examples/product-demo/src/copy/tour.ts` | P1-FR-1, P1-FR-3, P1-FR-5, P1-FR-6, P1-FR-8 | not started | — |
 | 1.3 | Chapters 2-5 wired end-to-end + restart/skip/resume + selector-handle registry | `examples/product-demo/src/demo-domain/walkthrough/chapters/{2..5}.ts`, `examples/product-demo/src/components/**/registerSelector.ts`, `examples/product-demo/src/views/TourView.vue` | P1-FR-2, P1-FR-4, P1-FR-5, P1-FR-6, P1-FR-7 | not started | — |
 | 1.4 | Playwright `tour-happy-path.spec.ts` | `examples/product-demo/tests/e2e/tour-happy-path.spec.ts`, `examples/product-demo/playwright.config.ts` (script wiring) | P1-AC-1, P1-AC-5 | not started | — |
 
@@ -113,16 +113,20 @@ external narration.
   vs. terse-instructional vs. presenter-narration, record the choice
   in this plan's Done log + apply to chapter-1 copy.
 - **Legacy file deletion (clean break per pre-v1 policy):** delete
-  `examples/product-demo/src/{ui.ts, traceView.ts, seed.ts,
-  speciesConfig.ts, main.ts}`. `cognitionSwitcher.ts`,
-  `lossSparkline.ts`, `predictionStrip.ts` stay until **Pillar 2**
-  ports them; `speciesConfig.ts`'s pure logic (validator + applyOverride)
-  stays available for **Pillar 4** to relocate. Update
-  `eslint.config.js` `ignores` accordingly each step. Note: the legacy
-  `agentonomous/seed`, `agentonomous/speed`, `agentonomous/trace-visible`,
-  `agentonomous/species-config`, `whiskers`, `whiskers:speed` localStorage
-  keys are NOT migrated (pre-v1 clean break) — the new shell uses the
-  `demo.v2.*` namespace exclusively per design's storage contract.
+  `examples/product-demo/src/{ui.ts, traceView.ts, seed.ts, main.ts}`
+  in this slice — their logic now lives in the SFCs and stores above.
+  `cognitionSwitcher.ts`, `lossSparkline.ts`, `predictionStrip.ts`,
+  `speciesConfig.ts` are deliberately NOT deleted here: Pillar 2 slice
+  2.5 deletes the first three after porting them, Pillar 4 slice 4.3
+  deletes `speciesConfig.ts` after relocating its pure logic
+  (`EditableSpeciesConfig` shape, `validateEditableConfig`,
+  `applyOverride`) into `demo-domain/scenarios/petCare/config/`.
+  Update `eslint.config.js` `ignores` accordingly each step. Note: the
+  legacy `agentonomous/seed`, `agentonomous/speed`,
+  `agentonomous/trace-visible`, `agentonomous/species-config`,
+  `whiskers`, `whiskers:speed` localStorage keys are NOT migrated
+  (pre-v1 clean break) — the new shell uses the `demo.v2.*` namespace
+  exclusively per design's storage contract.
 
 ### 1.3 — Fan-out + resilience
 

--- a/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
@@ -19,14 +19,25 @@ external narration.
 
 - Blocked by: rename preflight (`docs/plans/2026-04-26-pre-v1-demo-rename-preflight.md`). The `WalkthroughStep` contract lives under `examples/product-demo/src/demo-domain/walkthrough/` so the rename must merge first.
 - Worktree pattern: `.worktrees/feat-tour-<slice>/`.
-- Tour copy tone is **OQ-P1** (open question) — settle in slice 1.1 review.
+- Tour copy tone is **OQ-P1** (open question) — settle in slice 1.2b review.
+- **Legacy recycle.** Slice 1.2a relocates pure modules from the legacy
+  vanilla-TS demo (`examples/product-demo/src/{species.ts,constants.ts,
+  cognition/*,skills/*}` + the random-event + agent-construction recipe in
+  the legacy `main.ts`) into `examples/product-demo/src/demo-domain/scenarios/petCare/`
+  via `git mv` (history preserved). Slice 1.2b ports the DOM-mount UI
+  (`mountHud`, `mountTraceView`) into Vue SFCs, reusing the data tables
+  (INTERACTION_BUTTONS, STAGE_LABELS, NEEDS, lifetime counters) verbatim.
+  Cognition switcher port + JSON editor port deferred to **Pillar 2** /
+  **Pillar 4** (those plans recycle `cognitionSwitcher.ts` /
+  `lossSparkline.ts` / `predictionStrip.ts` and `speciesConfig.ts` directly).
 
 ## Roadmap
 
 | # | Slice | Files | Spec FRs | Status | PR |
 |---|---|---|---|---|---|
 | 1.1 | Step-graph + completion-predicate domain module + headless tests | `examples/product-demo/src/demo-domain/walkthrough/{types.ts,graph.ts,predicates.ts}`, `examples/product-demo/test/demo-domain/walkthrough/*.test.ts` | P1-FR-2, P1-FR-3, P1-FR-4 | ✅ shipped | [#140](https://github.com/Luis85/agentonomous/pull/140) |
-| 1.2 | `useTourProgress` view store + tour overlay component (chapter 1 only) | `examples/product-demo/src/stores/view/useTourProgress.ts`, `examples/product-demo/src/components/tour/{TourOverlay.vue,StepHighlight.vue}`, `examples/product-demo/test/stores/view/useTourProgress.test.ts` | P1-FR-1, P1-FR-3, P1-FR-5, P1-FR-6, P1-FR-8 | not started | — |
+| 1.2a | Vue 3 / Pinia 2 / Vue Router 4 shell bootstrap + `git mv` salvage of pure legacy modules into `demo-domain/scenarios/petCare/` + `useAgentSession` domain store wrapping `buildAgent` factory | `examples/product-demo/package.json` (vue/pinia/vue-router/@vue/test-utils/@pinia/testing/@vue/eslint-parser/eslint-plugin-vue), `examples/product-demo/src/{app/App.vue,app/main.ts,routes/index.ts,views/IntroView.vue,views/PlayView.vue,components/shell/AppHeader.vue,stores/domain/useAgentSession.ts,composables/}`, `git mv` of `examples/product-demo/src/{species.ts,constants.ts,cognition/**,skills/**}` → `examples/product-demo/src/demo-domain/scenarios/petCare/{species.ts,constants.ts,cognition/**,skills/**}`, new `examples/product-demo/src/demo-domain/scenarios/petCare/buildAgent.ts` (random-event defs + skill registry wiring extracted from legacy `main.ts`), `examples/product-demo/eslint.config.js` (drop relocated paths from `ignores`, add Vue SFC parser), `examples/product-demo/test/stores/domain/useAgentSession.test.ts` | P1-FR-1 (CTA scaffolding) | not started | — |
+| 1.2b | Chapter-1 vertical: port `mountHud`→`<HudPanel>` + `mountTraceView`→`<TracePanel>`, introduce `useTourProgress` view store + `<TourOverlay>` + `<StepHighlight>`, chapter-1 (autonomy) step content, **delete** legacy `examples/product-demo/src/{ui.ts,traceView.ts,seed.ts,speciesConfig.ts,cognitionSwitcher.ts,lossSparkline.ts,predictionStrip.ts,main.ts}` (their logic now lives in SFCs+stores OR is preserved for the Pillar 2 / 4 ports — see "Recycle deferral" below) | `examples/product-demo/src/components/{shell/HudPanel.vue,trace/TracePanel.vue,tour/TourOverlay.vue,tour/StepHighlight.vue}`, `examples/product-demo/src/stores/view/useTourProgress.ts`, `examples/product-demo/src/demo-domain/walkthrough/chapters/1.ts`, `examples/product-demo/test/stores/view/useTourProgress.test.ts`, `examples/product-demo/test/components/{HudPanel,TracePanel,TourOverlay}.test.ts`, `examples/product-demo/src/copy/tour.ts` | P1-FR-1, P1-FR-3, P1-FR-5, P1-FR-6, P1-FR-8 | not started | — |
 | 1.3 | Chapters 2-5 wired end-to-end + restart/skip/resume + selector-handle registry | `examples/product-demo/src/demo-domain/walkthrough/chapters/{2..5}.ts`, `examples/product-demo/src/components/**/registerSelector.ts`, `examples/product-demo/src/views/TourView.vue` | P1-FR-2, P1-FR-4, P1-FR-5, P1-FR-6, P1-FR-7 | not started | — |
 | 1.4 | Playwright `tour-happy-path.spec.ts` | `examples/product-demo/tests/e2e/tour-happy-path.spec.ts`, `examples/product-demo/playwright.config.ts` (script wiring) | P1-AC-1, P1-AC-5 | not started | — |
 
@@ -40,13 +51,78 @@ external narration.
 - The `SelectorHandle` type is defined here as a branded string; the
   per-component registry is added in slice 1.3.
 
-### 1.2 — Chapter-1 vertical slice
+### 1.2a — Bootstrap + salvage
 
-- Scope intentionally narrow: end-to-end vertical for chapter 1 only
-  (autonomy). Validates the shape (overlay, predicate, advance) before
-  fanning out to all five chapters.
-- View-store tests use `@pinia/testing` with stubbed `useAgentSession`
-  snapshots.
+- **Adds workspace deps:** `vue@^3`, `pinia@^2`, `vue-router@^4`,
+  `@vue/test-utils`, `@pinia/testing`, `@vue/eslint-parser`,
+  `eslint-plugin-vue`, `@types/node` (for the bootstrap `app/main.ts`
+  rewrite). `lint:demo` continues to enforce the design's DDD
+  forbidden-import + NFR-D-1 determinism rules.
+- **`git mv` salvage** (history preserved):
+  - `src/species.ts` → `src/demo-domain/scenarios/petCare/species.ts`
+  - `src/constants.ts` → `src/demo-domain/scenarios/petCare/constants.ts`
+  - `src/cognition/{heuristic,bt,bdi,learning,index}.ts` +
+    `learning.network.json` → `src/demo-domain/scenarios/petCare/cognition/`
+  - `src/skills/ApproachTreatSkill.ts` →
+    `src/demo-domain/scenarios/petCare/skills/ApproachTreatSkill.ts`
+- **New `src/demo-domain/scenarios/petCare/buildAgent.ts`** factory: takes
+  `{ seed, speciesOverride? }` and returns a fully-wired `Agent`
+  (random-event defs + skill registry wiring + `createAgent` call
+  extracted verbatim from the legacy `main.ts`). Pure TS — no DOM, no
+  Pinia.
+- **`useAgentSession` domain store** wraps `buildAgent`: owns the live
+  `Agent`, the tick loop, control-mode actions (`start` / `pause` /
+  `resume` / `step` / `setSpeed` / `replayFromSnapshot`), and exposes
+  `subscribe` for view stores. Storage key `demo.v2.session.lastSeed.<scenarioId>`
+  per design's STO contract (the legacy `agentonomous/seed` +
+  `whiskers` keys are NOT migrated — pre-v1 clean break).
+- **`app/main.ts` rewrite:** replaces the `await import('../main.js')`
+  bridge with the Vue app mount (`createApp(App).use(pinia).use(router)
+  .mount(...)`). The STO-3 legacy-key purge stays as the first step.
+- **Legacy `main.ts` deletion is deferred to 1.2b** so the live demo
+  keeps booting via the bridge until the chapter-1 vertical replaces it.
+- **eslint.config.js update:** the `ignores` list drops the relocated
+  paths; the `*.vue` SFC parser is wired (no-op until the first SFC
+  arrives in 1.2b but eliminates the parser-mismatch surprise).
+
+### 1.2b — Chapter-1 vertical + DOM-mount port
+
+- Scope intentionally narrow: end-to-end vertical for chapter 1
+  (autonomy) only. Validates the shape (overlay, predicate, advance)
+  before fanning out to all five chapters.
+- **`<HudPanel>`** ports `mountHud` from legacy `ui.ts` — reuses
+  `INTERACTION_BUTTONS`, `STAGE_LABELS`, `LIFETIME_COUNTERS` data tables
+  verbatim; the per-need bar markup becomes a `<template v-for>` over
+  `NEEDS` (already relocated to `demo-domain/scenarios/petCare/constants.ts`).
+- **`<TracePanel>`** ports `mountTraceView` from legacy `traceView.ts`
+  — keeps the four-section computation (summary / needs / candidates /
+  selected) but lets Vue handle reactivity; the legacy "near-zero DOM
+  work" diff trick (serialized signature compare) is no longer needed.
+- **`useTourProgress`** view store: cursor (`lastStep`),
+  `completedAt`, `skipped[]`. Reads `useAgentSession` projections and
+  the route via injected `useRoute`. `@pinia/testing` for unit tests
+  with stubbed snapshots.
+- **`<TourOverlay>` + `<StepHighlight>`** render the active step's
+  hint + highlight against the `SelectorHandle` registry stub (full
+  registry lands in 1.3).
+- **Chapter-1 step content** in `demo-domain/walkthrough/chapters/1.ts`
+  uses the slice-1.1 predicate primitives (`tickAtLeast`,
+  `eventEmittedSince('AGENT_TICKED', …)`) to detect the agent
+  acting on its own.
+- **Tour copy tone (OQ-P1) settled here** — pick friendly-informal
+  vs. terse-instructional vs. presenter-narration, record the choice
+  in this plan's Done log + apply to chapter-1 copy.
+- **Legacy file deletion (clean break per pre-v1 policy):** delete
+  `examples/product-demo/src/{ui.ts, traceView.ts, seed.ts,
+  speciesConfig.ts, main.ts}`. `cognitionSwitcher.ts`,
+  `lossSparkline.ts`, `predictionStrip.ts` stay until **Pillar 2**
+  ports them; `speciesConfig.ts`'s pure logic (validator + applyOverride)
+  stays available for **Pillar 4** to relocate. Update
+  `eslint.config.js` `ignores` accordingly each step. Note: the legacy
+  `agentonomous/seed`, `agentonomous/speed`, `agentonomous/trace-visible`,
+  `agentonomous/species-config`, `whiskers`, `whiskers:speed` localStorage
+  keys are NOT migrated (pre-v1 clean break) — the new shell uses the
+  `demo.v2.*` namespace exclusively per design's storage contract.
 
 ### 1.3 — Fan-out + resilience
 

--- a/docs/plans/2026-04-26-pre-v1-demo-json-preview-commit.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-json-preview-commit.md
@@ -16,30 +16,51 @@ keyed off a whitelist of safely previewable fields.
 
 ## Pre-flight
 
-- Blocked by: rename preflight.
+- Blocked by: rename preflight + Pillar-1 slice 1.2a (the
+  `useAgentSession` factory the editor patches into).
 - Coordinates with **Pillar 3** — every commit triggers a fresh
   fingerprint window. Confirm the `useFingerprintRecorder` API is
   stable before slice 4.3 lands.
 - Pre-v1 policy applies: the legacy restart-only path is **removed**,
   not left as a fallback.
+- **Legacy recycle.** Pillar-1 slice 1.2b deliberately PRESERVED
+  `examples/product-demo/src/speciesConfig.ts` so Pillar 4 can port
+  rather than rebuild. The legacy file already contains:
+  `EditableSpeciesConfig` shape, `currentEditableConfig`,
+  `validateEditableConfig`, `applyOverride`, `loadConfigOverride` —
+  all pure logic apart from the localStorage adapters. Slice 4.1
+  relocates the pure parts (validator + applyOverride + edit shape)
+  into `demo-domain/scenarios/petCare/config/`; slice 4.2 absorbs the storage
+  adapter into `useConfigDraft`. The legacy `mountConfigPanel` DOM
+  mount is replaced by the new `<JsonEditor>` SFC family (slice 4.3),
+  which then deletes `speciesConfig.ts` outright.
 
 ## Roadmap
 
 | # | Slice | Files | Spec FRs | Status | PR |
 |---|---|---|---|---|---|
-| 4.1 | Whitelisted-field schema + validator (pure domain) | `examples/product-demo/src/demo-domain/config/{types.ts,schema.ts,validate.ts,diff.ts}`, `examples/product-demo/test/demo-domain/config/*.test.ts` | P4-FR-2, P4-FR-6 | not started | — |
+| 4.1 | Whitelisted-field schema + validator (pure domain) — relocates `speciesConfig.ts`'s pure logic (`EditableSpeciesConfig`, `currentEditableConfig`, `validateEditableConfig`, `applyOverride`) into `demo-domain/scenarios/petCare/config/` and replaces the implicit list with the design's explicit `{ path, kind: 'preview' \| 'commit' }` whitelist | `examples/product-demo/src/demo-domain/scenarios/petCare/config/{types.ts,schema.ts,validate.ts,diff.ts,applyOverride.ts}`, `examples/product-demo/test/demo-domain/scenarios/petCare/config/*.test.ts` | P4-FR-2, P4-FR-6 | not started | — |
 | 4.2 | `useConfigDraft` domain store + preview lifecycle (headless) | `examples/product-demo/src/stores/domain/useConfigDraft.ts`, `examples/product-demo/test/stores/domain/useConfigDraft.test.ts` | P4-FR-1, P4-FR-3, P4-FR-5 | not started | — |
-| 4.3 | Editor view: Preview / Commit+Restart actions, diff summary, inline validation | `examples/product-demo/src/views/JsonEditorView.vue`, `examples/product-demo/src/components/config/{EditorPanel.vue,DiffSummary.vue,ValidationList.vue,ActionRow.vue}`, `examples/product-demo/src/stores/view/useJsonEditorView.ts` | P4-FR-3, P4-FR-4 | not started | — |
+| 4.3 | Editor view: Preview / Commit+Restart actions, diff summary, inline validation; **delete** legacy `examples/product-demo/src/speciesConfig.ts` once its mount logic is fully replaced | `examples/product-demo/src/views/JsonEditorView.vue`, `examples/product-demo/src/components/config/{EditorPanel.vue,DiffSummary.vue,ValidationList.vue,ActionRow.vue}`, `examples/product-demo/src/stores/view/useJsonEditorView.ts`, `examples/product-demo/eslint.config.js` (drop `speciesConfig.ts` from `ignores`) | P4-FR-3, P4-FR-4 | not started | — |
 | 4.4 | Storage migration cleanup + commit-triggers-fingerprint wiring | `examples/product-demo/src/app/main.ts` (legacy purge tick), `examples/product-demo/src/stores/domain/useConfigDraft.ts` (commit handshake with `useFingerprintRecorder`) | P4-FR-7, P4-AC-5 | not started | — |
 
 ## Slice notes
 
-### 4.1 — Schema first
+### 4.1 — Schema first (recycle, don't rebuild)
 
 - The whitelist is declarative: `{ path: ConfigPath, kind: 'preview' | 'commit' }`.
   All other fields are commit-only by default — explicit > implicit.
 - Validators return `ValidationFinding[]`; tests assert that an invalid
   draft never partially applies (P4-AC-4 evidence).
+- **Recycle from legacy `speciesConfig.ts`:** the existing
+  `validateEditableConfig` already implements range checks, monotonic
+  lifecycle ordering, and unknown-field rejection — port those rules
+  verbatim into `validate.ts` (translate the ad-hoc error strings into
+  `ValidationFinding` codes per spec). `applyOverride` already handles
+  the partial-edit merge — port it into `applyOverride.ts` and add the
+  test guarantee that an invalid draft never half-applies. The legacy
+  `EditableSpeciesConfig` shape becomes the starting point for
+  `NormalizedConfig` (rename + add `__brand` if needed).
 
 ### 4.2 — Headless lifecycle
 

--- a/docs/plans/2026-04-26-pre-v1-demo-json-preview-commit.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-json-preview-commit.md
@@ -17,7 +17,13 @@ keyed off a whitelist of safely previewable fields.
 ## Pre-flight
 
 - Blocked by: rename preflight + Pillar-1 slice 1.2a (the
-  `useAgentSession` factory the editor patches into).
+  `useAgentSession` factory the editor patches into) + Pillar-1
+  slice **1.2b** (slice 4.3 deletes `src/speciesConfig.ts`; the
+  legacy `src/main.ts` imports `applyOverride` /
+  `loadConfigOverride` / `mountConfigPanel` from it and the Wave-0
+  bridge keeps `src/main.ts` live until 1.2b swaps
+  `src/app/main.ts` to mount Vue. Running 4.3 before 1.2b would
+  break the build).
 - Coordinates with **Pillar 3** — every commit triggers a fresh
   fingerprint window. Confirm the `useFingerprintRecorder` API is
   stable before slice 4.3 lands.
@@ -39,7 +45,7 @@ keyed off a whitelist of safely previewable fields.
 
 | # | Slice | Files | Spec FRs | Status | PR |
 |---|---|---|---|---|---|
-| 4.1 | Cross-scenario config engine (pure domain) + pet-care relocation: NEW `demo-domain/config/` engine (`ConfigPath`, `ValidationFinding`, `ConfigDraft` shape, schema-driven validator/diff framework) + RELOCATED `speciesConfig.ts`'s pure logic (`EditableSpeciesConfig` → `NormalizedConfig`, `validateEditableConfig` rules, `applyOverride`) into `demo-domain/scenarios/petCare/config/` plugged into the engine. Replaces the implicit allow-list with the design's explicit `{ path, kind: 'preview' \| 'commit' }` whitelist. | `examples/product-demo/src/demo-domain/config/{types.ts,validateEngine.ts,diff.ts}` (cross-scenario, new), `examples/product-demo/src/demo-domain/scenarios/petCare/config/{schema.ts,validate.ts,applyOverride.ts}` (per-scenario, recycled), `examples/product-demo/test/demo-domain/config/*.test.ts`, `examples/product-demo/test/demo-domain/scenarios/petCare/config/*.test.ts` | P4-FR-2, P4-FR-6 | not started | — |
+| 4.1 | Cross-scenario config engine (pure domain) + pet-care relocation: NEW `demo-domain/config/` engine (`ConfigPath`, `ValidationFinding`, `ConfigDraft` shape, the previewable-field whitelist schema TYPE per spec **P4-FR-2**, schema-driven validator/diff framework) + RELOCATED `speciesConfig.ts`'s pure logic (`EditableSpeciesConfig` → `NormalizedConfig`, `validateEditableConfig` rules, `applyOverride`) into `demo-domain/scenarios/petCare/config/` plugged into the engine. The pet-care SCHEMA INSTANCE (which fields are `preview` vs `commit`) lives in `scenarios/petCare/config/schema.ts`; the schema TYPE + whitelist registry helpers live in `demo-domain/config/schema.ts` to honour the spec's exact path. Replaces the implicit allow-list with the design's explicit `{ path, kind: 'preview' \| 'commit' }` whitelist. | `examples/product-demo/src/demo-domain/config/{types.ts,schema.ts,validateEngine.ts,diff.ts}` (cross-scenario, new — `schema.ts` matches spec P4-FR-2), `examples/product-demo/src/demo-domain/scenarios/petCare/config/{schema.ts,validate.ts,applyOverride.ts}` (per-scenario instance + rules, recycled), `examples/product-demo/test/demo-domain/config/*.test.ts`, `examples/product-demo/test/demo-domain/scenarios/petCare/config/*.test.ts` | P4-FR-2, P4-FR-6 | not started | — |
 | 4.2 | `useConfigDraft` domain store + preview lifecycle (headless) | `examples/product-demo/src/stores/domain/useConfigDraft.ts`, `examples/product-demo/test/stores/domain/useConfigDraft.test.ts` | P4-FR-1, P4-FR-3, P4-FR-5 | not started | — |
 | 4.3 | Editor view: Preview / Commit+Restart actions, diff summary, inline validation; **delete** legacy `examples/product-demo/src/speciesConfig.ts` once its mount logic is fully replaced | `examples/product-demo/src/views/JsonEditorView.vue`, `examples/product-demo/src/components/config/{EditorPanel.vue,DiffSummary.vue,ValidationList.vue,ActionRow.vue}`, `examples/product-demo/src/stores/view/useJsonEditorView.ts`, `examples/product-demo/eslint.config.js` (drop `speciesConfig.ts` from `ignores`) | P4-FR-3, P4-FR-4 | not started | — |
 | 4.4 | Storage migration cleanup + commit-triggers-fingerprint wiring | `examples/product-demo/src/app/main.ts` (legacy purge tick), `examples/product-demo/src/stores/domain/useConfigDraft.ts` (commit handshake with `useFingerprintRecorder`) | P4-FR-7, P4-AC-5 | not started | — |
@@ -52,13 +58,18 @@ keyed off a whitelist of safely previewable fields.
   All other fields are commit-only by default — explicit > implicit.
 - Validators return `ValidationFinding[]`; tests assert that an invalid
   draft never partially applies (P4-AC-4 evidence).
-- **Two-layer split:**
+- **Two-layer split (the spec's `demo-domain/config/schema.ts`
+  filename is honoured at the engine layer):**
   - `demo-domain/config/` (NEW, cross-scenario engine): `ConfigPath`,
-    `ValidationFinding`, `ConfigDraft` shape, generic schema-driven
-    validator + diff framework. No pet-care knowledge here.
+    `ValidationFinding`, `ConfigDraft` shape, the previewable-field
+    whitelist schema TYPE per spec P4-FR-2 (`schema.ts`), and the
+    generic schema-driven validator + diff framework. No pet-care
+    knowledge here.
   - `demo-domain/scenarios/petCare/config/` (RECYCLED from legacy
-    `speciesConfig.ts`): pet-care-specific schema + validator rules +
-    `applyOverride`, plugged into the engine above.
+    `speciesConfig.ts`): pet-care-specific schema INSTANCE
+    (`schema.ts` declaring which fields are `preview` vs `commit`),
+    validator rules, `applyOverride` — all plugged into the engine
+    above.
 - **Recycle from legacy `speciesConfig.ts`:** the existing
   `validateEditableConfig` already implements range checks, monotonic
   lifecycle ordering, and unknown-field rejection — port those rules

--- a/docs/plans/2026-04-26-pre-v1-demo-json-preview-commit.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-json-preview-commit.md
@@ -39,7 +39,7 @@ keyed off a whitelist of safely previewable fields.
 
 | # | Slice | Files | Spec FRs | Status | PR |
 |---|---|---|---|---|---|
-| 4.1 | Whitelisted-field schema + validator (pure domain) — relocates `speciesConfig.ts`'s pure logic (`EditableSpeciesConfig`, `currentEditableConfig`, `validateEditableConfig`, `applyOverride`) into `demo-domain/scenarios/petCare/config/` and replaces the implicit list with the design's explicit `{ path, kind: 'preview' \| 'commit' }` whitelist | `examples/product-demo/src/demo-domain/scenarios/petCare/config/{types.ts,schema.ts,validate.ts,diff.ts,applyOverride.ts}`, `examples/product-demo/test/demo-domain/scenarios/petCare/config/*.test.ts` | P4-FR-2, P4-FR-6 | not started | — |
+| 4.1 | Cross-scenario config engine (pure domain) + pet-care relocation: NEW `demo-domain/config/` engine (`ConfigPath`, `ValidationFinding`, `ConfigDraft` shape, schema-driven validator/diff framework) + RELOCATED `speciesConfig.ts`'s pure logic (`EditableSpeciesConfig` → `NormalizedConfig`, `validateEditableConfig` rules, `applyOverride`) into `demo-domain/scenarios/petCare/config/` plugged into the engine. Replaces the implicit allow-list with the design's explicit `{ path, kind: 'preview' \| 'commit' }` whitelist. | `examples/product-demo/src/demo-domain/config/{types.ts,validateEngine.ts,diff.ts}` (cross-scenario, new), `examples/product-demo/src/demo-domain/scenarios/petCare/config/{schema.ts,validate.ts,applyOverride.ts}` (per-scenario, recycled), `examples/product-demo/test/demo-domain/config/*.test.ts`, `examples/product-demo/test/demo-domain/scenarios/petCare/config/*.test.ts` | P4-FR-2, P4-FR-6 | not started | — |
 | 4.2 | `useConfigDraft` domain store + preview lifecycle (headless) | `examples/product-demo/src/stores/domain/useConfigDraft.ts`, `examples/product-demo/test/stores/domain/useConfigDraft.test.ts` | P4-FR-1, P4-FR-3, P4-FR-5 | not started | — |
 | 4.3 | Editor view: Preview / Commit+Restart actions, diff summary, inline validation; **delete** legacy `examples/product-demo/src/speciesConfig.ts` once its mount logic is fully replaced | `examples/product-demo/src/views/JsonEditorView.vue`, `examples/product-demo/src/components/config/{EditorPanel.vue,DiffSummary.vue,ValidationList.vue,ActionRow.vue}`, `examples/product-demo/src/stores/view/useJsonEditorView.ts`, `examples/product-demo/eslint.config.js` (drop `speciesConfig.ts` from `ignores`) | P4-FR-3, P4-FR-4 | not started | — |
 | 4.4 | Storage migration cleanup + commit-triggers-fingerprint wiring | `examples/product-demo/src/app/main.ts` (legacy purge tick), `examples/product-demo/src/stores/domain/useConfigDraft.ts` (commit handshake with `useFingerprintRecorder`) | P4-FR-7, P4-AC-5 | not started | — |
@@ -52,13 +52,21 @@ keyed off a whitelist of safely previewable fields.
   All other fields are commit-only by default — explicit > implicit.
 - Validators return `ValidationFinding[]`; tests assert that an invalid
   draft never partially applies (P4-AC-4 evidence).
+- **Two-layer split:**
+  - `demo-domain/config/` (NEW, cross-scenario engine): `ConfigPath`,
+    `ValidationFinding`, `ConfigDraft` shape, generic schema-driven
+    validator + diff framework. No pet-care knowledge here.
+  - `demo-domain/scenarios/petCare/config/` (RECYCLED from legacy
+    `speciesConfig.ts`): pet-care-specific schema + validator rules +
+    `applyOverride`, plugged into the engine above.
 - **Recycle from legacy `speciesConfig.ts`:** the existing
   `validateEditableConfig` already implements range checks, monotonic
   lifecycle ordering, and unknown-field rejection — port those rules
-  verbatim into `validate.ts` (translate the ad-hoc error strings into
-  `ValidationFinding` codes per spec). `applyOverride` already handles
-  the partial-edit merge — port it into `applyOverride.ts` and add the
-  test guarantee that an invalid draft never half-applies. The legacy
+  verbatim into `scenarios/petCare/config/validate.ts` (translate the
+  ad-hoc error strings into `ValidationFinding` codes per spec).
+  `applyOverride` already handles the partial-edit merge — port it
+  into `scenarios/petCare/config/applyOverride.ts` and add the test
+  guarantee that an invalid draft never half-applies. The legacy
   `EditableSpeciesConfig` shape becomes the starting point for
   `NormalizedConfig` (rename + add `__brand` if needed).
 

--- a/docs/plans/2026-04-26-pre-v1-demo-second-scenario.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-second-scenario.md
@@ -17,20 +17,31 @@ second scenario.
 
 ## Pre-flight
 
-- Blocked by: rename preflight.
+- Blocked by: rename preflight + Pillar-1 slice 1.2a (the pet-care
+  modules already live under `demo-domain/scenarios/petCare/`).
 - The `Scenario` interface is locked in the design doc. Concept of the
   `companion-npc` scenario is **OQ-P5** — settle in the kickoff for
   slice 5.3.
 - Coordinate with **Pillar 3**: scenario id is part of the fingerprint
   scope key. Confirm `useFingerprintRecorder.beginWindow` accepts a
   scenario id by the time slice 5.2 lands.
+- **Legacy recycle.** Pillar-1 slice 1.2a `git mv`-relocated the
+  pet-care species, constants, cognition, and skills into
+  `examples/product-demo/src/demo-domain/scenarios/petCare/`, and introduced
+  `demo-domain/scenarios/petCare/buildAgent.ts` as the agent-construction recipe.
+  Slice 5.2 below is therefore a much lighter refactor than originally
+  scoped: it WRAPS the existing modules in the design's `Scenario`
+  contract rather than relocating them. Pillar-4 may also have already
+  ported `speciesConfig.ts`'s `applyOverride` into
+  `demo-domain/scenarios/petCare/config/` by the time 5.2 lands — consume that
+  if so.
 
 ## Roadmap
 
 | # | Slice | Files | Spec FRs | Status | PR |
 |---|---|---|---|---|---|
 | 5.1 | `Scenario` contract + `useScenarioCatalog` domain store | `examples/product-demo/src/demo-domain/scenarios/{types.ts,catalog.ts}`, `examples/product-demo/src/stores/domain/useScenarioCatalog.ts`, `examples/product-demo/test/**` | P5-FR-1 | not started | — |
-| 5.2 | Refactor nurture-pet into `pet-care` scenario (no behavioral change) + scenario selector UI + `/play/:scenarioId` route | `examples/product-demo/src/demo-domain/scenarios/petCare/{index.ts,skills.ts,config.ts}`, `examples/product-demo/src/components/shell/ScenarioSelector.vue`, `examples/product-demo/src/routes/index.ts` | P5-FR-2, P5-FR-4, P5-AC-1 | not started | — |
+| 5.2 | Wrap existing `demo-domain/scenarios/petCare/` modules in `Scenario` contract (no module relocation needed — Pillar-1 slice 1.2a already moved them) + scenario selector UI + `/play/:scenarioId` route | `examples/product-demo/src/demo-domain/scenarios/petCare/scenario.ts` (new — composes `species.ts` / `cognition/index.ts` / `skills/*` / `buildAgent.ts` / `config/*` into a single `Scenario` value), `examples/product-demo/src/components/shell/ScenarioSelector.vue`, `examples/product-demo/src/routes/index.ts` | P5-FR-2, P5-FR-4, P5-AC-1 | not started | — |
 | 5.3 | `companion-npc` reference scenario implementation (concept-locked at kickoff) | `examples/product-demo/src/demo-domain/scenarios/companionNpc/{index.ts,skills.ts,config.ts}`, `examples/product-demo/test/demo-domain/scenarios/companionNpc.test.ts` | P5-FR-3, P5-AC-2 | not started | — |
 | 5.4 | Per-scenario seed/config scoping + Playwright `scenario-swap.spec.ts` | `examples/product-demo/src/stores/domain/useScenarioCatalog.ts` (per-scenario persistence keys), `examples/product-demo/tests/e2e/scenario-swap.spec.ts` | P5-FR-5, P5-FR-6, P5-AC-3, P5-AC-4, P5-AC-5 | not started | — |
 
@@ -45,12 +56,17 @@ second scenario.
   and `getScopeKeyComponent()` so other domain stores can include the
   scenario id in their scope keys.
 
-### 5.2 — Refactor without regression
+### 5.2 — Wrap, not relocate (refactor without regression)
 
-- Move the existing nurture-pet skill registrations + species defaults
-  into `demo-domain/scenarios/petCare/`. Behavior must not change;
-  existing tests that reference the pet defaults are updated to import
-  from the new path.
+- Pillar-1 slice 1.2a already relocated the pet-care modules into
+  `demo-domain/scenarios/petCare/`. Slice 5.2 ADDS `demo-domain/scenarios/petCare/scenario.ts`
+  that composes those modules into a single `Scenario` value (per the
+  design's `Scenario` contract: `id`, `displayName`, `narrative`,
+  `seedScope`, `skillBundle`, `configSchema`, `initialAgentSpec`).
+- No module path changes. No behavioral change. Existing tests stay
+  put; the new `scenario.ts` plus its registration in
+  `useScenarioCatalog` are the entire diff alongside the selector UI
+  + route.
 - The scenario selector UI lives in the shell header. Selecting
   triggers `useScenarioCatalog.setActive`, which navigates via the
   domain-store wrapper (per the design's "components do not call

--- a/docs/plans/2026-04-26-pre-v1-demo-second-scenario.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-second-scenario.md
@@ -18,7 +18,11 @@ second scenario.
 ## Pre-flight
 
 - Blocked by: rename preflight + Pillar-1 slice 1.2a (the pet-care
-  modules already live under `demo-domain/scenarios/petCare/`).
+  species/constants/cognition/skills already live under
+  `demo-domain/scenarios/petCare/`) + Pillar-4 slice **4.1** (the
+  pet-care `config/` subfolder must exist before `scenario.ts` can
+  compose it as the `Scenario.configSchema` field — the relocation
+  is what 4.1 does).
 - The `Scenario` interface is locked in the design doc. Concept of the
   `companion-npc` scenario is **OQ-P5** — settle in the kickoff for
   slice 5.3.
@@ -27,14 +31,14 @@ second scenario.
   scenario id by the time slice 5.2 lands.
 - **Legacy recycle.** Pillar-1 slice 1.2a `git mv`-relocated the
   pet-care species, constants, cognition, and skills into
-  `examples/product-demo/src/demo-domain/scenarios/petCare/`, and introduced
-  `demo-domain/scenarios/petCare/buildAgent.ts` as the agent-construction recipe.
-  Slice 5.2 below is therefore a much lighter refactor than originally
-  scoped: it WRAPS the existing modules in the design's `Scenario`
-  contract rather than relocating them. Pillar-4 may also have already
-  ported `speciesConfig.ts`'s `applyOverride` into
-  `demo-domain/scenarios/petCare/config/` by the time 5.2 lands — consume that
-  if so.
+  `examples/product-demo/src/demo-domain/scenarios/petCare/`, and
+  introduced `demo-domain/scenarios/petCare/buildAgent.ts` as the
+  agent-construction recipe. Pillar-4 slice 4.1 then ported
+  `speciesConfig.ts`'s `validateEditableConfig` + `applyOverride`
+  into `demo-domain/scenarios/petCare/config/`. Slice 5.2 below is
+  therefore a much lighter refactor than originally scoped: it
+  WRAPS the existing modules in the design's `Scenario` contract
+  rather than relocating them.
 
 ## Roadmap
 

--- a/docs/product/2026-04-26-pre-v1-demo-evolution-plan.md
+++ b/docs/product/2026-04-26-pre-v1-demo-evolution-plan.md
@@ -122,6 +122,46 @@ This increment is intentionally **pre-v1**. We optimize for a clean architecture
 - No requirement to keep transitional APIs if a cleaner API exists.
 - Determinism and testability remain non-negotiable; compatibility is negotiable.
 
+## Legacy code recycling (cross-cutting)
+
+"Pre-v1" does **not** mean "rewrite everything from scratch". The legacy
+vanilla-TS demo on `develop` (post-Wave-0) contains a substantial body
+of pure domain logic — species descriptor, cognition mode probes +
+reasoner constructors + softmax helpers, skill, random-event defs,
+config validator, SVG renderers — that is fully reusable under the new
+Vue/Pinia/Router shell.
+
+**Pillar-1 slice 1.2a** does the bulk of the salvage via `git mv`
+(history preserved): `species.ts`, `constants.ts`, `cognition/**`,
+`skills/**` move into `examples/product-demo/src/demo-domain/scenarios/petCare/`,
+and a new `buildAgent.ts` factory extracts the random-event +
+agent-construction recipe from the legacy `main.ts` verbatim.
+
+**Pillar-1 slice 1.2b** ports the DOM-mount UI (`mountHud`,
+`mountTraceView`) into Vue SFCs that reuse the legacy data tables
+(`INTERACTION_BUTTONS`, `STAGE_LABELS`, `LIFETIME_COUNTERS`, per-need
+bar markup) verbatim, then deletes the now-orphaned legacy mount files.
+
+**Pillar 2** ports `cognitionSwitcher.ts` (46 KB) into
+`<CognitionSwitcher>` + `useAgentSession.setMode()`, and the pure SVG
+renderers (`lossSparkline.ts`, `predictionStrip.ts`) into thin Vue SFCs
+that consume compute helpers extracted into `demo-domain/scenarios/petCare/cognition/`.
+
+**Pillar 4** ports `speciesConfig.ts`'s `EditableSpeciesConfig` +
+`validateEditableConfig` + `applyOverride` into
+`demo-domain/scenarios/petCare/config/` (validator + apply rules
+verbatim), and the `mountConfigPanel` mount becomes the `<JsonEditor>`
+SFC family.
+
+**Pillar 5 slice 5.2** is much lighter than originally scoped: the
+pet-care modules already live under `demo-domain/scenarios/petCare/`
+thanks to slice 1.2a, so 5.2 just wraps them in the design's
+`Scenario` contract rather than relocating them.
+
+The full per-module recycle map (with destination paths and timing)
+lives in the design doc under `Legacy code recycling`; per-pillar
+plans repeat the relevant rows in their `Pre-flight` and slice notes.
+
 ## 1) Guided walkthrough mode (from optional docs flow to in-product flow)
 
 ### Outcome

--- a/docs/specs/2026-04-26-pre-v1-demo-evolution-design.md
+++ b/docs/specs/2026-04-26-pre-v1-demo-evolution-design.md
@@ -78,7 +78,13 @@ examples/product-demo/src/
 │       └── useShellLayout.ts
 ├── composables/               # cross-cutting hooks (router-aware, focus, a11y)
 ├── demo-domain/               # demo-specific domain modules (NOT in `agentonomous`)
-│   ├── scenarios/             # Scenario contract impls (pet-care, companion-npc)
+│   ├── scenarios/             # Scenario contract impls
+│   │   ├── petCare/           # bootstrapped in Pillar-1 slice 1.2a (`git mv` from
+│   │   │                      # legacy `species.ts` / `constants.ts` / `cognition/*` /
+│   │   │                      # `skills/*` + new `buildAgent.ts` extracting random-event
+│   │   │                      # defs from legacy `main.ts`); wrapped in Scenario contract
+│   │   │                      # in Pillar-5 slice 5.2
+│   │   └── companionNpc/      # added in Pillar-5 slice 5.3
 │   ├── walkthrough/           # step-graph definitions + completion predicates
 │   ├── diff/                  # rolling-window metric helpers
 │   ├── fingerprint/           # normalizer + hash function
@@ -90,6 +96,47 @@ examples/product-demo/src/
 `examples/product-demo/` is the renamed workspace as of Wave-0 (preflight
 shipped 2026-04-26). The old workspace name has been retired; the per-pillar
 plans below all assume `examples/product-demo/` from day 1.
+
+### Legacy code recycling
+
+The increment is intentionally pre-v1 (no compat shims), but "no compat"
+does not mean "rewrite everything from scratch". The legacy vanilla-TS
+demo on `develop` after Wave-0 contains a substantial body of pure
+domain logic (species descriptor, cognition mode probes + reasoner
+constructors + softmax helpers, skill, random-event defs, config
+validator, SVG renderers) that is fully reusable under the new shell.
+Each pillar plan calls out exactly what it recycles vs rebuilds. The
+recycle map for the increment as a whole:
+
+| Legacy module | Reuse strategy | Lands in |
+|---|---|---|
+| `src/species.ts`, `src/constants.ts` | `git mv` (history preserved) — pure data | Pillar-1 slice 1.2a → `demo-domain/scenarios/petCare/{species,constants}.ts` |
+| `src/cognition/{heuristic,bt,bdi,learning,index}.ts` + `learning.network.json` | `git mv` — pure TS, peer-dep probes intact | Pillar-1 slice 1.2a → `demo-domain/scenarios/petCare/cognition/` |
+| `src/skills/ApproachTreatSkill.ts` | `git mv` — pure Skill | Pillar-1 slice 1.2a → `demo-domain/scenarios/petCare/skills/` |
+| Random-event defs + skill-registry wiring + `createAgent` call from `src/main.ts` | Extract verbatim into a `buildAgent({ seed, speciesOverride? })` factory | Pillar-1 slice 1.2a → `demo-domain/scenarios/petCare/buildAgent.ts` |
+| `src/seed.ts loadSeed()` | Storage-key migration to `demo.v2.session.lastSeed.<scenarioId>` (no key migration — pre-v1 clean break); copy/new/replay buttons port to `<SeedPanel>` in Pillar-3 slice 3.3 | Pillar-1 slice 1.2a (`useAgentSession`) + Pillar-3 slice 3.3 (`<SeedPanel>`) |
+| `src/ui.ts mountHud / mountSpeedPicker / mountResetButton / mountExportImport` | Port DOM-mount fns to Vue SFCs; reuse `INTERACTION_BUTTONS`, `STAGE_LABELS`, `LIFETIME_COUNTERS`, per-need bar markup verbatim | Pillar-1 slice 1.2b → `<HudPanel>` / `<SpeedPicker>` / `<ResetButton>` / `<ExportImportPanel>` |
+| `src/traceView.ts mountTraceView` | Port four-section computation; Vue handles reactivity (drop the manual signature-diff trick) | Pillar-1 slice 1.2b → `<TracePanel>` |
+| `src/cognitionSwitcher.ts` (46 KB) | Port to `<CognitionSwitcher>` SFC; mode-construction logic moves to `useAgentSession.setMode()` | Pillar-2 slice 2.5 |
+| `src/lossSparkline.ts` / `src/predictionStrip.ts` | Pure SVG renderers — extract compute helpers into `demo-domain/scenarios/petCare/cognition/` and let thin Vue SFCs render | Pillar-2 slice 2.5 → `<LossSparkline>` / `<PredictionStrip>` |
+| `src/speciesConfig.ts` | Port `EditableSpeciesConfig` shape, `validateEditableConfig`, `applyOverride` into `demo-domain/scenarios/petCare/config/`; `mountConfigPanel` becomes `<JsonEditor>` SFC family | Pillar-4 slices 4.1 (validator + applyOverride) + 4.3 (editor SFCs + delete legacy file) |
+
+Module-deletion timeline (per pre-v1 clean break):
+
+- **Slice 1.2a** deletes nothing — only `git mv`s.
+- **Slice 1.2b** deletes `src/{ui.ts, traceView.ts, seed.ts, main.ts}`.
+  `cognitionSwitcher.ts`, `lossSparkline.ts`, `predictionStrip.ts`,
+  `speciesConfig.ts` stay until **Pillar 2 slice 2.5** and **Pillar 4
+  slice 4.3** respectively port them. The demo eslint config's `ignores`
+  list shrinks every step.
+- **Pillar 5 slice 5.2** is therefore much lighter than originally
+  scoped: it WRAPS the existing `demo-domain/scenarios/petCare/`
+  modules in the `Scenario` contract rather than relocating them.
+
+The `Scenario` contract under "Cross-pillar contracts" below is the
+final shape every pet-care module gets composed into; nothing in the
+recycle map blocks adding `companion-npc` as a peer in Pillar-5 slice
+5.3.
 
 ### Build + dev commands (unchanged contract, renamed targets)
 

--- a/docs/specs/2026-04-26-pre-v1-demo-evolution-design.md
+++ b/docs/specs/2026-04-26-pre-v1-demo-evolution-design.md
@@ -78,17 +78,24 @@ examples/product-demo/src/
 │       └── useShellLayout.ts
 ├── composables/               # cross-cutting hooks (router-aware, focus, a11y)
 ├── demo-domain/               # demo-specific domain modules (NOT in `agentonomous`)
-│   ├── scenarios/             # Scenario contract impls
+│   ├── scenarios/             # Scenario contract impls (each owns its species + skills + per-scenario config schema)
 │   │   ├── petCare/           # bootstrapped in Pillar-1 slice 1.2a (`git mv` from
-│   │   │                      # legacy `species.ts` / `constants.ts` / `cognition/*` /
-│   │   │                      # `skills/*` + new `buildAgent.ts` extracting random-event
-│   │   │                      # defs from legacy `main.ts`); wrapped in Scenario contract
-│   │   │                      # in Pillar-5 slice 5.2
+│   │   │   ├── species.ts     # legacy `species.ts` / `constants.ts` / `cognition/*` /
+│   │   │   ├── constants.ts   # `skills/*` + new `buildAgent.ts` extracting random-event
+│   │   │   ├── cognition/     # defs from legacy `main.ts`); wrapped in Scenario contract
+│   │   │   ├── skills/        # in Pillar-5 slice 5.2. Pillar-4 slice 4.1 also adds a
+│   │   │   ├── config/        # `config/` subfolder porting `speciesConfig.ts`'s
+│   │   │   ├── buildAgent.ts  # `validateEditableConfig` + `applyOverride` + the
+│   │   │   └── scenario.ts    # pet-care-specific schema (the cross-scenario engine
+│   │   │                      # lives in `demo-domain/config/` below).
 │   │   └── companionNpc/      # added in Pillar-5 slice 5.3
-│   ├── walkthrough/           # step-graph definitions + completion predicates
-│   ├── diff/                  # rolling-window metric helpers
-│   ├── fingerprint/           # normalizer + hash function
-│   └── config/                # whitelisted-field schema + validator
+│   ├── walkthrough/           # step-graph definitions + completion predicates (cross-scenario)
+│   ├── diff/                  # rolling-window metric helpers (cross-scenario)
+│   ├── fingerprint/           # normalizer + hash function (cross-scenario)
+│   └── config/                # cross-scenario engine: ConfigPath, ValidationFinding,
+│                              # ConfigDraft shape, schema/validator framework. Each
+│                              # scenario plugs its own per-scenario schema in via
+│                              # `demo-domain/scenarios/<id>/config/`.
 ├── copy/                      # English-only UI strings, grouped by pillar
 └── styles/                    # tokens, layout, component overrides
 ```


### PR DESCRIPTION
## Summary

Revises the pre-v1 demo evolution plans + design + planning doc to PORT rather than REBUILD the pure domain logic + tested helpers in the legacy vanilla-TS demo. Pre-v1 still applies (no compat shims, clean-break storage keys), but "no compat" never meant "rewrite from scratch".

## Recycle map (full table lives in design doc → "Legacy code recycling")

| Legacy file(s) | Reuse strategy | Lands in |
|---|---|---|
| `species.ts`, `constants.ts`, `cognition/**`, `skills/**` | `git mv` — pure data + pure TS | Pillar-1 **slice 1.2a** → `demo-domain/scenarios/petCare/` |
| Random-event defs + skill registry wiring + `createAgent` from `main.ts` | Extract verbatim into a `buildAgent` factory | Pillar-1 slice 1.2a → `demo-domain/scenarios/petCare/buildAgent.ts` |
| `seed.ts loadSeed()` | Storage-key migration into `useAgentSession`; copy/new/replay buttons port to `<SeedPanel>` | Pillar-1 1.2a + Pillar-3 slice 3.3 |
| `ui.ts mountHud / mountSpeedPicker / mountResetButton / mountExportImport` | Port DOM-mount fns to Vue SFCs; reuse data tables verbatim | Pillar-1 **slice 1.2b** |
| `traceView.ts mountTraceView` | Port four-section computation; Vue handles reactivity | Pillar-1 slice 1.2b → `<TracePanel>` |
| `cognitionSwitcher.ts` (46 KB) | Port to `<CognitionSwitcher>` SFC + `useAgentSession.setMode()` | **Pillar-2 slice 2.5** |
| `lossSparkline.ts` / `predictionStrip.ts` | Pure SVG renderers — extract compute helpers + thin Vue SFCs | Pillar-2 slice 2.5 |
| `speciesConfig.ts` | Port `EditableSpeciesConfig` + `validateEditableConfig` + `applyOverride` into `demo-domain/scenarios/petCare/config/` | **Pillar-4 slices 4.1 + 4.3** |

## What changes per file

- **Design doc** — adds the "Legacy code recycling" cross-cutting section with the per-module reuse table + deletion timeline; updates folder layout to show `demo-domain/scenarios/{petCare,companionNpc}/` with petCare bootstrapped in 1.2a.
- **Planning doc** — adds a planning-level "Legacy code recycling" subsection right after the pre-v1 policy block.
- **Pillar-1 plan** — splits slice 1.2 → 1.2a (bootstrap + salvage) + 1.2b (chapter-1 vertical + DOM-mount port + delete now-orphaned legacy files); explicit dep list for 1.2a; tour copy tone (OQ-P1) decision moves to 1.2b.
- **Pillar-2 plan** — adds slice 2.5 (port `cognitionSwitcher.ts` + SVG renderers); pre-flight declares 1.2a dependency + recycle plan.
- **Pillar-3 plan** — pre-flight notes seed.ts absorption into `useAgentSession`; slice 3.3 reintroduces `<SeedPanel>` ported from `mountSeedPanel`.
- **Pillar-4 plan** — slice 4.1 RELOCATES `speciesConfig.ts`'s pure logic rather than rebuilding; slice 4.3 deletes the legacy file.
- **Pillar-5 plan** — slice 5.2 scope-reduces to "wrap, not relocate" (modules already under `demo-domain/scenarios/petCare/` thanks to 1.2a).

## Out of scope

- Source code changes (none).
- New pillar additions or contract changes (the `Scenario` / `WalkthroughStep` / `DiffMetric` / `RunFingerprint` / `ConfigDraft` contracts are unchanged).
- Plan tracker-row flips for already-shipped slices (slice 1.1 row stays at ✅ shipped #140).

## Test plan

- [x] Prettier: `npx prettier --check` passes on the 7 modified docs.
- [x] No code changes — no `npm run verify` needed (root `eslint.config.js` ignores `docs/`; demo workspace eslint scope unchanged).
- [ ] Codex review.

Tracks: #132