### PR TITLE
fix(routine): plan-recon-bot post-#143 review followups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ examples/**/playwright-report
 examples/**/test-results
 .worktrees
 .review-fix-cache
+.plan-recon-cache/
 .claude/settings.local.json
 .claude/.last-run
 

--- a/docs/plan-recon-bot/PROMPT.md
+++ b/docs/plan-recon-bot/PROMPT.md
@@ -50,8 +50,11 @@ For each plan file, decide:
   table is `- [x] shipped` (or a synonym: `shipped via #NNN`,
   `complete`), AND the plan's last commit on `origin/develop` is
   ≥ 14 days old, AND no live work in the repo points at it.
-  Successor-supersession also counts: if the plan body or its tracker
-  issue links forward to a successor plan, archive the predecessor.
+  Successor-supersession is the only path that overrides the
+  "every row shipped" requirement, and it requires BOTH a successor
+  link in the plan body AND a closed tracker issue — see
+  [Cross-check 4](#cross-checks-run-before-deciding-b) for the full
+  precedence (a successor link alone is NOT enough).
 - **(c) Flag for owner** if the evidence is genuinely ambiguous — e.g.
   the tracker table looks complete but the umbrella issue has unclosed
   child issues, or two plans cover overlapping scope and it isn't
@@ -102,8 +105,22 @@ and opens one PR per run.
 git fetch origin
 RUN_DATE="$(date -u +%F)"
 BRANCH="docs/plan-recon-${RUN_DATE}"
-git worktree add ".worktrees/${BRANCH//\//-}" -b "${BRANCH}" origin/develop
-cd ".worktrees/${BRANCH//\//-}"
+WORKTREE_DIR=".worktrees/${BRANCH//\//-}"
+
+# Prune any stale branch / worktree from a same-day rerun BEFORE the
+# worktree-add below. A failed earlier run on the same UTC date leaves
+# `${BRANCH}` and/or `${WORKTREE_DIR}` behind; without this guard,
+# `git worktree add ... -b "${BRANCH}"` aborts with `fatal: a branch
+# named '${BRANCH}' already exists` and the routine never gets past
+# startup. Same prune body as [Recon-branch abandonment](#recon-branch-abandonment)
+# below — kept inline here so it runs first.
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  git worktree remove --force "${WORKTREE_DIR}" 2>/dev/null || true
+  git branch -D "${BRANCH}" 2>/dev/null || true
+fi
+
+git worktree add "${WORKTREE_DIR}" -b "${BRANCH}" origin/develop
+cd "${WORKTREE_DIR}"
 npm ci
 ```
 
@@ -133,12 +150,25 @@ For each plan that passed the [Cross-checks](#cross-checks-run-before-deciding-b
    fi
    ```
 
-3. **Stage the archive banner edit + the `git mv`** as one logical
-   change per plan. One commit per plan keeps the PR diff readable
-   and lets the owner revert a single move without losing the
-   others.
+3. **Stage and commit the archive banner edit + the `git mv`** as one
+   logical change per plan. One commit per plan keeps the PR diff
+   readable and lets the owner revert a single move without losing the
+   others. The `git mv` itself already updates the index, but the
+   banner edit needs an explicit `git add` of the archived path before
+   the commit. Skip the commit in dry-run mode.
 
-After every move is staged:
+   ```bash
+   if [ -n "${DRY_RUN:-}" ]; then
+     printf '[DRY_RUN] would call: git add %q && git commit -m %q\n' \
+       "docs/archive/plans/${PLAN}" \
+       "docs(archive): ${PLAN%.md}"
+   else
+     git add "docs/archive/plans/${PLAN}"
+     git commit -m "docs(archive): ${PLAN%.md}"
+   fi
+   ```
+
+After every move is committed:
 
 4. **Run the verify gate.** `npm run verify` must stay green even
    after the moves — links inside the archived plans that resolve
@@ -146,10 +176,10 @@ After every move is staged:
    files (e.g. an active doc that still points at
    `docs/plans/<file>` instead of `docs/archive/plans/<file>`) are
    not. If verify fails on a broken link, route through
-   [Failure handling](#failure-handling) (unstage the moves, open
-   the failure issue, exit 1) — do not silently rewrite links to
-   make verify pass, and do not leave a dirty index for the next
-   monthly run to inherit.
+   [Failure handling](#failure-handling) (reset the recon branch back
+   to `origin/develop`, open the failure issue, exit 1) — do not
+   silently rewrite links to make verify pass, and do not leave local
+   commits on the recon branch for the next monthly run to inherit.
 
    ```bash
    npm run verify
@@ -388,7 +418,7 @@ accidentally trust signals from arbitrary users.
 
 ## Skip check (run at the start of every run)
 
-Two duplicate-detection checks run before any move is staged:
+Two duplicate-detection checks run before any move is committed:
 
 ### 1. Same-day re-run on the same `origin/develop` head SHA
 
@@ -513,16 +543,19 @@ in-progress staged moves so the run produces realistic verify-pass /
 verify-fail signals. Under no circumstances trigger `git push`,
 `gh pr create`, or `gh issue create` from that path.
 
-In dry-run mode, do NOT write any cache files. Dry runs leave zero
-filesystem side effects beyond the staged-but-uncommitted working tree.
+In dry-run mode, do NOT write any cache files and do NOT commit. Dry
+runs leave zero filesystem side effects beyond the staged-but-
+uncommitted working tree.
 Exit 0 after dumping.
 
 # Failure handling
 
 If anything in the run fails — `git mv` errors, `npm run verify` fails,
 the archive parse breaks, `git push` fails, etc. — abort the run,
-unstage the moves on the recon branch, open a failure issue, and exit
-1.
+reset the recon branch back to `origin/develop` (`git reset --hard
+origin/develop`) so the local commits vanish, open a failure issue,
+and exit 1. The recon branch is never pushed before verify, so this
+reset is local-only.
 
 ## Issue spec
 
@@ -536,7 +569,7 @@ unstage the moves on the recon branch, open a failure issue, and exit
 
   Run id: plan-recon-<UTC-iso8601>
   Stage: git mv / verify / parse / push / pr-open
-  Plans staged before failure: <list>
+  Plans committed before failure: <list>
 
   <details><summary>Verbatim failure tail (last 40 lines)</summary>
 

--- a/docs/plan-recon-bot/README.md
+++ b/docs/plan-recon-bot/README.md
@@ -216,11 +216,19 @@ Each per-run issue carries exactly its routine's label — no
 cross-labelling, no shared `automation` umbrella label. Filter the
 issue list by label to see one routine's full history.
 
-For `plan-recon-bot` specifically, the label-tagged surface is the
-**failure issue**, not the archive PR (the PR is filterable by
-title pattern + base branch). An empty `plan-recon-bot` label view
-is the desired state — every issue in there is a real failure
-needing investigation.
+For `plan-recon-bot` specifically, the label-tagged surface covers
+**two distinct issue types** (the archive PR is filterable separately
+by title pattern + base branch):
+
+| Issue type | Title prefix | Marker | Meaning |
+| ---------- | ------------ | ------ | ------- |
+| Failure issue | `Plan reconciliation YYYY-MM-DD — <head-sha7>` | `<!-- plan-recon:<head-sha7>:failed -->` | Run aborted on `git mv` / `verify` / `push` / `pr-open`. Investigate. |
+| Ambiguous-only triage issue | `Ambiguous plan candidates YYYY-MM-DD — <head-sha7>` | `<!-- plan-recon:<head-sha7>:ambiguous-only -->` | Run completed cleanly, zero archive moves but ≥1 ambiguous flag. Owner triage. |
+
+An empty `plan-recon-bot` label view means the routine has not
+surfaced anything for owner attention recently — neither failure
+nor ambiguous candidates. Triage the label by reading the title /
+marker before assuming "issue here = failure".
 
 ## Related
 


### PR DESCRIPTION
Refs: Codex round-7 review on #143 (the merge commit `91b2fde360`,
which landed the moment #143 merged). Tackles the five P1/P2
findings on develop in one pass instead of waiting for the first
monthly run to break.

## What changed

| File | Finding | Fix |
| ---- | ------- | --- |
| `docs/plan-recon-bot/PROMPT.md` ~282 | **P1** No `git commit` between staging and `git push -u origin`. Push would have produced an empty branch and `gh pr create` would have failed with no diff. | Step 3 now stages AND commits per plan (matches its own "one commit per plan" rationale at line 137). Verify-fail language updated from "unstage the moves" → "`git reset --hard origin/develop`". `Plans staged before failure` → `Plans committed before failure`. |
| `docs/plan-recon-bot/PROMPT.md` ~106 | **P2** `git worktree add ... -b "${BRANCH}"` ran before the prune snippet at line 597, so same-day reruns aborted with `fatal: a branch named ... already exists`. | Inline prune-on-entry guard immediately before the worktree-add, mirroring the body in `## Recon-branch abandonment`. |
| `docs/plan-recon-bot/PROMPT.md` line 53-54 | **P2** Decision-policy (b) successor clause restated the supersession rule loosely (no tracker-closure gate), conflicting with Cross-check 4 + the hard rule. Codex resurfaced the same conflict for four straight rounds because three sections each restated the rule in different words. | Replaced the duplicate restatement with a forward reference to Cross-check 4 — single source of truth. |
| `.gitignore` | **P2** `.plan-recon-cache/` was promised gitignored by PROMPT.md but never actually added. `git add -A` on a recon branch would have swept cache files into the archive PR. | Added `.plan-recon-cache/` next to `.review-fix-cache`. |
| `docs/plan-recon-bot/README.md` ~219 | **P2** Bot-label section claimed label = failure issues only, but PROMPT.md now opens triage issues under the same label for ambiguous-only runs. | Replaced the paragraph with a two-row table (failure-issue + ambiguous-only) keyed on title prefix and the `<!-- plan-recon:<sha7>:<action> -->` marker. |

## Improvement angle

User asked whether #143 could be made simpler. The recurring
Codex finding (same superseded-plan conflict, four rounds in a
row) was a symptom of the same constraint being restated in three
sections. The decision-policy (b) clause now points at
Cross-check 4 instead of paraphrasing it, so the precedence rule
lives in exactly one place — drift between sections cannot
re-introduce the contradiction.

## Verify

`npm run verify` green from the worktree:

- format:check ✅
- lint ✅
- typecheck ✅
- vitest ✅ 588/588
- build ✅

## Test plan

- [ ] Codex re-reviews this branch and the superseded-plan rule
      no longer trips a finding.
- [ ] Manual read-through of PROMPT.md from top to bottom: the
      successor / open-rows / tracker-issue precedence is stated
      once (Cross-check 4) and referenced from `(b)` + the hard
      rules, not paraphrased.
- [ ] First monthly run picks up the inline prune guard, the
      per-plan commit step, and the `.plan-recon-cache/` ignore
      on entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)