### PR TITLE
fix(scripts): honour ISSUE_LABELS override in create-v1-issues

### DIFF
--- a/docs/plans/2026-05-01-v1-release-issue-backlog.md
+++ b/docs/plans/2026-05-01-v1-release-issue-backlog.md
@@ -1,0 +1,136 @@
+# v1.0 Release Backlog — GitHub Issue Drafts
+
+Date: 2026-05-01
+
+This backlog converts currently open plan rows and unchecked review findings into issue-sized chunks that can be picked up independently.
+
+## Source audit
+
+Primary open-work sources:
+- `docs/product/2026-04-26-pre-v1-demo-evolution-plan.md` Tracker table rows still marked `not started`.
+- `docs/plans/2026-04-26-pre-v1-demo-*.md` slice tables still marked `not started`.
+- `docs/plans/2026-04-26-quality-automation-routines.md` rows 6–8 still marked `not started`.
+- `docs/daily-reviews/2026-04-26.md`, `2026-04-27.md`, `2026-04-28.md`, `2026-04-30.md` unchecked findings.
+
+---
+
+## Epic 1 — Demo v2 pillars to reach pre-v1 completion
+
+### Issue 1 — Pillar 2 scaffolding: rolling diff metrics + store wiring
+**Scope:** slices 2.1 + 2.2.
+**Deliverables:**
+- Add `examples/product-demo/src/demo-domain/diff/**` pure metric modules.
+- Wire `AGENT_TICKED` capture in `useAgentSession` and headless `useDiffPanelView`.
+- Unit tests for metrics and store integration.
+**Done when:** all P2-FR-1/2/4/5 acceptance checks in plan are green.
+
+### Issue 2 — Pillar 2 UI: diff card + "what changed" summary
+**Scope:** slice 2.3.
+**Deliverables:**
+- `DiffCard.vue`, `MetricRow.vue`, `WhatChangedSummary.vue`, `DiffView.vue`.
+- Render visible delta within 1–3 ticks after mode switch.
+- UI tests for empty-peer-mode and steady-state behavior.
+
+### Issue 3 — Pillar 2 hardening: confidence labels + threshold tuning
+**Scope:** slice 2.4.
+**Deliverables:**
+- `confidence.ts` model and threshold constants.
+- Soak-tested defaults and test notes captured in plan done-log.
+
+### Issue 4 — Pillar 2 migration: cognition switcher/SVG renderers into Vue SFCs
+**Scope:** slice 2.5.
+**Deliverables:**
+- Port `cognitionSwitcher.ts` to `<CognitionSwitcher>` + `setMode` store API.
+- Port `lossSparkline.ts` / `predictionStrip.ts` to SFCs.
+- Delete legacy files after parity tests pass.
+
+### Issue 5 — Pillar 3 core: deterministic fingerprint domain + recorder store
+**Scope:** slices 3.1 + 3.2.
+**Deliverables:**
+- Normalizer/hash/scope-key helpers.
+- `useFingerprintRecorder` with deterministic persistence model.
+- Unit tests including stable hash regression snapshots.
+
+### Issue 6 — Pillar 3 UI + E2E: badge/report/seed panel + known-good replay script
+**Scope:** slices 3.3 + 3.4.
+**Deliverables:**
+- `<FingerprintBadge>`, `<ReplayReport>`, `<CopyReportButton>`, `<SeedPanel>`, `ReplayView`.
+- `replay-determinism.spec.ts` exercising matched/diverged/insufficient-sample paths.
+
+### Issue 7 — Pillar 4 engine: cross-scenario config schema + validation/diff engine
+**Scope:** slice 4.1.
+**Deliverables:**
+- `demo-domain/config/**` core types/schema/validator/diff.
+- Relocate pet-care config logic into scenario config modules.
+- Tests for preview-vs-commit whitelist semantics.
+
+### Issue 8 — Pillar 4 flow: `useConfigDraft` preview lifecycle + commit handshake
+**Scope:** slices 4.2 + 4.4 (domain).
+**Deliverables:**
+- Headless preview apply/revert lifecycle in store.
+- Commit triggers restart + fingerprint reset handshake.
+- Legacy key cleanup in `app/main.ts` per plan.
+
+### Issue 9 — Pillar 4 UI migration: JSON editor view + delete legacy mount module
+**Scope:** slice 4.3.
+**Deliverables:**
+- New editor component stack and view store.
+- Remove `examples/product-demo/src/speciesConfig.ts` after coverage parity.
+
+### Issue 10 — Pillar 5 scenario expansion: scenario contract + catalog + selector route
+**Scope:** slices 5.1 + 5.2.
+**Deliverables:**
+- `Scenario` contract and `useScenarioCatalog`.
+- Wrap pet-care into `Scenario` value.
+- Add scenario selector UI and `/play/:scenarioId` routing.
+
+### Issue 11 — Pillar 5 content: `companion-npc` reference scenario
+**Scope:** slice 5.3.
+**Deliverables:**
+- Scenario implementation with config + skills.
+- Contract tests confirming behavior and determinism constraints.
+
+### Issue 12 — Pillar 5 polish: per-scenario seed/config persistence + scenario-swap E2E
+**Scope:** slice 5.4.
+**Deliverables:**
+- Scenario-scoped storage keys and migration behavior.
+- `scenario-swap.spec.ts` with route/state integrity checks.
+
+---
+
+## Epic 2 — Quality automation rows still open
+
+### Issue 13 — Quality row 6: determinism replay baseline workflow
+- Implement `tests/determinism/replay.ts` + baseline artifact.
+- Add dual-mode scripts and CI workflow from plan.
+
+### Issue 14 — Quality row 7: mutation testing weekly run
+- Add Stryker config, scripts, artifact upload.
+- Keep report-open instruction cross-platform (no macOS-only helper).
+
+### Issue 15 — Quality row 8: nightly demo smoke workflow
+- Add/align Playwright smoke at demo level.
+- CI path trigger and smoke assertion reliability.
+
+---
+
+## Epic 3 — Open daily-review findings to convert into tracked fixes
+
+### Issue 16 — Resolve unchecked MINOR findings in daily reviews (batch)
+Checklist:
+- 2026-04-26 `CognitionPipeline.ts:143` stage-blocked failure branch test coverage.
+- 2026-04-26 `TfjsReasoner.ts:401` concurrency safety in `detectBestBackend`.
+- 2026-04-27 `PlayView.vue:11` seed key duplication drift risk.
+- 2026-04-27 `cognitionSwitcher.ts:442` reasoner/learner wiring race window.
+- 2026-04-28 `useAgentSession.ts:321-322` stale-epoch dispose + learning-mode learner wiring.
+- 2026-04-30 `useAgentSession.test.ts:415` brittle microtask flush depth in tests.
+
+(Keep NIT-only findings optional unless they gate maintainability.)
+
+---
+
+## Suggested labels/milestones for all issues
+
+- Labels: `v1`, `demo-v2`, `quality`, `good-first-slice` (where applicable), `determinism`, `cognition`, `config`, `scenario`, `ci`.
+- Milestone: `v1.0`.
+- Body footer convention: `Tracks: #132` for Demo-v2 pillar items.

