### PR TITLE
fix(scripts): use Date.getTime() in review-fix sort comparator

### DIFF
--- a/docs/plans/2026-04-27-review-bot-nit-date-implicit-valueof-coercion-d9b4b85-4.md
+++ b/docs/plans/2026-04-27-review-bot-nit-date-implicit-valueof-coercion-d9b4b85-4.md
@@ -1,0 +1,45 @@
+---
+date: 2026-04-27
+slug: review-bot-nit-date-implicit-valueof-coercion-d9b4b85-4
+finding-id: d9b4b85.4
+tracker: '#155'
+severity: NIT
+---
+
+# Fix review finding `d9b4b85.4` — `new Date(b.issue.createdAt) - new Date(a.issue.createdAt)` relies on implicit `Date.valueOf()` coercion
+
+## Source
+
+From `#155` (https://github.com/Luis85/agentonomous/issues/155), finding `d9b4b85.4`:
+
+> **[NIT]** `scripts/review-fix-parse.mjs:105` — `new Date(b.issue.createdAt) - new Date(a.issue.createdAt)` relies on implicit `Date.valueOf()` coercion
+>
+> <details><summary>details</summary>
+>
+> **Problem:** Arithmetic between two `Date` objects coerces via `valueOf()` implicitly.
+>
+> **Why it matters:** TypeScript strict mode would flag this as `error TS2362/2363`; if this file is ever migrated to `.ts` or a TypeScript-strict linter is applied to `.mjs` files, the implicit coercion becomes a build error.
+>
+> **Fix:**
+>
+> ```diff
+> -  .sort((a, b) => new Date(b.issue.createdAt) - new Date(a.issue.createdAt));
+> +  .sort((a, b) => new Date(b.issue.createdAt).getTime() - new Date(a.issue.createdAt).getTime());
+> ```
+>
+> </details>
+
+## Acceptance
+
+- Apply the bot's proposed fix (see body above).
+- Add or update tests covering the new code paths.
+- `npm run verify` passes locally.
+- Codex review on the PR is acknowledged or rebutted on each thread.
+
+## Rollout
+
+- Branch: `fix/review-bot-nit-date-implicit-valueof-coercion-d9b4b85-4` (already cut by review-fix skill).
+- PR base: `develop`.
+- PR body MUST contain on its own line: `Refs #155 finding:d9b4b85.4`.
+- PR body MUST NOT contain `Closes #155` / `Fixes #155`.
+- Changeset required if behavior changes (`npm run changeset`).

--- a/scripts/review-fix-parse.mjs
+++ b/scripts/review-fix-parse.mjs
@@ -102,7 +102,7 @@ const withFindings = issues
   .filter((iss) => typeof iss.body === 'string')
   .map((iss) => ({ issue: iss, findings: parseFindings(iss.body) }))
   .filter((entry) => entry.findings.length > 0)
-  .sort((a, b) => new Date(b.issue.createdAt) - new Date(a.issue.createdAt));
+  .sort((a, b) => new Date(b.issue.createdAt).getTime() - new Date(a.issue.createdAt).getTime());
 
 if (withFindings.length === 0) {
   stderr.write('No open review-bot issue contains findings — nothing to sweep\n');


### PR DESCRIPTION
## Summary

- Replace implicit `Date.valueOf()` coercion in `scripts/review-fix-parse.mjs:105` with explicit `.getTime()` subtraction.

## Why

`new Date(b.issue.createdAt) - new Date(a.issue.createdAt)` relies on JS coercing both operands via `valueOf()`. TypeScript strict mode flags this as `error TS2362/2363`; if the file is ever migrated to `.ts` or a TypeScript-strict linter is applied to `.mjs` files, the implicit coercion becomes a build error. Review-bot finding `d9b4b85.4` from #155.

## Test plan

- [x] `npm run verify` (format:check + lint + lint:demo + typecheck + test + build + docs) — all green
- [x] Sort behaviour unchanged: still returns negative when `b` is older, positive when `b` is newer

Refs #155 finding:d9b4b85.4

@codex review