### PR TITLE
fix(demo): share seed storage key between PlayView and useAgentSession

### DIFF
--- a/docs/plans/2026-04-27-review-bot-minor-hardcoded-seed-storage-key-d9b4b85-1.md
+++ b/docs/plans/2026-04-27-review-bot-minor-hardcoded-seed-storage-key-d9b4b85-1.md
@@ -1,0 +1,54 @@
+---
+date: 2026-04-27
+slug: review-bot-minor-hardcoded-seed-storage-key-d9b4b85-1
+finding-id: d9b4b85.1
+tracker: '#155'
+severity: MINOR
+---
+
+# Fix review finding `d9b4b85.1` — hardcoded seed storage key duplicates store's computed key, silent drift risk
+
+## Source
+
+From `#155` (https://github.com/Luis85/agentonomous/issues/155), finding `d9b4b85.1`:
+
+> **[MINOR]** `examples/product-demo/src/views/PlayView.vue:11` — hardcoded seed storage key duplicates store's computed key, silent drift risk
+>
+> <details><summary>details</summary>
+>
+> **Problem:** `SEED_PERSIST_KEY = 'demo.v2.session.lastSeed.petCare'` in `PlayView.vue` hardcodes the same string that `useAgentSession.ts` constructs dynamically as `` `${SEED_STORAGE_KEY_PREFIX}${scenarioId}` `` (`'demo.v2.session.lastSeed.' + 'petCare'`).
+>
+> **Why it matters:** If `SEED_STORAGE_KEY_PREFIX` or `DEFAULT_SCENARIO_ID` ever changes in the store, `PlayView.vue`'s read silently misses the new key, generating a fresh seed on every load and losing session continuity for returning users without any compile-time or test-time signal.
+>
+> **Fix:**
+>
+> ```diff
+> // examples/product-demo/src/views/PlayView.vue
+> -const SEED_PERSIST_KEY = 'demo.v2.session.lastSeed.petCare';
+> -
+> -function readPersistedSeed(): string | null {
+> -  try {
+> -    const raw = globalThis.localStorage?.getItem(SEED_PERSIST_KEY);
+> -    return typeof raw === 'string' && raw.length > 0 ? raw : null;
+> -  } catch { return null; }
+> -}
+> ```
+>
+> Export `readPersistedSeed(scenarioId)` from `useAgentSession.ts` and call it in `PlayView.vue`, or expose the storage key constant so both sides stay in sync.
+>
+> </details>
+
+## Acceptance
+
+- Apply the bot's proposed fix (see body above).
+- Add or update tests covering the new code paths.
+- `npm run verify` passes locally.
+- Codex review on the PR is acknowledged or rebutted on each thread.
+
+## Rollout
+
+- Branch: `fix/review-bot-minor-hardcoded-seed-storage-key-d9b4b85-1` (already cut by review-fix skill).
+- PR base: `develop`.
+- PR body MUST contain on its own line: `Refs #155 finding:d9b4b85.1`.
+- PR body MUST NOT contain `Closes #155` / `Fixes #155`.
+- Changeset required if behavior changes (`npm run changeset`).

--- a/examples/product-demo/src/stores/domain/useAgentSession.ts
+++ b/examples/product-demo/src/stores/domain/useAgentSession.ts
@@ -21,14 +21,14 @@ import {
 import { setLearningAgent } from '../../demo-domain/scenarios/petCare/cognition/learning.js';
 import type { AgentSessionSnapshot, SessionEvent } from '../../demo-domain/walkthrough/types.js';
 
-const DEFAULT_SCENARIO_ID = 'petCare';
+export const DEFAULT_SCENARIO_ID = 'petCare';
 const SEED_STORAGE_KEY_PREFIX = 'demo.v2.session.lastSeed.';
 
 function seedStorageKey(scenarioId: string): string {
   return `${SEED_STORAGE_KEY_PREFIX}${scenarioId}`;
 }
 
-function readPersistedSeed(scenarioId: string): string | null {
+export function readPersistedSeed(scenarioId: string): string | null {
   try {
     const stored = globalThis.localStorage?.getItem(seedStorageKey(scenarioId));
     return typeof stored === 'string' && stored.length > 0 ? stored : null;

--- a/examples/product-demo/src/views/PlayView.vue
+++ b/examples/product-demo/src/views/PlayView.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted } from 'vue';
-import { useAgentSession } from '../stores/domain/useAgentSession.js';
+import {
+  DEFAULT_SCENARIO_ID,
+  readPersistedSeed,
+  useAgentSession,
+} from '../stores/domain/useAgentSession.js';
 import HudPanel from '../components/shell/HudPanel.vue';
 import SpeedPicker from '../components/shell/SpeedPicker.vue';
 import ResetButton from '../components/shell/ResetButton.vue';
@@ -8,22 +12,11 @@ import ExportImportPanel from '../components/shell/ExportImportPanel.vue';
 import TracePanel from '../components/trace/TracePanel.vue';
 import TourOverlay from '../components/tour/TourOverlay.vue';
 
-const SEED_PERSIST_KEY = 'demo.v2.session.lastSeed.petCare';
-
 const session = useAgentSession();
 
 let raf = 0;
 let last = 0;
 let stopped = false;
-
-function readPersistedSeed(): string | null {
-  try {
-    const raw = globalThis.localStorage?.getItem(SEED_PERSIST_KEY);
-    return typeof raw === 'string' && raw.length > 0 ? raw : null;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Generate a fresh seed string. Non-determinism is intentional here —
@@ -53,7 +46,7 @@ async function loop(now: number): Promise<void> {
 // `onMounted` would silently overwrite persisted controls (notably
 // SpeedPicker's saved speed / pause) that children re-apply on their own
 // mount.
-const initialSeed = readPersistedSeed() ?? generateSeed();
+const initialSeed = readPersistedSeed(DEFAULT_SCENARIO_ID) ?? generateSeed();
 session.init({ seed: initialSeed });
 
 onMounted(() => {

--- a/examples/product-demo/test/views/PlayView.test.ts
+++ b/examples/product-demo/test/views/PlayView.test.ts
@@ -54,4 +54,18 @@ describe('<PlayView>', () => {
     expect(session.running).toBe(true);
     wrapper.unmount();
   });
+
+  // Reads the same `demo.v2.session.lastSeed.<scenarioId>` key the store
+  // writes via `useAgentSession.init`. Tripwire for review-bot finding
+  // d9b4b85.1: if PlayView ever drifts back to a hardcoded key, the
+  // persisted seed silently misses and a fresh seed is generated on
+  // every mount.
+  it('reuses the seed persisted under the store-owned key', async () => {
+    globalThis.localStorage.setItem('demo.v2.session.lastSeed.petCare', 'persisted-seed-x');
+    const session = useAgentSession();
+    const wrapper = mount(PlayView);
+    await nextTick();
+    expect(session.seed).toBe('persisted-seed-x');
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
## Summary

- Export `readPersistedSeed(scenarioId)` + `DEFAULT_SCENARIO_ID` from `useAgentSession.ts` and drop PlayView's hardcoded `'demo.v2.session.lastSeed.petCare'` duplicate.
- Add a regression test in `PlayView.test.ts` that pre-persists a seed under the store-owned key and asserts the mounted session adopts it.

## Why

`PlayView.vue` carried its own `SEED_PERSIST_KEY` literal that mirrored `${SEED_STORAGE_KEY_PREFIX}${scenarioId}` inside the store. If either side drifted, the read silently missed the persisted seed and a fresh seed was generated on every mount — review-bot finding `d9b4b85.1` from #155.

## Test plan

- [x] `npm run verify` (format:check + lint + lint:demo + typecheck + test + build) — all green, 674 tests pass
- [x] New `PlayView.test.ts` case asserts persisted seed is honoured
- [x] No library-behavior change — no changeset

Refs #155 finding:d9b4b85.1

@codex review