### PR TITLE
fix(test): move attachResetHandler below static imports

### DIFF
--- a/docs/plans/2026-04-27-review-bot-minor-attachresethandler-decl-before-d9b4b85-3.md
+++ b/docs/plans/2026-04-27-review-bot-minor-attachresethandler-decl-before-d9b4b85-3.md
@@ -1,0 +1,55 @@
+---
+date: 2026-04-27
+slug: review-bot-minor-attachresethandler-decl-before-d9b4b85-3
+finding-id: d9b4b85.3
+tracker: '#155'
+severity: MINOR
+---
+
+# Fix review finding `d9b4b85.3` — `function attachResetHandler` declared before a static `import` statement on line 38
+
+## Source
+
+From `#155` (https://github.com/Luis85/agentonomous/issues/155), finding `d9b4b85.3`:
+
+> **[MINOR]** `tests/examples/learningMode.train.test.ts:27` — `function attachResetHandler` declared before a static `import` statement on line 38
+>
+> <details><summary>details</summary>
+>
+> **Problem:** The replacement for the deleted `mountResetButton` import was inserted as a function declaration on line 27, above the surviving `import { TEST_BACKEND } from '../setup/tfjsBackend.js'` on line 38. ES module `import` statements are hoisted at parse time so it works at runtime, but the source order (declaration before import) is non-standard, confuses readers, and will fail under any future `import/first` lint rule.
+>
+> **Why it matters:** This pattern will silently break if the project ever enables `eslint-plugin-import`'s `import/first` rule, turning a style issue into a blocked build with no obvious connection to the original change. It also signals to readers that the file was edited carelessly, undermining confidence in the surrounding test logic.
+>
+> **Fix:**
+>
+> ```diff
+> -// `mountResetButton` lived in…
+> -function attachResetHandler(agentId: string): void {
+> -  …
+> -}
+>  import { TEST_BACKEND } from '../setup/tfjsBackend.js';
+> +
+> +// `mountResetButton` lived in…
+> +function attachResetHandler(agentId: string): void {
+> +  …
+> +}
+> ```
+>
+> Move the function below all `import` statements.
+>
+> </details>
+
+## Acceptance
+
+- Apply the bot's proposed fix (see body above).
+- Add or update tests covering the new code paths.
+- `npm run verify` passes locally.
+- Codex review on the PR is acknowledged or rebutted on each thread.
+
+## Rollout
+
+- Branch: `fix/review-bot-minor-attachresethandler-decl-before-d9b4b85-3` (already cut by review-fix skill).
+- PR base: `develop`.
+- PR body MUST contain on its own line: `Refs #155 finding:d9b4b85.3`.
+- PR body MUST NOT contain `Closes #155` / `Fixes #155`.
+- Changeset required if behavior changes (`npm run changeset`).

--- a/tests/examples/learningMode.train.test.ts
+++ b/tests/examples/learningMode.train.test.ts
@@ -18,6 +18,8 @@ import {
   setLearningAgent,
   SOFTMAX_SKILL_IDS,
 } from '../../examples/product-demo/src/demo-domain/scenarios/petCare/cognition/learning.js';
+import { TEST_BACKEND } from '../setup/tfjsBackend.js';
+
 // `mountResetButton` lived in `examples/product-demo/src/ui.ts`, deleted by
 // Pillar 1 slice 1.2b. The test still needs a click handler that clears the
 // per-agent tfjs-network key (the only behaviour this file asserted), so it
@@ -35,7 +37,6 @@ function attachResetHandler(agentId: string): void {
     }
   });
 }
-import { TEST_BACKEND } from '../setup/tfjsBackend.js';
 
 type FakeAgent = {
   setReasoner: Mock<(r: unknown) => void>;


### PR DESCRIPTION
## Summary

- Move the `attachResetHandler` function in `tests/examples/learningMode.train.test.ts` below the surviving `tfjsBackend.js` import so all `import` statements come first.

## Why

The function sat between two static imports (`learning.js` on line 16-20, `tfjsBackend.js` on line 38). ES modules hoist imports at parse time so runtime is unaffected, but the source order is non-standard and would break under any future `eslint-plugin-import` `import/first` rule. Review-bot finding `d9b4b85.3` from #155.

## Test plan

- [x] `npm run verify` (format:check + lint + lint:demo + typecheck + test + build + docs) — all green
- [x] Test still exercises the same train→persist→reset flow; only declaration order changed

Refs #155 finding:d9b4b85.3

@codex review