### PR TITLE
chore(lint-staged): per-workspace config for examples/product-demo

### DIFF
--- a/examples/product-demo/package.json
+++ b/examples/product-demo/package.json
@@ -29,5 +29,14 @@
     "vite": "^8.0.8",
     "vue": "^3.5.0",
     "vue-router": "^4.5.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,vue,mjs,cjs,d.mts}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md,yml,yaml,html,css}": [
+      "prettier --write"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `lint-staged` block to `examples/product-demo/package.json` so lint-staged 16 discovers two configs and routes staged files to each workspace's ESLint subprocess (with cwd inside that workspace).
- Unblocks merge commits that touch files in both workspaces (root \`src/\` + demo `examples/product-demo/src/`) — pre-commit hook had been failing with `not found by the project service` despite \`npm run verify\` being green.

## Why

`typescript-eslint`'s `projectService` is a singleton — initialised lazily on the first parse. When lint-staged 16 batches files from both workspaces into one ESLint invocation and a demo `.ts` file gets parsed first, the projectService binds to the demo `tsconfig` and rejects subsequent root paths (`scripts/*.mjs` aren't in `examples/product-demo/tsconfig.json`).

Reproducer:

\`\`\`
npx eslint examples/product-demo/test/demo-domain/walkthrough/index.test.ts \
           scripts/append-size-snapshot.mjs
# → Parsing error: scripts/append-size-snapshot.mjs was not found by the project service.
#   allowDefaultProject is set to ["eslint.config.js","vite.config.ts","playwright.config.ts"],
#   which does not match 'scripts/append-size-snapshot.mjs'

# Reverse the order:
npx eslint scripts/append-size-snapshot.mjs \
           examples/product-demo/test/demo-domain/walkthrough/index.test.ts
# → no error
\`\`\`

Order-dependence confirms a singleton-state leak rather than a config mismatch.

## Fix

`lint-staged` 16 walks staged files and matches each to the closest `lint-staged` config. With a config now present in `examples/product-demo/package.json`, lint-staged spawns a separate ESLint process per workspace (cwd inside each), so each invocation only ever sees one workspace's files and one workspace's projectService.

## Test plan

- [x] \`npm run verify\` green
- [x] Reproducer reverses to clean output via lint-staged path:
  - touch demo `.ts` + root `.mjs`, \`git add\`, \`npx lint-staged --debug\` → "Found 2 config files", spawns 2 separate ESLint runs, all complete successfully
- [x] Existing single-workspace stagings still work (1-file commit during this PR exercised the demo lint-staged config)
- [ ] Owner: confirm next merge of `develop` into a docs branch (e.g. PR #143) no longer trips the pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)