### PR TITLE
docs: fix drift flagged in #157 docs-review (d9b4b85)

### DIFF
--- a/.claude/memory/project_pending_major_changesets.md
+++ b/.claude/memory/project_pending_major_changesets.md
@@ -5,8 +5,10 @@ type: project
 ---
 
 Changesets under `.changeset/*.md` accumulate until the owner cuts the 1.0
-release. As of 2026-04-24, two major-bump changesets are queued (plus one
-minor-bump port addition that also lives in the same train):
+release. The pending changeset pile is the source of truth — skim
+`.changeset/*.md` before proposing a new changeset. The table below is an
+early snapshot (2026-04-24) preserved for context only and no longer
+maintained.
 
 | File                       | PR  | Bump  | What breaks                                                                                                                                        |
 | -------------------------- | --- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -14,9 +16,6 @@ minor-bump port addition that also lives in the same train):
 | `narrow-public-surface.md` | #67 | major | `AgentDependencies` removed from the public barrel; `AgentModule` / `ReactiveHandler` / `Needs` / `Modifiers` / `AgeModel` tagged `@experimental`. |
 | `llm-provider-port.md`     | #66 | minor | `LlmProviderPort` + `MockLlmProvider` added — public-surface addition.                                                                             |
 | `tfjs-learner.md`          | #70 | minor | `TfjsLearner` added to the `agentonomous/cognition/adapters/tfjs` subpath.                                                                         |
-
-Plus the older backlog from the tfjs-adapter PR and Phase A work under
-`.changeset/` (all pre-1.0).
 
 **How to apply:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,8 @@ MVP is a virtual-pet nurture demo (`examples/product-demo`).
   depends on an earlier unmerged one (rare).
 - **Worktrees per topic branch.** All feature / refactor / chore work
   happens in an isolated `git worktree` under `.worktrees/<branch-slug>`.
-  Worktree directory is `.worktrees/` (gitignored). This keeps
-  `D:\Projects\agent-library` itself on `develop` so multiple parallel
+  Worktree directory is `.worktrees/` (gitignored). This keeps the main
+  checkout itself on `develop` so multiple parallel
   agents (one per worktree) can each run `npm install` / `npm test` /
   `npm run dev` without stepping on each other's `node_modules` or vite
   caches. After PR merges: prune the worktree via
@@ -50,7 +50,7 @@ pull origin develop && git branch -d <topic>`. Delete the remote topic
   permissions allow). Prune stale tracking refs with `git fetch --prune
 origin` when switching contexts.
 - **Pre-PR gate.** `npm run verify` must be green before opening a PR.
-  Equivalent to `format:check && lint && typecheck && test && build`.
+  Equivalent to `format:check && lint && lint:demo && typecheck && test && build && docs`.
 - **No `--no-verify`.** If a pre-commit hook fails, fix the cause — don't
   bypass it. CI will reject `--no-verify`'d commits anyway.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,9 +140,9 @@ feat(persistence): add LocalStorage adapter
 
 - Target: always `develop` (except hotfixes → `main`).
 - Title: short, imperative, no period. "Add markdown memory adapter".
-- Body: summary + test plan. Link to relevant R-XX or issue numbers.
+- Body: summary + test plan. Link to relevant issue or PR numbers (`#NNN`).
 - Required gates before merge: `npm run verify` (= format:check + lint +
-  typecheck + test + build), GitHub Actions CI green. CI runs on every
+  lint:demo + typecheck + test + build + docs), GitHub Actions CI green. CI runs on every
   push to and PR against `develop`, `main`, or `demo` (see
   `.github/workflows/ci.yml`).
 - Reviews: at least one approving review for anything beyond a

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -32,10 +32,14 @@ Baseline (all three):
 
 - Require a pull request before merging; require at least 1 approving
   review.
-- Require status checks to pass before merging; include every job in the
-  `CI` workflow (`Format (Prettier)`, `Lint (ESLint)`,
-  `Typecheck (tsc --noEmit)`, `Test (Vitest + coverage)`,
-  `Build & size budget`).
+- Require status checks to pass before merging; add the `CI gate (required
+check)` job — it is the terminal aggregator that depends on every other
+  required job in the workflow, so adding only this one check is sufficient.
+  (For reference, the full leaf-job list as of d9b4b85: `Format (Prettier)`,
+  `Lint (ESLint)`, `Typecheck (tsc --noEmit)`, `Lint workflows (actionlint)`,
+  `Audit production deps (npm audit)`, `API docs (typedoc)`,
+  `Test core (Vitest, ubuntu-latest)`, `Test tfjs (cpu on ubuntu-latest)`,
+  `Build & size budget`, `Demo build (examples/product-demo)`.)
 - Require branches to be up to date before merging.
 - Disallow force pushes. Disallow deletions.
 - Do **not** allow bypass for administrators (hold yourself to the same bar).

--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -1,9 +1,7 @@
 # agentonomous — Product Vision
 
-> Companion to `docs/specs/overview.md` (technical spec) and
-> `docs/specs/roadmap.md` (phased delivery). This document answers the
-> "why" — the problem we solve, who we serve, and the invariants that
-> guide every trade-off.
+> This document answers the "why" — the problem we solve, who we serve,
+> and the invariants that guide every trade-off.
 
 ## Vision statement
 
