### PR TITLE
chore: gitignore .docs-review-cache/ (docs-review-bot one-time setup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ examples/**/test-results
 .worktrees
 .review-fix-cache
 .plan-recon-cache/
+.docs-review-cache/
 .claude/settings.local.json
 .claude/.last-run
 


### PR DESCRIPTION
## Summary

- Adds `.docs-review-cache/` to `.gitignore` — the docs-review-bot writes its per-run issue body there before calling `gh issue create`, then the directory is gitignored so the working tree stays clean after each run.
- One-time setup step required by `docs/docs-review-bot/PROMPT.md` (same pattern as `.review-fix-cache` and `.plan-recon-cache/` already present in `.gitignore`).

## Test plan

- [ ] `git status` on `develop` after next docs-review-bot run shows no untracked files.
- [ ] `.gitignore` change has no effect on CI (no source files affected).

https://claude.ai/code/session_01CaNfC8rSy46i28YsJ6KvVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaNfC8rSy46i28YsJ6KvVR)_