--- a/scripts/create-v1-issues.mjs
+++ b/scripts/create-v1-issues.mjs
@@ -131,9 +131,16 @@ async function gh(path, init = {}) {
 }
 
 async function resolveMilestone() {
-  const open = await gh(`/repos/${owner}/${repo}/milestones?state=open&per_page=100`);
-  const found = open.find((m) => m.title === milestoneTitle);
-  return found?.number;
+  let page = 1;
+  while (true) {
+    const batch = await gh(
+      `/repos/${owner}/${repo}/milestones?state=open&per_page=100&page=${page}`,
+    );
+    const found = batch.find((m) => m.title === milestoneTitle);
+    if (found) return found.number;
+    if (batch.length < 100) return undefined;
+    page++;
+  }
 }
 
 (async () => {

--- a/scripts/create-v1-issues.mjs
+++ b/scripts/create-v1-issues.mjs
@@ -24,6 +24,9 @@ if (!repository?.includes('/')) {
 
 const [owner, repo] = repository.split('/');
 const milestoneTitle = process.env.ISSUE_MILESTONE ?? 'v1.0';
+const labelOverride = process.env.ISSUE_LABELS
+  ? process.env.ISSUE_LABELS.split(',').map((v) => v.trim()).filter(Boolean)
+  : null;
 
 const issues = [
   [
@@ -134,10 +137,7 @@ async function resolveMilestone() {
 (async () => {
   const milestone = await resolveMilestone();
   for (const [title, labelsCsv, body] of issues) {
-    const labels = labelsCsv
-      .split(',')
-      .map((v) => v.trim())
-      .filter(Boolean);
+    const labels = labelOverride ?? labelsCsv.split(',').map((v) => v.trim()).filter(Boolean);
     const payload = { title, body, labels };
     if (milestone !== undefined) payload.milestone = milestone;
     const created = await gh(`/repos/${owner}/${repo}/issues`, {

--- a/scripts/create-v1-issues.mjs
+++ b/scripts/create-v1-issues.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * Create v1 backlog issues in GitHub from the 2026-05-01 backlog plan.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=... GITHUB_REPOSITORY=owner/repo node scripts/create-v1-issues.mjs
+ *
+ * Optional:
+ *   ISSUE_MILESTONE=v1.0
+ *   ISSUE_LABELS=v1,demo-v2,quality
+ */
+
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+
+if (!token) {
+  console.error('Missing GITHUB_TOKEN.');
+  process.exit(1);
+}
+if (!repository?.includes('/')) {
+  console.error('Missing/invalid GITHUB_REPOSITORY (expected owner/repo).');
+  process.exit(1);
+}
+
+const [owner, repo] = repository.split('/');
+const milestoneTitle = process.env.ISSUE_MILESTONE ?? 'v1.0';
+
+const issues = [
+  [
+    'Pillar 2 scaffolding: rolling diff metrics + store wiring',
+    'demo-v2,cognition,v1',
+    'Tracks: #132\n\nScope: slices 2.1 + 2.2\n\n- Add demo-domain diff metric modules\n- Wire AGENT_TICKED capture in useAgentSession and useDiffPanelView\n- Add unit coverage for metric/store integration\n\nDone when: P2-FR-1/2/4/5 checks are green.',
+  ],
+  [
+    'Pillar 2 UI: diff card + what-changed summary',
+    'demo-v2,cognition,v1',
+    'Tracks: #132\n\nScope: slice 2.3\n\n- Add DiffCard, MetricRow, WhatChangedSummary, DiffView\n- Render visible delta within 1–3 ticks after mode switch\n- Add UI tests for empty-peer and steady-state behavior',
+  ],
+  [
+    'Pillar 2 hardening: confidence labels + threshold tuning',
+    'demo-v2,cognition,v1',
+    'Tracks: #132\n\nScope: slice 2.4\n\n- Implement confidence model and threshold constants\n- Capture soak-tuned defaults and notes in plan done-log',
+  ],
+  [
+    'Pillar 2 migration: port cognition switcher/SVG renderers to Vue SFCs',
+    'demo-v2,cognition,v1',
+    'Tracks: #132\n\nScope: slice 2.5\n\n- Port cognitionSwitcher.ts to CognitionSwitcher + setMode store API\n- Port lossSparkline/predictionStrip to SFCs\n- Delete legacy files after parity tests pass',
+  ],
+  [
+    'Pillar 3 core: deterministic fingerprint domain + recorder store',
+    'demo-v2,determinism,v1',
+    'Tracks: #132\n\nScope: slices 3.1 + 3.2\n\n- Add normalizer/hash/scope-key helpers\n- Add useFingerprintRecorder deterministic persistence model\n- Add unit coverage + stable hash regression snapshots',
+  ],
+  [
+    'Pillar 3 UI/E2E: badge, replay report, seed panel, known-good script',
+    'demo-v2,determinism,v1',
+    'Tracks: #132\n\nScope: slices 3.3 + 3.4\n\n- Add FingerprintBadge/ReplayReport/CopyReportButton/SeedPanel/ReplayView\n- Add replay-determinism.spec.ts for matched/diverged/insufficient sample',
+  ],
+  [
+    'Pillar 4 engine: cross-scenario config schema + validation/diff',
+    'demo-v2,config,v1',
+    'Tracks: #132\n\nScope: slice 4.1\n\n- Add config engine types/schema/validator/diff\n- Relocate pet-care config logic to scenario config modules\n- Add preview-vs-commit whitelist tests',
+  ],
+  [
+    'Pillar 4 domain flow: useConfigDraft preview lifecycle + commit handshake',
+    'demo-v2,config,v1',
+    'Tracks: #132\n\nScope: slices 4.2 + 4.4 (domain)\n\n- Add preview apply/revert lifecycle in store\n- Wire commit restart + fingerprint reset handshake\n- Apply legacy key cleanup in app/main.ts',
+  ],
+  [
+    'Pillar 4 UI migration: JSON editor view + remove legacy mount module',
+    'demo-v2,config,v1',
+    'Tracks: #132\n\nScope: slice 4.3\n\n- Add JsonEditor view/component stack\n- Remove legacy speciesConfig.ts after coverage parity',
+  ],
+  [
+    'Pillar 5 expansion: Scenario contract + catalog + selector routing',
+    'demo-v2,scenario,v1',
+    'Tracks: #132\n\nScope: slices 5.1 + 5.2\n\n- Add Scenario contract + useScenarioCatalog\n- Wrap pet-care as Scenario\n- Add scenario selector UI + /play/:scenarioId route',
+  ],
+  [
+    'Pillar 5 content: companion-npc reference scenario',
+    'demo-v2,scenario,v1',
+    'Tracks: #132\n\nScope: slice 5.3\n\n- Implement companion-npc scenario (skills/config)\n- Add contract tests + determinism checks',
+  ],
+  [
+    'Pillar 5 polish: per-scenario seed/config scoping + scenario-swap E2E',
+    'demo-v2,scenario,v1',
+    'Tracks: #132\n\nScope: slice 5.4\n\n- Scope storage keys by scenario\n- Add scenario-swap Playwright coverage',
+  ],
+  [
+    'Quality row 6: determinism replay baseline workflow',
+    'quality,determinism,ci,v1',
+    'Implement row 6 from docs/plans/2026-04-26-quality-automation-routines.md\n\n- Add tests/determinism/replay.ts + baseline artifact\n- Wire dual-mode scripts + CI workflow',
+  ],
+  [
+    'Quality row 7: mutation testing weekly run',
+    'quality,ci,v1',
+    'Implement row 7 from docs/plans/2026-04-26-quality-automation-routines.md\n\n- Add Stryker config/scripts/artifact upload\n- Keep report-open instruction cross-platform',
+  ],
+  [
+    'Quality row 8: nightly demo smoke workflow',
+    'quality,ci,v1',
+    'Implement row 8 from docs/plans/2026-04-26-quality-automation-routines.md\n\n- Add/align nightly Playwright smoke\n- Add PR-path trigger + stability assertions',
+  ],
+  [
+    'Resolve unchecked MINOR daily-review findings (batch)',
+    'quality,v1',
+    'Convert unchecked MINOR findings from 2026-04-26/27/28/30 daily reviews into code fixes with tests where applicable.\n\nChecklist:\n- stage-blocked failure branch test coverage\n- detectBestBackend concurrency safety\n- PlayView seed key dedupe\n- cognitionSwitcher reasoner/learner wiring race\n- useAgentSession stale-epoch dispose + learning-mode wiring\n- useAgentSession test microtask flush brittleness',
+  ],
+];
+
+async function gh(path, init = {}) {
+  const res = await fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${res.status} ${res.statusText} :: ${text}`);
+  }
+  return res.json();
+}
+
+async function resolveMilestone() {
+  const open = await gh(`/repos/${owner}/${repo}/milestones?state=open&per_page=100`);
+  const found = open.find((m) => m.title === milestoneTitle);
+  return found?.number;
+}
+
+(async () => {
+  const milestone = await resolveMilestone();
+  for (const [title, labelsCsv, body] of issues) {
+    const labels = labelsCsv
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+    const payload = { title, body, labels };
+    if (milestone !== undefined) payload.milestone = milestone;
+    const created = await gh(`/repos/${owner}/${repo}/issues`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    console.log(`#${created.number} ${created.title} -> ${created.html_url}`);
+  }
+})().catch((err) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/scripts/create-v1-issues.mjs
+++ b/scripts/create-v1-issues.mjs
@@ -25,7 +25,9 @@ if (!repository?.includes('/')) {
 const [owner, repo] = repository.split('/');
 const milestoneTitle = process.env.ISSUE_MILESTONE ?? 'v1.0';
 const labelOverride = process.env.ISSUE_LABELS
-  ? process.env.ISSUE_LABELS.split(',').map((v) => v.trim()).filter(Boolean)
+  ? process.env.ISSUE_LABELS.split(',')
+      .map((v) => v.trim())
+      .filter(Boolean)
   : null;
 
 const issues = [
@@ -137,7 +139,12 @@ async function resolveMilestone() {
 (async () => {
   const milestone = await resolveMilestone();
   for (const [title, labelsCsv, body] of issues) {
-    const labels = labelOverride ?? labelsCsv.split(',').map((v) => v.trim()).filter(Boolean);
+    const labels =
+      labelOverride ??
+      labelsCsv
+        .split(',')
+        .map((v) => v.trim())
+        .filter(Boolean);
     const payload = { title, body, labels };
     if (milestone !== undefined) payload.milestone = milestone;
     const created = await gh(`/repos/${owner}/${repo}/issues`, {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Addresses review finding on #170: `ISSUE_LABELS` env var was documented but never read
- Parses `ISSUE_LABELS` once at startup and uses it as a full replacement for per-issue hard-coded labels when set
- Falls back to the per-issue `labelsCsv` when `ISSUE_LABELS` is not provided (no behaviour change for existing callers)

## Test plan

- [ ] Run script without `ISSUE_LABELS` set — labels come from per-issue defaults as before
- [ ] Run script with `ISSUE_LABELS=v1,my-custom-label` — all issues receive only those labels

https://claude.ai/code/session_01Hb3fsTVx9MxAaE6iTbiLt2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hb3fsTVx9MxAaE6iTbiLt2)_