@@ -410,14 +408,6 @@ is weighed against that feeling.
 
 ## Relationship to other docs
 
-- **`docs/specs/overview.md`** — the technical spec. How each of
-  these pillars is implemented.
-- **`docs/specs/roadmap.md`** — the phased path from today to the
-  24-month horizon.
-- **`docs/plans/review-remediation.md`** — the specific work needed
-  to close the gap between current state and V1.0.0.
-- **`/root/.claude/plans/i-want-to-create-warm-matsumoto.md`** — the
-  internal planning document that drove the initial build.
 - **[`agentic-workflow`](https://github.com/luis85/agentic-workflow)** —
   external companion repo. Defines the structured
   software-development workflow (tasks + roles) that v2 / Phase B
@@ -466,8 +456,6 @@ the vision. Changes to this document require:
 
 1. A pull request with rationale.
 2. Sign-off from project owner.
-3. A corresponding update to `docs/specs/roadmap.md` showing how the
-   change propagates.
 
 Last reviewed: 2026-04-26 (refined to introduce the v1 → v2 arc and
 the [`agentic-workflow`](https://github.com/luis85/agentic-workflow)

--- a/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
+++ b/docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md
@@ -17,7 +17,7 @@ external narration.
 
 ## Pre-flight
 
-- Blocked by: rename preflight (`docs/plans/2026-04-26-pre-v1-demo-rename-preflight.md`). The `WalkthroughStep` contract lives under `examples/product-demo/src/demo-domain/walkthrough/` so the rename must merge first.
+- Rename preflight: resolved — archived at `docs/archive/plans/2026-04-26-pre-v1-demo-rename-preflight.md` (PR #134, 2026-04-26).
 - Worktree pattern: `.worktrees/feat-tour-<slice>/`.
 - Tour copy tone is **OQ-P1** (open question) — settle in slice 1.2b review.
 - **Legacy recycle.** Slice 1.2a relocates pure modules from the legacy

--- a/examples/product-demo/README.md
+++ b/examples/product-demo/README.md
@@ -106,7 +106,7 @@ unsubscribe();
 
 Pair this with a `requestAnimationFrame` loop that calls
 `pet.tick(dt)` but does not render — the event drives UI. See
-`src/main.ts` for the reference implementation.
+`src/app/main.ts` for the reference implementation.
 
 ## Cognition switcher
 


### PR DESCRIPTION
## Summary

Resolves all 11 findings from the 2026-04-27 docs-review run (`d9b4b85`) tracked in #157: 5 MAJOR + 5 MINOR + 1 NIT.

| ID | File | Severity | Fix |
|----|------|----------|-----|
| `d9b4b85.1` | `CLAUDE.md:53` | MAJOR | Add `lint:demo` + `docs` to `npm run verify` description |
| `d9b4b85.2` | `CONTRIBUTING.md:144` | MAJOR | Same `npm run verify` alignment |
| `d9b4b85.3` | `docs/PRODUCT_VISION.md:419` | MAJOR | Remove leaked `/root/.claude/plans/...` path |
| `d9b4b85.4` | `examples/product-demo/README.md:109` | MAJOR | `src/main.ts` → `src/app/main.ts` (moved in #150) |
| `d9b4b85.5` | `PUBLISHING.md:36-38` | MAJOR | Replace stale 5-job CI list with `CI gate (required check)` aggregator + current leaf-job reference |
| `d9b4b85.6` | `docs/PRODUCT_VISION.md:3-4,~413,~415,~469` | MINOR | Remove dead `docs/specs/overview.md` + `docs/specs/roadmap.md` references (header, relationship section, review steps) |
| `d9b4b85.7` | `docs/PRODUCT_VISION.md:417` | MINOR | Remove dead `docs/plans/review-remediation.md` link |
| `d9b4b85.8` | `CONTRIBUTING.md:143` | MINOR | `R-XX` → `#NNN` (no R-XX scheme in this repo) |
| `d9b4b85.9` | `CLAUDE.md:44` | MINOR | Drop hardcoded `D:\Projects\agent-library` path |
| `d9b4b85.10` | `docs/plans/2026-04-26-pre-v1-demo-guided-walkthrough.md:20` | MINOR | Mark rename preflight as resolved (archived via #134) |
| `d9b4b85.11` | `.claude/memory/project_pending_major_changesets.md:8` | NIT | Replace stale 4-changeset count with pointer to `.changeset/*.md` |

## Test plan

- [x] `npm run verify` (format:check + lint + lint:demo + typecheck + test + build + docs) green
- [x] No code changes — docs-only PR; behavior unchanged
- [ ] Codex review on the PR is acknowledged or rebutted

## Notes

- No changeset (docs-only).
- Issue #157 uses the `docs-review` label and `<!-- d:... -->` markers, which the `review-fix-shipped` Action does not handle (it only matches `<!-- f:... -->` from the code-review bot). The owner ticks the boxes manually per `docs/docs-review-bot/README.md`. PR body therefore lists each finding ID for manual reconciliation rather than the `Refs # finding:` magic line.
- Bundled all 11 findings into one PR per the "one PR per session" rule and the doc-only nature of the changes (each fix is a one-liner with no test surface).

Refs #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)