### PR TITLE
fix(demo): address review-bot findings from issue #165

### DIFF
--- a/examples/product-demo/src/components/shell/HudPanel.vue
+++ b/examples/product-demo/src/components/shell/HudPanel.vue
@@ -56,7 +56,12 @@ useRegisterSelector('hud.json.toggle');
 // Cognition picker (Pillar-1 slice 1.3): minimal placeholder until
 // Pillar-2 slice 2.5 ports the legacy cognitionSwitcher with its loss
 // sparkline + prediction strip. Probes the peer dep on first hover so
-// unavailable modes render disabled with an install hint.
+// unavailable modes render disabled with an install hint. `learning`
+// stays force-disabled here regardless of TF.js availability — the
+// store's `setCognitionMode` only wires the reasoner, not the paired
+// `TfjsLearner`, so enabling the option would silently disable online
+// training while the UI claims "Active: learning". The full switcher
+// (cognitionSwitcher.ts) is the supported path until slice 2.5.
 const cognitionAvailable = ref<Record<CognitionModeSpec['id'], boolean>>({
   heuristic: true,
   bt: false,
@@ -68,6 +73,10 @@ const cognitionError = ref<string | null>(null);
 async function probeCognitionModes(): Promise<void> {
   for (const mode of session.cognitionModes) {
     if (mode.id === 'heuristic') continue;
+    // See `cognitionAvailable` JSDoc — `learning` is intentionally
+    // pinned to false here. The store-side `setCognitionMode` also
+    // throws on `'learning'` as a defence-in-depth guard.
+    if (mode.id === 'learning') continue;
     try {
       cognitionAvailable.value = {
         ...cognitionAvailable.value,

--- a/examples/product-demo/src/stores/domain/useAgentSession.ts
+++ b/examples/product-demo/src/stores/domain/useAgentSession.ts
@@ -320,6 +320,19 @@ export const useAgentSession = defineStore('agentSession', () => {
     if (mode === undefined) {
       throw new Error(`useAgentSession.setCognitionMode: unknown mode "${String(modeId)}".`);
     }
+    const targetAgent = agent.value;
+    if (targetAgent === null) {
+      throw new Error('useAgentSession.setCognitionMode: no live agent (call init() first).');
+    }
+    // Bump the token BEFORE the learning guard so a prior in-flight
+    // swap is invalidated even when this call rejects synchronously.
+    // Without this, a caller bypassing the HUD's disabled-option guard
+    // who issued `setCognitionMode('learning')` while another mode
+    // change was still constructing would see the older swap land
+    // after the error — a surprising late mode switch from a call
+    // that already failed.
+    cognitionToken += 1;
+    const myToken = cognitionToken;
     // Learning mode requires a paired `TfjsLearner` so the online batch-
     // training loop can score outcomes against the same network the
     // reasoner runs inference on. The store path doesn't yet build a
@@ -334,12 +347,6 @@ export const useAgentSession = defineStore('agentSession', () => {
         'useAgentSession.setCognitionMode: learning mode is not yet wired through the store path — use the legacy cognitionSwitcher (Pillar-2 slice 2.5).',
       );
     }
-    const targetAgent = agent.value;
-    if (targetAgent === null) {
-      throw new Error('useAgentSession.setCognitionMode: no live agent (call init() first).');
-    }
-    cognitionToken += 1;
-    const myToken = cognitionToken;
     const available = await mode.probe();
     if (myToken !== cognitionToken || agent.value !== targetAgent) return;
     if (!available) {

--- a/examples/product-demo/src/stores/domain/useAgentSession.ts
+++ b/examples/product-demo/src/stores/domain/useAgentSession.ts
@@ -7,6 +7,7 @@ import type {
   AgentTickedEvent,
   DecisionTrace,
   DomainEvent,
+  Reasoner,
   SpeciesDescriptor,
 } from 'agentonomous';
 import {
@@ -86,6 +87,23 @@ const RECENT_EVENT_LIMIT = 50;
  * Tour predicates only need identity equality across sibling snapshots,
  * not cryptographic uniqueness — `cyrb53` is plenty.
  */
+/**
+ * Best-effort reasoner disposal for stale-completion paths. Concrete
+ * reasoners may or may not implement `dispose()` (heuristic / bt / bdi
+ * don't; `TfjsReasoner` does, holding WebGL allocations). Duck-typed
+ * + try/catch so a noop reasoner is a no-op and a throwing dispose
+ * doesn't bubble out of the swap path.
+ */
+function disposeReasoner(reasoner: Reasoner): void {
+  const maybe = reasoner as { dispose?: () => void };
+  if (typeof maybe.dispose !== 'function') return;
+  try {
+    maybe.dispose();
+  } catch {
+    // Best-effort — disposal must not block the cognition swap.
+  }
+}
+
 function hashSeed(seedStr: string): number {
   let h1 = 0xdeadbeef;
   let h2 = 0x41c6ce57;
@@ -302,6 +320,20 @@ export const useAgentSession = defineStore('agentSession', () => {
     if (mode === undefined) {
       throw new Error(`useAgentSession.setCognitionMode: unknown mode "${String(modeId)}".`);
     }
+    // Learning mode requires a paired `TfjsLearner` so the online batch-
+    // training loop can score outcomes against the same network the
+    // reasoner runs inference on. The store path doesn't yet build a
+    // learner — wiring just the reasoner would leave the HUD claiming
+    // "Active: learning" while online training is silently disabled.
+    // The full reasoner+learner switcher lives in `cognitionSwitcher.ts`
+    // (Pillar-2 slice 2.5 ports it onto the store path). Refuse here so a
+    // caller bypassing the HUD's disabled-option guard fails loudly
+    // instead of running in the broken intermediate state.
+    if (modeId === 'learning') {
+      throw new Error(
+        'useAgentSession.setCognitionMode: learning mode is not yet wired through the store path — use the legacy cognitionSwitcher (Pillar-2 slice 2.5).',
+      );
+    }
     const targetAgent = agent.value;
     if (targetAgent === null) {
       throw new Error('useAgentSession.setCognitionMode: no live agent (call init() first).');
@@ -318,7 +350,17 @@ export const useAgentSession = defineStore('agentSession', () => {
       throw new Error(`useAgentSession.setCognitionMode: ${hint}`);
     }
     const reasoner = await mode.construct();
-    if (myToken !== cognitionToken || agent.value !== targetAgent) return;
+    if (myToken !== cognitionToken || agent.value !== targetAgent) {
+      // Stale completion: a parallel `init()` / `replayFromSnapshot()` /
+      // second `setCognitionMode()` landed while `mode.construct()` was
+      // in flight. The freshly-built reasoner will never be adopted —
+      // dispose it before dropping the reference so peer-dep adapters
+      // that hold native handles (e.g. `TfjsReasoner`'s WebGL
+      // allocations) don't leak. Mirrors `cognitionSwitcher.ts`'s
+      // `disposeIfOwned` on its analogous stale-epoch guard.
+      disposeReasoner(reasoner);
+      return;
+    }
     targetAgent.setReasoner(reasoner);
     cognitionModeId.value = modeId;
     recordUiEvent('CognitionModeChanged');

--- a/examples/product-demo/src/views/TourView.vue
+++ b/examples/product-demo/src/views/TourView.vue
@@ -24,12 +24,23 @@ const tour = useTourProgress();
 const router = useRouter();
 const route = useRoute();
 
+/**
+ * Surface `router.push` rejections from `syncRoute` instead of swallowing
+ * them with a bare `void`. A future navigation guard that blocks
+ * `/tour/...` mid-session would otherwise silently fail — the URL
+ * never updates, the chapter predicate never fires, and the tour
+ * appears stuck with no console output during development.
+ */
+function logSyncRouteFailure(err: unknown): void {
+  globalThis.console?.warn('[TourView] syncRoute failed:', err);
+}
+
 function reconcileFromRoute(): void {
   const stepRaw = route.params['step'];
   if (typeof stepRaw === 'string' && stepRaw.length > 0) {
     tour.resumeFromRoute(stepRaw);
   }
-  void tour.syncRoute(router);
+  tour.syncRoute(router).catch(logSyncRouteFailure);
 }
 
 onMounted(reconcileFromRoute);
@@ -39,7 +50,7 @@ watch(() => route.params['step'], reconcileFromRoute);
 watch(
   () => tour.lastStep,
   () => {
-    void tour.syncRoute(router);
+    tour.syncRoute(router).catch(logSyncRouteFailure);
   },
 );
 </script>

--- a/examples/product-demo/test/stores/domain/useAgentSession.test.ts
+++ b/examples/product-demo/test/stores/domain/useAgentSession.test.ts
@@ -478,6 +478,47 @@ describe('useAgentSession', () => {
     );
   });
 
+  it('setCognitionMode("learning") invalidates a prior in-flight swap so the older swap cannot land after the throw', async () => {
+    const session = useAgentSession();
+    session.init({ seed: 'cognition-learning-invalidates-seed' });
+    const liveAgent = session.agent!;
+    const setReasonerSpy = vi.spyOn(liveAgent, 'setReasoner');
+
+    // Defer heuristic's construct so we can race a synchronous
+    // `setCognitionMode('learning')` against the suspended swap. Without
+    // bumping `cognitionToken` BEFORE the learning guard's throw, the
+    // earlier swap would still resolve and call `setReasoner` after the
+    // synchronous rejection — a late, surprising mode switch from a call
+    // that already failed.
+    const heuristic = session.cognitionModes.find((m) => m.id === 'heuristic')!;
+    const originalConstruct = heuristic.construct.bind(heuristic);
+    let resolveConstruct!: (reasoner: Awaited<ReturnType<typeof originalConstruct>>) => void;
+    const constructSpy = vi.spyOn(heuristic, 'construct').mockImplementationOnce(
+      () =>
+        new Promise<Awaited<ReturnType<typeof originalConstruct>>>((resolve) => {
+          resolveConstruct = resolve;
+        }),
+    );
+
+    const firstSwap = session.setCognitionMode('heuristic');
+    // Flush probe so the function suspends on construct.
+    await Promise.resolve();
+    await Promise.resolve();
+    // The learning guard rejects synchronously; the token bump that
+    // PRECEDES the throw is what invalidates the suspended first swap.
+    await expect(session.setCognitionMode('learning')).rejects.toThrow(
+      /learning mode is not yet wired/i,
+    );
+    // Resolve the first swap's construct AFTER the rejection so the
+    // stale-epoch guard fires on its return path.
+    resolveConstruct(await originalConstruct());
+    await firstSwap;
+
+    expect(setReasonerSpy).not.toHaveBeenCalled();
+    constructSpy.mockRestore();
+    setReasonerSpy.mockRestore();
+  });
+
   it('recordUiEvent bumps recentEventsVersion every push, even past the ring-buffer cap', async () => {
     const session = useAgentSession();
     session.init({ seed: 'recent-events-version-seed' });

--- a/examples/product-demo/test/stores/domain/useAgentSession.test.ts
+++ b/examples/product-demo/test/stores/domain/useAgentSession.test.ts
@@ -392,6 +392,92 @@ describe('useAgentSession', () => {
     expect(session.cognitionModeId).toBe('heuristic');
   });
 
+  it('setCognitionMode disposes the freshly-constructed reasoner when init() invalidates the swap mid-construct', async () => {
+    const session = useAgentSession();
+    session.init({ seed: 'cognition-dispose-seed-1' });
+    const firstAgent = session.agent;
+    expect(firstAgent).not.toBeNull();
+
+    // Defer `construct` so init() can land between the probe-stale check
+    // (already passed) and the construct-stale check we want to exercise.
+    // Without the deferral, probe + construct both flush in one microtask
+    // and the synchronous init() reaches the function only after
+    // setCognitionMode has already returned past the probe-stale guard.
+    const heuristic = session.cognitionModes.find((m) => m.id === 'heuristic')!;
+    const originalConstruct = heuristic.construct.bind(heuristic);
+    let resolveConstruct!: (reasoner: Awaited<ReturnType<typeof originalConstruct>>) => void;
+    const constructSpy = vi.spyOn(heuristic, 'construct').mockImplementationOnce(
+      () =>
+        new Promise<Awaited<ReturnType<typeof originalConstruct>>>((resolve) => {
+          resolveConstruct = resolve;
+        }),
+    );
+
+    const swap = session.setCognitionMode('heuristic');
+    // Flush probe's microtask so setCognitionMode advances to the
+    // suspended `await mode.construct()`. Two flushes give probe's
+    // continuation room to schedule construct, then suspend on it.
+    await Promise.resolve();
+    await Promise.resolve();
+    // Now race a fresh init() against the suspended construct. Bumps
+    // cognitionToken AND swaps `agent.value`, so both stale-epoch
+    // predicates fire when construct resolves.
+    session.init({ seed: 'cognition-dispose-seed-2' });
+
+    // Build a real reasoner and attach a dispose spy. The swap will
+    // discard this reasoner via the stale-epoch guard — without the
+    // fix, a `TfjsReasoner` would leak its WebGL allocations.
+    const inner = await originalConstruct();
+    let disposed = false;
+    const reasonerWithDispose = Object.assign(inner, {
+      dispose: () => {
+        disposed = true;
+      },
+    });
+    resolveConstruct(reasonerWithDispose);
+    await swap;
+
+    expect(disposed).toBe(true);
+    constructSpy.mockRestore();
+  });
+
+  it('setCognitionMode tolerates reasoners without a dispose method on the stale-epoch path', async () => {
+    const session = useAgentSession();
+    session.init({ seed: 'cognition-no-dispose-seed-1' });
+
+    // Default heuristic reasoner (`UrgencyReasoner`) has no `dispose`
+    // method; the duck-type check in `disposeReasoner` must skip
+    // without throwing. Race construct + init() the same way the
+    // dispose test does, but with the unmodified mode.
+    const heuristic = session.cognitionModes.find((m) => m.id === 'heuristic')!;
+    const originalConstruct = heuristic.construct.bind(heuristic);
+    let resolveConstruct!: (reasoner: Awaited<ReturnType<typeof originalConstruct>>) => void;
+    const constructSpy = vi.spyOn(heuristic, 'construct').mockImplementationOnce(
+      () =>
+        new Promise<Awaited<ReturnType<typeof originalConstruct>>>((resolve) => {
+          resolveConstruct = resolve;
+        }),
+    );
+
+    const swap = session.setCognitionMode('heuristic');
+    await Promise.resolve();
+    await Promise.resolve();
+    session.init({ seed: 'cognition-no-dispose-seed-2' });
+
+    const inner = await originalConstruct();
+    resolveConstruct(inner);
+    await expect(swap).resolves.toBeUndefined();
+    constructSpy.mockRestore();
+  });
+
+  it('setCognitionMode("learning") throws because the store does not yet wire a paired learner', async () => {
+    const session = useAgentSession();
+    session.init({ seed: 'cognition-learning-guard-seed' });
+    await expect(session.setCognitionMode('learning')).rejects.toThrow(
+      /learning mode is not yet wired/i,
+    );
+  });
+
   it('recordUiEvent bumps recentEventsVersion every push, even past the ring-buffer cap', async () => {
     const session = useAgentSession();
     session.init({ seed: 'recent-events-version-seed' });

--- a/examples/product-demo/test/views/TourView.test.ts
+++ b/examples/product-demo/test/views/TourView.test.ts
@@ -70,6 +70,31 @@ describe('<TourView>', () => {
     wrapper.unmount();
   });
 
+  it('logs a warning when syncRoute rejects (e.g. a navigation guard blocks the push)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const { wrapper, router } = await mountTourAt(`/tour/${STEP_ID_AUTONOMY}`);
+
+      // Replace `router.push` with a rejecting stub. The TourView watcher on
+      // `tour.lastStep` triggers `syncRoute(router)`, which then awaits the
+      // failing push. Without the `.catch` the rejection becomes a silent
+      // unhandled promise; with it the warning lands on `console.warn`.
+      const pushSpy = vi
+        .spyOn(router, 'push')
+        .mockRejectedValueOnce(new Error('synthetic guard rejection'));
+
+      const tour = useTourProgress();
+      tour.lastStep = STEP_ID_COGNITION_SWAP;
+      await flushPromises();
+
+      expect(pushSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith('[TourView] syncRoute failed:', expect.any(Error));
+      wrapper.unmount();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('on mount with an upstream URL step, leaves the cursor on the persisted progress', async () => {
     // Seed persisted progress at chapter-3.
     globalThis.localStorage.setItem(


### PR DESCRIPTION
## Summary

Resolves the three review findings from #165 (2 MINOR, 1 NIT) on `98c191b`.

### Finding 1 (MINOR) — `useAgentSession.ts:321` — leaked reasoner on stale-epoch
After `await mode.construct()`, the post-construct stale-epoch guard returned without disposing the freshly-built reasoner. A `TfjsReasoner` cancelled by a parallel `init()` / `replayFromSnapshot()` / second `setCognitionMode()` would leak its WebGL allocations. Added a `disposeReasoner` helper (duck-typed + try/catch, mirroring `cognitionSwitcher.ts`'s `disposeIfOwned`) and call it on the stale-epoch return path.

### Finding 2 (MINOR) — `setCognitionMode` for `learning` would wire reasoner without learner
The store path constructs a `TfjsReasoner` but never calls `setLearner`, so the HUD would claim "Active: learning" while online batch training was silently disabled. Defended in two places:
- `HudPanel.vue` — skip the `learning` probe so the dropdown stays force-disabled regardless of TF.js availability, until Pillar-2 slice 2.5 ports the full reasoner+learner switcher onto the store path.
- `useAgentSession.setCognitionMode` — throw a clear error when `modeId === 'learning'` so a caller bypassing the HUD's disabled-option guard fails loudly instead of running broken.

### Finding 3 (NIT) — `TourView.syncRoute` rejections silently swallowed
Both `void tour.syncRoute(router)` callers in `TourView.vue` discarded any rejection from `router.push`. A future navigation guard that blocks `/tour/...` mid-session would silently fail with no console output. Replaced with `.catch(logSyncRouteFailure)` which emits `console.warn('[TourView] syncRoute failed:', err)`.

## Test plan

- [x] `npm run verify` — format, lint, lint:demo, typecheck, 681/681 tests, build, docs all pass
- [x] New unit tests in `useAgentSession.test.ts`:
  - `setCognitionMode` disposes the freshly-built reasoner on the stale-epoch path
  - `setCognitionMode` tolerates reasoners without a `dispose` method
  - `setCognitionMode('learning')` throws with a clear message
- [x] New unit test in `TourView.test.ts`: a rejecting `router.push` triggers `console.warn` (no silent swallow)

Refs #165 finding:98c191b.1
Refs #165 finding:98c191b.2
Refs #165 finding:98c191b.3

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRJ3FSEPX6HZguXMs47qJZ)_