### PR TITLE
docs(memory): squash-merge default + force-delete cleanup

### DIFF
--- a/.claude/memory/feedback_autonomous_merge_after_codex.md
+++ b/.claude/memory/feedback_autonomous_merge_after_codex.md
@@ -25,10 +25,18 @@ all of the following hold**:
 **How to apply:**
 
 - After Codex 👍 + CI green + `mergeStateStatus=CLEAN`, run
-  `gh pr merge <n> --merge --delete-branch` (project uses merge
-  commits, not squash — see recent `Merge pull request #N` history).
+  `gh pr merge <n> --squash --delete-branch` (project switched to
+  **squash-merge** post-PR #119; all PRs from #133 onward land as
+  squash commits with title pattern `<type>: <subject> (#NNN)`. Trying
+  `--merge` returns `enablePullRequestAutoMerge` GraphQL error). Use
+  `--auto` if the head SHA is mid-CI run — GitHub will fire the merge
+  once required checks pass.
+- After local merge commit blocked on CI, the post-merge branch is
+  squash-merged so the local topic branch will not be "fully merged"
+  ancestor of `develop`. Use `git branch -D <topic>` (force) for
+  cleanup, not `-d`.
 - Then `git switch develop && git pull origin develop && git
-worktree remove .worktrees/<slug> && git branch -d <topic>`.
+worktree remove .worktrees/<slug> && git branch -D <topic>`.
 - If Codex finds something or CI fails, do NOT merge — fix and
   re-trigger `@codex review`.
 - If user is paired in real-time and watching, still default to


### PR DESCRIPTION
## Summary

Update `feedback_autonomous_merge_after_codex.md` to reflect two operational shifts already in practice:

- **Project switched to squash-merge** post-PR #119. Every PR from #133 onward lands as a squash commit (`<type>: <subject> (#NNN)`). Previous `gh pr merge <n> --merge --delete-branch` recipe returns `enablePullRequestAutoMerge` GraphQL error.
- **Post-squash topic branches need `-D`** for cleanup. The squash creates a NEW commit SHA, so the local topic branch is no longer an ancestor of develop and `git branch -d <topic>` fails.

Also documents the `--auto` flag for cases where `gh pr merge` is fired while required checks are still mid-run.

## Files changed

- `.claude/memory/feedback_autonomous_merge_after_codex.md` — `--merge` → `--squash`, `-d` → `-D`, plus the `--auto` note.

## Test plan

- [x] `npm run verify` green locally (format:check + lint + typecheck + 588 tests + build + typedoc)
- [x] No `src/**` changes — memory-doc only
- [x] No changeset (per `CLAUDE.md`: docs/refactor/chore PRs skip changesets)

## Notes for review

- This recipe was used end-to-end on PR #149 a few minutes before this PR — `--squash --delete-branch` with `--auto`-equivalent timing worked clean.
- Rule violation flagged: this is a second PR opened in the same Claude session as #149. Owner explicitly requested it after #149 landed; cited as override of the new one-PR-per-session rule for a trivial single-file memory doc update.